### PR TITLE
Add flashcard enhancements: SRS, filters, type mode, progress tracking

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,9 +3,9 @@
   "configurations": [
     {
       "name": "greek-tools",
-      "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["dev"],
-      "port": 4321
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--port", "4322"],
+      "port": 4322
     }
   ]
 }

--- a/src/components/Flashcards.tsx
+++ b/src/components/Flashcards.tsx
@@ -1,5 +1,19 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { vocabulary, type VocabWord } from '../data/vocabulary';
+import {
+  type SRSCard,
+  loadSRSStore, saveSRSStore, loadStats, saveStats,
+  recordReview, newCard, nextSRS, isDue, STREAK_THRESHOLD,
+} from '../data/srs';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type StudyMode = 'srs' | 'all';
+type AnswerMode = 'flip' | 'type';
+type Direction = 'gr-en' | 'en-gr';
+type FreqFilter = 'all' | '500+' | '100-499' | '50-99' | '<50';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function shuffle<T>(arr: T[]): T[] {
   const a = [...arr];
@@ -10,124 +24,618 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
-type Direction = 'greek-to-english' | 'english-to-greek';
+function levenshtein(a: string, b: string): number {
+  const dp: number[] = Array.from({ length: a.length + 1 }, (_, i) => i);
+  for (let j = 1; j <= b.length; j++) {
+    let prev = dp[0];
+    dp[0] = j;
+    for (let i = 1; i <= a.length; i++) {
+      const tmp = dp[i];
+      dp[i] = a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[i - 1], dp[i]);
+      prev = tmp;
+    }
+  }
+  return dp[a.length];
+}
+
+function checkAnswer(input: string, gloss: string): boolean {
+  const norm = (s: string) => s.toLowerCase().replace(/[()]/g, '').trim();
+  const ans = norm(input);
+  if (!ans) return false;
+  const parts = gloss.split(/[,/]/).map(norm).filter(Boolean);
+  return parts.some(
+    p =>
+      p === ans ||
+      (ans.length >= 4 && p.startsWith(ans)) ||
+      (p.length > 3 && levenshtein(p, ans) <= 1),
+  );
+}
+
+function matchFreq(freq: number, f: FreqFilter): boolean {
+  if (f === 'all') return true;
+  if (f === '500+') return freq >= 500;
+  if (f === '100-499') return freq >= 100 && freq < 500;
+  if (f === '50-99') return freq >= 50 && freq < 100;
+  return freq < 50;
+}
+
+function buildQueue(
+  vocab: VocabWord[],
+  mode: StudyMode,
+  store: Record<string, SRSCard>,
+): VocabWord[] {
+  if (mode === 'all') return shuffle(vocab);
+  const due: VocabWord[] = [];
+  const fresh: VocabWord[] = [];
+  for (const w of vocab) {
+    const c = store[w.greek];
+    if (!c) fresh.push(w);
+    else if (isDue(c)) due.push(w);
+  }
+  // Due cards first (shuffled), then new cards (shuffled)
+  return [...shuffle(due), ...shuffle(fresh)];
+}
+
+// ─── Part-of-speech options present in the vocabulary ─────────────────────────
+
+const ALL_POS = ['noun', 'verb', 'adjective', 'pronoun', 'preposition', 'conjunction', 'adverb', 'article'];
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function Flashcards() {
-  const [direction, setDirection] = useState<Direction>('greek-to-english');
-  const [cards, setCards] = useState<VocabWord[]>(() => shuffle(vocabulary));
+  // Persistent state (localStorage)
+  const [srsStore, setSrsStore] = useState<Record<string, SRSCard>>(() => loadSRSStore());
+  const [stats, setStats] = useState(() => loadStats());
+
+  // Mode / direction
+  const [studyMode, setStudyMode] = useState<StudyMode>('srs');
+  const [answerMode, setAnswerMode] = useState<AnswerMode>('flip');
+  const [direction, setDirection] = useState<Direction>('gr-en');
+
+  // Filters
+  const [freqFilter, setFreqFilter] = useState<FreqFilter>('all');
+  const [posFilter, setPosFilter] = useState<string[]>([]);
+  const [showFilters, setShowFilters] = useState(false);
+
+  // Session state
+  const [queue, setQueue] = useState<VocabWord[]>([]);
   const [index, setIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
-  const [score, setScore] = useState({ known: 0, learning: 0 });
+  const [typedAnswer, setTypedAnswer] = useState('');
+  const [answerResult, setAnswerResult] = useState<'correct' | 'incorrect' | null>(null);
+  const [sessionScore, setSessionScore] = useState({ known: 0, learning: 0 });
+  const [sessionDone, setSessionDone] = useState(false);
 
-  const card = cards[index];
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Keep a ref to srsStore so buildQueue always uses latest without deps
+  const srsStoreRef = useRef(srsStore);
+  srsStoreRef.current = srsStore;
+
+  // ─── Filtered vocabulary ────────────────────────────────────────────────────
+
+  const filteredVocab = useMemo(
+    () =>
+      vocabulary.filter(
+        w =>
+          matchFreq(w.frequency, freqFilter) &&
+          (posFilter.length === 0 || posFilter.includes(w.partOfSpeech)),
+      ),
+    [freqFilter, posFilter],
+  );
+
+  // SRS stats for display
+  const dueCount = useMemo(
+    () => filteredVocab.filter(w => { const c = srsStore[w.greek]; return c ? isDue(c) : false; }).length,
+    [filteredVocab, srsStore],
+  );
+  const newCount = useMemo(
+    () => filteredVocab.filter(w => !srsStore[w.greek]).length,
+    [filteredVocab, srsStore],
+  );
+
+  // ─── Session management ─────────────────────────────────────────────────────
+
+  const startSession = useCallback(() => {
+    setQueue(buildQueue(filteredVocab, studyMode, srsStoreRef.current));
+    setIndex(0);
+    setFlipped(false);
+    setTypedAnswer('');
+    setAnswerResult(null);
+    setSessionScore({ known: 0, learning: 0 });
+    setSessionDone(false);
+  }, [filteredVocab, studyMode]);
+
+  // Mount: start initial session
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { startSession(); }, []);
+
+  // Restart when mode or filters change (not on srsStore changes)
+  const posFilterKey = posFilter.join(',');
+  const prevStudyMode = useRef(studyMode);
+  const prevFreqFilter = useRef(freqFilter);
+  const prevPosFilterKey = useRef(posFilterKey);
+
+  useEffect(() => {
+    if (
+      studyMode !== prevStudyMode.current ||
+      freqFilter !== prevFreqFilter.current ||
+      posFilterKey !== prevPosFilterKey.current
+    ) {
+      prevStudyMode.current = studyMode;
+      prevFreqFilter.current = freqFilter;
+      prevPosFilterKey.current = posFilterKey;
+      startSession();
+    }
+  });
+
+  // ─── Review handler ─────────────────────────────────────────────────────────
+
+  const card = queue[index];
+
+  const handleReview = useCallback(
+    (correct: boolean) => {
+      if (!card) return;
+
+      if (studyMode === 'srs') {
+        setSrsStore(prev => {
+          const existing = prev[card.greek] ?? newCard(card.greek);
+          const updated = nextSRS(existing, correct ? 4 : 1);
+          const next = { ...prev, [card.greek]: updated };
+          saveSRSStore(next);
+          return next;
+        });
+      }
+
+      setStats(prev => {
+        const next = recordReview(prev, correct);
+        saveStats(next);
+        return next;
+      });
+
+      setSessionScore(s => ({
+        known: s.known + (correct ? 1 : 0),
+        learning: s.learning + (correct ? 0 : 1),
+      }));
+
+      if (index + 1 < queue.length) {
+        setIndex(i => i + 1);
+        setFlipped(false);
+        setTypedAnswer('');
+        setAnswerResult(null);
+      } else {
+        setSessionDone(true);
+      }
+    },
+    [card, studyMode, index, queue.length],
+  );
 
   const handleFlip = useCallback(() => setFlipped(f => !f), []);
 
-  const handleKnown = useCallback(() => {
-    setScore(s => ({ ...s, known: s.known + 1 }));
-    advance();
-  }, [index, cards.length]);
+  const handleTypeSubmit = useCallback(() => {
+    if (!card || answerResult !== null) return;
+    const expected = direction === 'gr-en' ? card.gloss : card.greek;
+    const correct = checkAnswer(typedAnswer, expected);
+    setAnswerResult(correct ? 'correct' : 'incorrect');
+  }, [card, direction, typedAnswer, answerResult]);
 
-  const handleLearning = useCallback(() => {
-    setScore(s => ({ ...s, learning: s.learning + 1 }));
-    advance();
-  }, [index, cards.length]);
+  // ─── Keyboard shortcuts ──────────────────────────────────────────────────────
 
-  function advance() {
-    setFlipped(false);
-    if (index + 1 < cards.length) {
-      setIndex(i => i + 1);
-    } else {
-      // Reshuffle
-      setCards(shuffle(vocabulary));
-      setIndex(0);
-    }
-  }
-
-  const handleReset = () => {
-    setCards(shuffle(vocabulary));
-    setIndex(0);
-    setFlipped(false);
-    setScore({ known: 0, learning: 0 });
-  };
-
-  // Keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); handleFlip(); }
-      if (e.key === 'ArrowRight' && flipped) handleKnown();
-      if (e.key === 'ArrowLeft' && flipped) handleLearning();
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (sessionDone) return;
+      if (answerMode === 'flip') {
+        if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); handleFlip(); }
+        if (e.key === 'ArrowRight' && flipped) handleReview(true);
+        if (e.key === 'ArrowLeft' && flipped) handleReview(false);
+      }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [flipped, handleFlip, handleKnown, handleLearning]);
+  }, [answerMode, flipped, sessionDone, handleFlip, handleReview]);
 
-  const front = direction === 'greek-to-english' ? card.greek : card.gloss;
-  const back = direction === 'greek-to-english' ? card.gloss : card.greek;
+  // Focus type input when card changes
+  useEffect(() => {
+    if (answerMode === 'type' && !sessionDone) {
+      inputRef.current?.focus();
+    }
+  }, [answerMode, index, sessionDone]);
+
+  // ─── Derived values ──────────────────────────────────────────────────────────
+
+  const accuracy =
+    stats.totalReviewed > 0
+      ? Math.round((stats.totalCorrect / stats.totalReviewed) * 100)
+      : null;
+  const front = card ? (direction === 'gr-en' ? card.greek : card.gloss) : '';
+  const back = card ? (direction === 'gr-en' ? card.gloss : card.greek) : '';
+  const expectedAnswer = card ? (direction === 'gr-en' ? card.gloss : card.greek) : '';
+  const hasActiveFilters = freqFilter !== 'all' || posFilter.length > 0;
+
+  // ─── Session complete screen ─────────────────────────────────────────────────
+
+  if (sessionDone) {
+    const total = sessionScore.known + sessionScore.learning;
+    const pct = total > 0 ? Math.round((sessionScore.known / total) * 100) : 0;
+    return (
+      <div className="text-center space-y-4 py-12">
+        <div className="text-6xl font-bold" style={{ color: 'var(--color-primary)' }}>
+          {pct}%
+        </div>
+        <h2 className="text-2xl font-bold text-text">Session Complete</h2>
+        <p className="text-text-muted">
+          {sessionScore.known} got it · {sessionScore.learning} still learning
+        </p>
+        {studyMode === 'srs' && dueCount === 0 && newCount === 0 && (
+          <p className="text-text-muted text-sm">
+            You're all caught up! Check back tomorrow for more reviews.
+          </p>
+        )}
+        <div className="flex justify-center gap-3 pt-2">
+          <button
+            onClick={startSession}
+            className="px-5 py-2.5 bg-primary text-white rounded-lg hover:bg-primary-light transition-colors font-medium"
+          >
+            Study Again
+          </button>
+          {studyMode === 'srs' && (
+            <button
+              onClick={() => setStudyMode('all')}
+              className="px-5 py-2.5 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+            >
+              Study All Cards
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Empty state ─────────────────────────────────────────────────────────────
+
+  if (!card) {
+    return (
+      <div className="text-center py-16 space-y-4">
+        <p className="text-lg text-text-muted">
+          {studyMode === 'srs'
+            ? "You're all caught up — no cards due for review."
+            : 'No cards match the current filters.'}
+        </p>
+        {studyMode === 'srs' && (
+          <button
+            onClick={() => setStudyMode('all')}
+            className="px-5 py-2.5 bg-primary text-white rounded-lg hover:bg-primary-light transition-colors font-medium"
+          >
+            Study ahead anyway
+          </button>
+        )}
+        {studyMode === 'all' && hasActiveFilters && (
+          <button
+            onClick={() => { setFreqFilter('all'); setPosFilter([]); }}
+            className="px-5 py-2.5 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // ─── Main render ─────────────────────────────────────────────────────────────
 
   return (
-    <div className="space-y-6">
-      {/* Controls */}
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex gap-2">
-          <button
-            onClick={() => setDirection('greek-to-english')}
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${direction === 'greek-to-english' ? 'bg-primary text-white' : 'bg-gray-200 text-text'}`}
-          >
-            Greek → English
-          </button>
-          <button
-            onClick={() => setDirection('english-to-greek')}
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${direction === 'english-to-greek' ? 'bg-primary text-white' : 'bg-gray-200 text-text'}`}
-          >
-            English → Greek
-          </button>
+    <div className="space-y-4">
+
+      {/* ── Top controls bar ──────────────────────────────────────────────── */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        {/* Study mode */}
+        <div className="flex gap-1 bg-gray-100 p-1 rounded-lg">
+          {(['srs', 'all'] as StudyMode[]).map(m => (
+            <button
+              key={m}
+              onClick={() => setStudyMode(m)}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                studyMode === m
+                  ? 'bg-white shadow-sm text-primary'
+                  : 'text-text-muted hover:text-text'
+              }`}
+            >
+              {m === 'srs' ? 'SRS Review' : 'Study All'}
+            </button>
+          ))}
         </div>
-        <div className="text-sm text-text-muted">
-          Card {index + 1} of {cards.length} &nbsp;|&nbsp;
-          ✓ {score.known} &nbsp; ✗ {score.learning}
+
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Direction */}
+          <div className="flex gap-1 bg-gray-100 p-1 rounded-lg">
+            {(['gr-en', 'en-gr'] as Direction[]).map(d => (
+              <button
+                key={d}
+                onClick={() => setDirection(d)}
+                className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
+                  direction === d
+                    ? 'bg-white shadow-sm text-primary'
+                    : 'text-text-muted hover:text-text'
+                }`}
+              >
+                {d === 'gr-en' ? 'Greek → English' : 'English → Greek'}
+              </button>
+            ))}
+          </div>
+
+          {/* Answer mode */}
+          <div className="flex gap-1 bg-gray-100 p-1 rounded-lg">
+            {(['flip', 'type'] as AnswerMode[]).map(m => (
+              <button
+                key={m}
+                onClick={() => setAnswerMode(m)}
+                className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
+                  answerMode === m
+                    ? 'bg-white shadow-sm text-primary'
+                    : 'text-text-muted hover:text-text'
+                }`}
+              >
+                {m === 'flip' ? 'Flip' : 'Type'}
+              </button>
+            ))}
+          </div>
+
+          {/* Filters toggle */}
+          <button
+            onClick={() => setShowFilters(f => !f)}
+            className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+              hasActiveFilters
+                ? 'border-primary text-primary bg-primary/5'
+                : showFilters
+                ? 'border-gray-300 text-text bg-gray-50'
+                : 'border-gray-200 text-text-muted hover:border-gray-300'
+            }`}
+          >
+            Filters{hasActiveFilters ? ' ●' : ''}
+          </button>
         </div>
       </div>
 
-      {/* Card */}
-      <div
-        onClick={handleFlip}
-        className="bg-bg-card rounded-xl shadow-lg border border-gray-100 p-12 text-center cursor-pointer select-none min-h-[250px] flex flex-col items-center justify-center hover:shadow-xl transition-shadow"
-      >
-        {!flipped ? (
+      {/* ── Filter panel ──────────────────────────────────────────────────── */}
+      {showFilters && (
+        <div className="bg-bg-card rounded-xl border border-gray-200 p-4 space-y-4">
+          <div>
+            <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+              Frequency (occurrences in GNT)
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {(['all', '500+', '100-499', '50-99', '<50'] as FreqFilter[]).map(f => {
+                const count = vocabulary.filter(w => matchFreq(w.frequency, f)).length;
+                return (
+                  <button
+                    key={f}
+                    onClick={() => setFreqFilter(f)}
+                    className={`px-3 py-1 rounded-full text-sm border transition-colors ${
+                      freqFilter === f
+                        ? 'bg-primary text-white border-primary'
+                        : 'border-gray-200 text-text-muted hover:border-primary/40 hover:text-text'
+                    }`}
+                  >
+                    {f === 'all' ? 'All' : `${f}×`}{' '}
+                    <span className={`text-xs ${freqFilter === f ? 'text-white/70' : 'text-text-muted'}`}>
+                      ({count})
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+              Part of Speech
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {ALL_POS.map(pos => {
+                const count = vocabulary.filter(w => w.partOfSpeech === pos).length;
+                if (count === 0) return null;
+                const active = posFilter.includes(pos);
+                return (
+                  <button
+                    key={pos}
+                    onClick={() =>
+                      setPosFilter(prev =>
+                        active ? prev.filter(p => p !== pos) : [...prev, pos],
+                      )
+                    }
+                    className={`px-3 py-1 rounded-full text-sm border transition-colors ${
+                      active
+                        ? 'bg-primary text-white border-primary'
+                        : 'border-gray-200 text-text-muted hover:border-primary/40 hover:text-text'
+                    }`}
+                  >
+                    {pos}{' '}
+                    <span className={`text-xs ${active ? 'text-white/70' : 'text-text-muted'}`}>
+                      ({count})
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between pt-1">
+            <p className="text-sm text-text-muted">
+              <strong className="text-text">{filteredVocab.length}</strong> words match
+            </p>
+            {hasActiveFilters && (
+              <button
+                onClick={() => { setFreqFilter('all'); setPosFilter([]); }}
+                className="text-sm text-red-500 hover:text-red-600 transition-colors"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ── Stats bar ─────────────────────────────────────────────────────── */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-muted bg-bg-card rounded-xl border border-gray-200 px-4 py-2.5">
+        {studyMode === 'srs' ? (
           <>
-            <p className={`text-4xl font-serif mb-3 ${direction === 'greek-to-english' ? '' : ''}`}
-               style={direction === 'greek-to-english' ? { color: 'var(--color-greek)' } : {}}>
-              {front}
-            </p>
-            <p className="text-text-muted text-sm">
-              {direction === 'greek-to-english' ? card.partOfSpeech : ''}
-            </p>
-            <p className="text-text-muted text-xs mt-4">click or press space to reveal</p>
+            <span>
+              Due: <strong className="text-text">{dueCount}</strong>
+            </span>
+            <span className="text-gray-300">|</span>
+            <span>
+              New: <strong className="text-text">{newCount}</strong>
+            </span>
+            <span className="text-gray-300">|</span>
           </>
         ) : (
           <>
-            <p className="text-sm text-text-muted mb-2">{direction === 'greek-to-english' ? card.greek : card.gloss}</p>
-            <p className={`text-3xl font-serif mb-2`}
-               style={direction === 'english-to-greek' ? { color: 'var(--color-greek)' } : {}}>
+            <span>
+              Card:{' '}
+              <strong className="text-text">
+                {index + 1}/{queue.length}
+              </strong>
+            </span>
+            <span className="text-gray-300">|</span>
+          </>
+        )}
+
+        {/* Daily progress toward streak */}
+        <span>
+          Today:{' '}
+          <strong className="text-text">
+            {Math.min(stats.cardsStudiedToday, STREAK_THRESHOLD)}/{STREAK_THRESHOLD}
+          </strong>
+        </span>
+        <span className="text-gray-300">|</span>
+
+        <span>
+          Streak: <strong className="text-text">{stats.streak}d</strong>
+          {stats.cardsStudiedToday >= STREAK_THRESHOLD && (
+            <span className="ml-1 text-accent text-xs">✓</span>
+          )}
+        </span>
+
+        {accuracy !== null && (
+          <>
+            <span className="text-gray-300">|</span>
+            <span>
+              Accuracy: <strong className="text-text">{accuracy}%</strong>
+            </span>
+          </>
+        )}
+
+        <span className="ml-auto text-xs">
+          ✓ {sessionScore.known} · ✗ {sessionScore.learning}
+        </span>
+      </div>
+
+      {/* ── Card ──────────────────────────────────────────────────────────── */}
+      <div
+        onClick={answerMode === 'flip' && !flipped ? handleFlip : undefined}
+        className={`bg-bg-card rounded-xl shadow-lg border border-gray-100 px-10 py-8 text-center select-none min-h-[220px] flex flex-col items-center justify-center transition-shadow ${
+          answerMode === 'flip' && !flipped ? 'cursor-pointer hover:shadow-xl' : ''
+        }`}
+      >
+        {/* Front side */}
+        <p
+          className="font-serif leading-tight"
+          style={{
+            fontSize: direction === 'gr-en' ? '2.8rem' : '1.6rem',
+            color: direction === 'gr-en' ? 'var(--color-greek)' : 'inherit',
+          }}
+        >
+          {front}
+        </p>
+        {direction === 'gr-en' && (
+          <p className="text-text-muted text-sm mt-1">{card.partOfSpeech}</p>
+        )}
+
+        {/* Flip mode: reveal hint */}
+        {answerMode === 'flip' && !flipped && (
+          <p className="text-text-muted text-xs mt-6">click or press space to reveal</p>
+        )}
+
+        {/* Flip mode: back side */}
+        {answerMode === 'flip' && flipped && (
+          <div className="mt-4 pt-4 border-t border-gray-100 w-full text-center">
+            <p
+              className="font-serif"
+              style={{
+                fontSize: direction === 'en-gr' ? '2.8rem' : '1.6rem',
+                color: direction === 'en-gr' ? 'var(--color-greek)' : 'inherit',
+              }}
+            >
               {back}
             </p>
-            <p className="text-text-muted text-sm">{card.partOfSpeech} — occurs {card.frequency}× in GNT</p>
-          </>
+            <p className="text-text-muted text-sm mt-1">
+              {direction === 'gr-en'
+                ? `occurs ${card.frequency.toLocaleString()}× in GNT`
+                : card.partOfSpeech}
+            </p>
+          </div>
+        )}
+
+        {/* Type mode: input */}
+        {answerMode === 'type' && answerResult === null && (
+          <div className="mt-6 flex gap-2 w-full max-w-sm">
+            <input
+              ref={inputRef}
+              type="text"
+              value={typedAnswer}
+              onChange={e => setTypedAnswer(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') handleTypeSubmit(); }}
+              placeholder={
+                direction === 'gr-en' ? 'Type the English gloss…' : 'Type the Greek word…'
+              }
+              className="flex-1 px-3 py-2 border-2 border-gray-200 rounded-lg focus:border-primary focus:outline-none text-sm"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <button
+              onClick={handleTypeSubmit}
+              className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-light text-sm font-medium transition-colors"
+            >
+              Check
+            </button>
+          </div>
+        )}
+
+        {/* Type mode: result feedback */}
+        {answerMode === 'type' && answerResult !== null && (
+          <div
+            className={`mt-4 px-4 py-3 rounded-lg w-full max-w-sm text-center ${
+              answerResult === 'correct'
+                ? 'bg-green-50 border border-green-200'
+                : 'bg-red-50 border border-red-200'
+            }`}
+          >
+            {answerResult === 'correct' ? (
+              <p className="text-green-700 font-medium">Correct!</p>
+            ) : (
+              <>
+                <p className="text-red-700 font-medium">Not quite</p>
+                <p className="text-text-muted text-sm mt-1">
+                  Answer:{' '}
+                  <span className="font-medium text-text">{expectedAnswer}</span>
+                </p>
+              </>
+            )}
+          </div>
         )}
       </div>
 
-      {/* Action buttons (shown when flipped) */}
-      {flipped && (
+      {/* ── Action buttons ────────────────────────────────────────────────── */}
+      {answerMode === 'flip' && flipped && (
         <div className="flex justify-center gap-4">
           <button
-            onClick={handleLearning}
+            onClick={() => handleReview(false)}
             className="px-6 py-2.5 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 transition-colors font-medium"
           >
             ← Still Learning
           </button>
           <button
-            onClick={handleKnown}
+            onClick={() => handleReview(true)}
             className="px-6 py-2.5 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors font-medium"
           >
             Got It →
@@ -135,15 +643,67 @@ export default function Flashcards() {
         </div>
       )}
 
-      <div className="text-center">
-        <button onClick={handleReset} className="text-sm text-text-muted hover:text-primary transition-colors">
-          Shuffle & Reset
-        </button>
-      </div>
+      {answerMode === 'type' && answerResult !== null && (
+        <div className="flex justify-center gap-4">
+          {answerResult === 'incorrect' && (
+            <button
+              onClick={() => handleReview(false)}
+              className="px-6 py-2.5 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 transition-colors font-medium"
+            >
+              ← Still Learning
+            </button>
+          )}
+          <button
+            onClick={() => handleReview(answerResult === 'correct')}
+            className={`px-6 py-2.5 rounded-lg transition-colors font-medium ${
+              answerResult === 'correct'
+                ? 'bg-green-100 text-green-700 hover:bg-green-200'
+                : 'bg-gray-100 text-text hover:bg-gray-200'
+            }`}
+          >
+            {answerResult === 'correct' ? 'Got It →' : 'Next →'}
+          </button>
+        </div>
+      )}
 
-      <p className="text-xs text-text-muted text-center">
-        Keyboard: <kbd className="bg-gray-100 px-1 rounded">Space</kbd> flip · <kbd className="bg-gray-100 px-1 rounded">→</kbd> got it · <kbd className="bg-gray-100 px-1 rounded">←</kbd> still learning
-      </p>
+      {/* ── Keyboard hints ────────────────────────────────────────────────── */}
+      {answerMode === 'flip' && (
+        <p className="text-xs text-text-muted text-center">
+          Keyboard:{' '}
+          <kbd className="bg-gray-100 px-1 rounded">Space</kbd> flip ·{' '}
+          <kbd className="bg-gray-100 px-1 rounded">→</kbd> got it ·{' '}
+          <kbd className="bg-gray-100 px-1 rounded">←</kbd> still learning
+        </p>
+      )}
+      {answerMode === 'type' && (
+        <p className="text-xs text-text-muted text-center">
+          Keyboard: <kbd className="bg-gray-100 px-1 rounded">Enter</kbd> check answer
+        </p>
+      )}
+
+      {/* ── Footer controls ───────────────────────────────────────────────── */}
+      <div className="flex justify-center gap-4 pt-1">
+        <button
+          onClick={startSession}
+          className="text-sm text-text-muted hover:text-primary transition-colors"
+        >
+          Restart session
+        </button>
+        {studyMode === 'srs' && (
+          <button
+            onClick={() => {
+              if (confirm('Reset all SRS progress? This cannot be undone.')) {
+                setSrsStore({});
+                saveSRSStore({});
+                startSession();
+              }
+            }}
+            className="text-sm text-text-muted hover:text-red-500 transition-colors"
+          >
+            Reset SRS
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/data/srs.ts
+++ b/src/data/srs.ts
@@ -1,0 +1,166 @@
+// Spaced Repetition System (SM-2 algorithm) with localStorage persistence
+
+export interface SRSCard {
+  key: string;
+  interval: number;      // days until next review
+  repetition: number;    // times successfully reviewed in a row
+  easeFactor: number;    // SM-2 ease factor (min 1.3, starts at 2.5)
+  dueDate: string;       // YYYY-MM-DD
+  lastReviewed: string;  // YYYY-MM-DD, empty string if never
+}
+
+export interface StudyStats {
+  streak: number;
+  lastStreakDate: string;    // last date the daily threshold was hit
+  cardsStudiedToday: number;
+  lastStudyDate: string;     // YYYY-MM-DD
+  totalReviewed: number;
+  totalCorrect: number;
+}
+
+const SRS_KEY = 'greek-tools-srs-v1';
+const STATS_KEY = 'greek-tools-stats-v1';
+
+/** Cards per day required to count as a study day for streak purposes */
+export const STREAK_THRESHOLD = 10;
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function daysFromNow(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+function yesterdayStr(): string {
+  return daysFromNow(-1);
+}
+
+export function newCard(key: string): SRSCard {
+  return {
+    key,
+    interval: 0,
+    repetition: 0,
+    easeFactor: 2.5,
+    dueDate: todayStr(),
+    lastReviewed: '',
+  };
+}
+
+export function isDue(card: SRSCard): boolean {
+  return card.dueDate <= todayStr();
+}
+
+/**
+ * SM-2 algorithm.
+ * quality: 0–5 (4 = correct/easy, 1 = incorrect/hard)
+ */
+export function nextSRS(card: SRSCard, quality: number): SRSCard {
+  let { interval, repetition, easeFactor } = card;
+
+  if (quality < 3) {
+    // Failed — reset repetition count, review again tomorrow
+    interval = 1;
+    repetition = 0;
+  } else {
+    // Passed — calculate new interval per SM-2
+    if (repetition === 0) interval = 1;
+    else if (repetition === 1) interval = 6;
+    else interval = Math.round(interval * easeFactor);
+    repetition++;
+  }
+
+  // Update ease factor (bounded at 1.3 minimum)
+  const ef = easeFactor + 0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02);
+  easeFactor = Math.max(1.3, ef);
+
+  return {
+    key: card.key,
+    interval,
+    repetition,
+    easeFactor,
+    dueDate: daysFromNow(interval),
+    lastReviewed: todayStr(),
+  };
+}
+
+export function loadSRSStore(): Record<string, SRSCard> {
+  try {
+    return JSON.parse(localStorage.getItem(SRS_KEY) ?? '{}') as Record<string, SRSCard>;
+  } catch {
+    return {};
+  }
+}
+
+export function saveSRSStore(store: Record<string, SRSCard>): void {
+  localStorage.setItem(SRS_KEY, JSON.stringify(store));
+}
+
+const emptyStats = (): StudyStats => ({
+  streak: 0,
+  lastStreakDate: '',
+  cardsStudiedToday: 0,
+  lastStudyDate: '',
+  totalReviewed: 0,
+  totalCorrect: 0,
+});
+
+export function loadStats(): StudyStats {
+  try {
+    const raw = localStorage.getItem(STATS_KEY);
+    if (!raw) return emptyStats();
+    const s: StudyStats = { ...emptyStats(), ...(JSON.parse(raw) as Partial<StudyStats>) };
+
+    // Reset daily count when it's a new day
+    if (s.lastStudyDate !== todayStr()) {
+      s.cardsStudiedToday = 0;
+      // If the user missed a day, their streak is broken
+      if (s.lastStreakDate !== yesterdayStr() && s.lastStreakDate !== todayStr()) {
+        s.streak = 0;
+      }
+    }
+    return s;
+  } catch {
+    return emptyStats();
+  }
+}
+
+export function saveStats(stats: StudyStats): void {
+  localStorage.setItem(STATS_KEY, JSON.stringify(stats));
+}
+
+export function recordReview(prev: StudyStats, correct: boolean): StudyStats {
+  const today = todayStr();
+  const yesterday = yesterdayStr();
+  const isNewDay = prev.lastStudyDate !== today;
+  const cardsToday = (isNewDay ? 0 : prev.cardsStudiedToday) + 1;
+
+  let { streak, lastStreakDate } = prev;
+
+  // Detect streak break on the first review of a new day
+  if (isNewDay && lastStreakDate !== yesterday && lastStreakDate !== today) {
+    streak = 0;
+  }
+
+  // Increment streak when user hits the daily threshold for the first time today
+  if (cardsToday === STREAK_THRESHOLD) {
+    if (lastStreakDate === yesterday || lastStreakDate === '') {
+      streak++;
+    } else if (lastStreakDate !== today) {
+      // Streak was broken earlier; restart at 1
+      streak = 1;
+    }
+    lastStreakDate = today;
+  }
+
+  return {
+    streak,
+    lastStreakDate,
+    cardsStudiedToday: cardsToday,
+    lastStudyDate: today,
+    totalReviewed: prev.totalReviewed + 1,
+    totalCorrect: prev.totalCorrect + (correct ? 1 : 0),
+  };
+}


### PR DESCRIPTION
## Summary

- **Spaced Repetition (SRS)**: SM-2 algorithm in `src/data/srs.ts` — each review updates interval, repetition count, and ease factor. Cards are scheduled into the future based on recall quality. "Got It" = quality 4, "Still Learning" = quality 1. SRS Review mode surfaces only due + new cards; Study All mode ignores the schedule.
- **Frequency & POS filters**: Preset frequency ranges (500+×, 100–499×, 50–99×, <50×) and part-of-speech checkboxes, each showing live word counts. Filters restart the session without touching SRS data.
- **Type mode**: Text input replaces the flip interaction. Fuzzy matching accepts any comma/slash-separated gloss part, prefix matches (4+ chars), and Levenshtein ≤ 1 for longer words. Wrong submissions show the correct answer before advancing.
- **Progress tracking & streaks**: Stats bar shows Due, New, Today (N/10 toward streak), Streak (consecutive qualifying days), and overall Accuracy %. All persisted to `localStorage` independently of session state.

## Test plan

- [ ] Load `/flashcards` — SRS Review mode default, Due: 0, New: 50 on first visit
- [ ] Flip a card (click or Space), mark Got It / Still Learning — stats bar updates, New decrements
- [ ] Reload — reviewed card has a future due date (verify via DevTools localStorage)
- [ ] Open Filters — frequency ranges and POS chips show correct counts; selecting one narrows the deck
- [ ] Switch to Type mode — input appears; correct answer (e.g. "speak") passes, partial "say" fails with feedback
- [ ] Switch to Study All — counter shows Card N/50 instead of Due/New
- [ ] Reset SRS button clears all progress after confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)