### PR TITLE
Brighten UI with Aegean Pop design system

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -19,4 +19,4 @@
   # To remove 'unsafe-inline', generate per-build hashes and inject them here — not worth the
   # complexity for a static site with no user-generated content.
   # style-src includes 'unsafe-inline' because React uses inline style attributes (e.g. style={{ color: ... }}).
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';

--- a/src/components/Flashcards.tsx
+++ b/src/components/Flashcards.tsx
@@ -259,7 +259,10 @@ export default function Flashcards() {
     const pct = total > 0 ? Math.round((sessionScore.known / total) * 100) : 0;
     return (
       <div className="text-center space-y-4 py-12">
-        <div className="text-6xl font-bold" style={{ color: 'var(--color-primary)' }}>
+        <div
+          className="text-7xl font-bold"
+          style={{ color: 'var(--color-grape)' }}
+        >
           {pct}%
         </div>
         <h2 className="text-2xl font-bold text-text">Session Complete</h2>
@@ -274,14 +277,14 @@ export default function Flashcards() {
         <div className="flex justify-center gap-3 pt-2">
           <button
             onClick={startSession}
-            className="px-5 py-2.5 bg-primary text-white rounded-lg hover:bg-primary-light transition-colors font-medium"
+            className="px-5 py-2.5 bg-grape text-white rounded-lg hover:opacity-90 transition-opacity font-semibold shadow-sm"
           >
             Study Again
           </button>
           {studyMode === 'srs' && (
             <button
               onClick={() => setStudyMode('all')}
-              className="px-5 py-2.5 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+              className="px-5 py-2.5 border-2 border-grape/30 text-grape rounded-lg hover:bg-grape/5 transition-colors font-medium"
             >
               Study All Cards
             </button>
@@ -304,7 +307,7 @@ export default function Flashcards() {
         {studyMode === 'srs' && (
           <button
             onClick={() => setStudyMode('all')}
-            className="px-5 py-2.5 bg-primary text-white rounded-lg hover:bg-primary-light transition-colors font-medium"
+            className="px-5 py-2.5 bg-grape text-white rounded-lg hover:opacity-90 transition-opacity font-semibold shadow-sm"
           >
             Study ahead anyway
           </button>
@@ -312,7 +315,7 @@ export default function Flashcards() {
         {studyMode === 'all' && hasActiveFilters && (
           <button
             onClick={() => { setFreqFilter('all'); setPosFilter([]); }}
-            className="px-5 py-2.5 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+            className="px-5 py-2.5 border-2 border-gray-200 rounded-lg hover:bg-gray-50 transition-colors font-medium"
           >
             Clear filters
           </button>
@@ -329,14 +332,14 @@ export default function Flashcards() {
       {/* ── Top controls bar ──────────────────────────────────────────────── */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         {/* Study mode */}
-        <div className="flex gap-1 bg-gray-100 p-1 rounded-lg">
+        <div className="flex gap-1 bg-white border border-indigo-100 p-1 rounded-xl shadow-sm">
           {(['srs', 'all'] as StudyMode[]).map(m => (
             <button
               key={m}
               onClick={() => setStudyMode(m)}
-              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              className={`px-3 py-1.5 rounded-lg text-sm font-semibold transition-all ${
                 studyMode === m
-                  ? 'bg-white shadow-sm text-primary'
+                  ? 'bg-grape text-white shadow-sm'
                   : 'text-text-muted hover:text-text'
               }`}
             >
@@ -347,14 +350,14 @@ export default function Flashcards() {
 
         <div className="flex flex-wrap items-center gap-2">
           {/* Direction */}
-          <div className="flex gap-1 bg-gray-100 p-1 rounded-lg">
+          <div className="flex gap-1 bg-white border border-indigo-100 p-1 rounded-xl shadow-sm">
             {(['gr-en', 'en-gr'] as Direction[]).map(d => (
               <button
                 key={d}
                 onClick={() => setDirection(d)}
-                className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
+                className={`px-2.5 py-1 rounded-lg text-xs font-semibold transition-all ${
                   direction === d
-                    ? 'bg-white shadow-sm text-primary'
+                    ? 'bg-grape text-white shadow-sm'
                     : 'text-text-muted hover:text-text'
                 }`}
               >
@@ -364,14 +367,14 @@ export default function Flashcards() {
           </div>
 
           {/* Answer mode */}
-          <div className="flex gap-1 bg-gray-100 p-1 rounded-lg">
+          <div className="flex gap-1 bg-white border border-indigo-100 p-1 rounded-xl shadow-sm">
             {(['flip', 'type'] as AnswerMode[]).map(m => (
               <button
                 key={m}
                 onClick={() => setAnswerMode(m)}
-                className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
+                className={`px-2.5 py-1 rounded-lg text-xs font-semibold transition-all ${
                   answerMode === m
-                    ? 'bg-white shadow-sm text-primary'
+                    ? 'bg-grape text-white shadow-sm'
                     : 'text-text-muted hover:text-text'
                 }`}
               >
@@ -383,12 +386,12 @@ export default function Flashcards() {
           {/* Filters toggle */}
           <button
             onClick={() => setShowFilters(f => !f)}
-            className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+            className={`px-3 py-1.5 rounded-xl text-sm border-2 font-semibold transition-colors ${
               hasActiveFilters
-                ? 'border-primary text-primary bg-primary/5'
+                ? 'border-grape text-grape bg-grape/5'
                 : showFilters
                 ? 'border-gray-300 text-text bg-gray-50'
-                : 'border-gray-200 text-text-muted hover:border-gray-300'
+                : 'border-gray-200 text-text-muted hover:border-grape/40'
             }`}
           >
             Filters{hasActiveFilters ? ' ●' : ''}
@@ -398,9 +401,9 @@ export default function Flashcards() {
 
       {/* ── Filter panel ──────────────────────────────────────────────────── */}
       {showFilters && (
-        <div className="bg-bg-card rounded-xl border border-gray-200 p-4 space-y-4">
+        <div className="bg-bg-card rounded-2xl border-2 border-indigo-100 p-4 space-y-4 shadow-sm">
           <div>
-            <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+            <p className="text-xs font-bold text-text-muted uppercase tracking-wider mb-2">
               Frequency (occurrences in GNT)
             </p>
             <div className="flex flex-wrap gap-2">
@@ -410,10 +413,10 @@ export default function Flashcards() {
                   <button
                     key={f}
                     onClick={() => setFreqFilter(f)}
-                    className={`px-3 py-1 rounded-full text-sm border transition-colors ${
+                    className={`px-3 py-1 rounded-full text-sm border-2 font-medium transition-colors ${
                       freqFilter === f
-                        ? 'bg-primary text-white border-primary'
-                        : 'border-gray-200 text-text-muted hover:border-primary/40 hover:text-text'
+                        ? 'bg-grape text-white border-grape'
+                        : 'border-indigo-100 text-text-muted hover:border-grape/40 hover:text-text'
                     }`}
                   >
                     {f === 'all' ? 'All' : `${f}×`}{' '}
@@ -427,7 +430,7 @@ export default function Flashcards() {
           </div>
 
           <div>
-            <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+            <p className="text-xs font-bold text-text-muted uppercase tracking-wider mb-2">
               Part of Speech
             </p>
             <div className="flex flex-wrap gap-2">
@@ -443,10 +446,10 @@ export default function Flashcards() {
                         active ? prev.filter(p => p !== pos) : [...prev, pos],
                       )
                     }
-                    className={`px-3 py-1 rounded-full text-sm border transition-colors ${
+                    className={`px-3 py-1 rounded-full text-sm border-2 font-medium transition-colors ${
                       active
-                        ? 'bg-primary text-white border-primary'
-                        : 'border-gray-200 text-text-muted hover:border-primary/40 hover:text-text'
+                        ? 'bg-grape text-white border-grape'
+                        : 'border-indigo-100 text-text-muted hover:border-grape/40 hover:text-text'
                     }`}
                   >
                     {pos}{' '}
@@ -466,7 +469,7 @@ export default function Flashcards() {
             {hasActiveFilters && (
               <button
                 onClick={() => { setFreqFilter('all'); setPosFilter([]); }}
-                className="text-sm text-red-500 hover:text-red-600 transition-colors"
+                className="text-sm text-coral hover:opacity-80 font-semibold transition-opacity"
               >
                 Clear filters
               </button>
@@ -476,27 +479,27 @@ export default function Flashcards() {
       )}
 
       {/* ── Stats bar ─────────────────────────────────────────────────────── */}
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-muted bg-bg-card rounded-xl border border-gray-200 px-4 py-2.5">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-muted bg-bg-card rounded-2xl border-2 border-indigo-100 px-4 py-2.5 shadow-sm">
         {studyMode === 'srs' ? (
           <>
             <span>
-              Due: <strong className="text-text">{dueCount}</strong>
+              Due: <strong className="text-grape">{dueCount}</strong>
             </span>
-            <span className="text-gray-300">|</span>
+            <span className="text-indigo-200">|</span>
             <span>
-              New: <strong className="text-text">{newCount}</strong>
+              New: <strong className="text-primary">{newCount}</strong>
             </span>
-            <span className="text-gray-300">|</span>
+            <span className="text-indigo-200">|</span>
           </>
         ) : (
           <>
             <span>
               Card:{' '}
-              <strong className="text-text">
+              <strong className="text-grape">
                 {index + 1}/{queue.length}
               </strong>
             </span>
-            <span className="text-gray-300">|</span>
+            <span className="text-indigo-200">|</span>
           </>
         )}
 
@@ -507,68 +510,74 @@ export default function Flashcards() {
             {Math.min(stats.cardsStudiedToday, STREAK_THRESHOLD)}/{STREAK_THRESHOLD}
           </strong>
         </span>
-        <span className="text-gray-300">|</span>
+        <span className="text-indigo-200">|</span>
 
         <span>
-          Streak: <strong className="text-text">{stats.streak}d</strong>
+          Streak: <strong className="text-accent">{stats.streak}d</strong>
           {stats.cardsStudiedToday >= STREAK_THRESHOLD && (
-            <span className="ml-1 text-accent text-xs">✓</span>
+            <span className="ml-1 text-jade text-xs font-bold">✓</span>
           )}
         </span>
 
         {accuracy !== null && (
           <>
-            <span className="text-gray-300">|</span>
+            <span className="text-indigo-200">|</span>
             <span>
               Accuracy: <strong className="text-text">{accuracy}%</strong>
             </span>
           </>
         )}
 
-        <span className="ml-auto text-xs">
-          ✓ {sessionScore.known} · ✗ {sessionScore.learning}
+        <span className="ml-auto text-xs font-medium">
+          <span className="text-jade">✓ {sessionScore.known}</span>
+          {' · '}
+          <span className="text-coral">✗ {sessionScore.learning}</span>
         </span>
       </div>
 
       {/* ── Card ──────────────────────────────────────────────────────────── */}
       <div
         onClick={answerMode === 'flip' && !flipped ? handleFlip : undefined}
-        className={`bg-bg-card rounded-xl shadow-lg border border-gray-100 px-10 py-8 text-center select-none min-h-[220px] flex flex-col items-center justify-center transition-shadow ${
-          answerMode === 'flip' && !flipped ? 'cursor-pointer hover:shadow-xl' : ''
+        className={`bg-bg-card rounded-2xl shadow-md border-2 border-indigo-100 px-10 py-8 text-center select-none min-h-[220px] flex flex-col items-center justify-center transition-all ${
+          answerMode === 'flip' && !flipped ? 'cursor-pointer hover:shadow-lg hover:border-grape/30' : ''
         }`}
       >
         {/* Front side */}
         <p
-          className="font-serif leading-tight"
+          className="leading-tight"
           style={{
-            fontSize: direction === 'gr-en' ? '2.8rem' : '1.6rem',
-            color: direction === 'gr-en' ? 'var(--color-greek)' : 'inherit',
+            fontSize: direction === 'gr-en' ? '3rem' : '1.8rem',
+            fontFamily: direction === 'gr-en' ? 'var(--font-greek)' : 'var(--font-sans)',
+            fontWeight: direction === 'gr-en' ? '700' : '600',
+            color: direction === 'gr-en' ? 'var(--color-greek)' : 'var(--color-text)',
           }}
         >
           {front}
         </p>
         {direction === 'gr-en' && (
-          <p className="text-text-muted text-sm mt-1">{card.partOfSpeech}</p>
+          <p className="text-text-muted text-sm mt-2 font-medium uppercase tracking-wide text-xs">{card.partOfSpeech}</p>
         )}
 
         {/* Flip mode: reveal hint */}
         {answerMode === 'flip' && !flipped && (
-          <p className="text-text-muted text-xs mt-6">click or press space to reveal</p>
+          <p className="text-text-muted/60 text-xs mt-6">click or press space to reveal</p>
         )}
 
         {/* Flip mode: back side */}
         {answerMode === 'flip' && flipped && (
-          <div className="mt-4 pt-4 border-t border-gray-100 w-full text-center">
+          <div className="mt-4 pt-4 border-t-2 border-indigo-50 w-full text-center">
             <p
-              className="font-serif"
+              className="leading-tight"
               style={{
-                fontSize: direction === 'en-gr' ? '2.8rem' : '1.6rem',
-                color: direction === 'en-gr' ? 'var(--color-greek)' : 'inherit',
+                fontSize: direction === 'en-gr' ? '3rem' : '1.8rem',
+                fontFamily: direction === 'en-gr' ? 'var(--font-greek)' : 'var(--font-sans)',
+                fontWeight: direction === 'en-gr' ? '700' : '600',
+                color: direction === 'en-gr' ? 'var(--color-greek)' : 'var(--color-text)',
               }}
             >
               {back}
             </p>
-            <p className="text-text-muted text-sm mt-1">
+            <p className="text-text-muted text-xs mt-2 uppercase tracking-wide font-medium">
               {direction === 'gr-en'
                 ? `occurs ${card.frequency.toLocaleString()}× in GNT`
                 : card.partOfSpeech}
@@ -588,13 +597,13 @@ export default function Flashcards() {
               placeholder={
                 direction === 'gr-en' ? 'Type the English gloss…' : 'Type the Greek word…'
               }
-              className="flex-1 px-3 py-2 border-2 border-gray-200 rounded-lg focus:border-primary focus:outline-none text-sm"
+              className="flex-1 px-3 py-2 border-2 border-indigo-100 rounded-xl focus:border-grape focus:outline-none text-sm"
               autoComplete="off"
               spellCheck={false}
             />
             <button
               onClick={handleTypeSubmit}
-              className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-light text-sm font-medium transition-colors"
+              className="px-4 py-2 bg-grape text-white rounded-xl hover:opacity-90 text-sm font-semibold transition-opacity shadow-sm"
             >
               Check
             </button>
@@ -604,20 +613,20 @@ export default function Flashcards() {
         {/* Type mode: result feedback */}
         {answerMode === 'type' && answerResult !== null && (
           <div
-            className={`mt-4 px-4 py-3 rounded-lg w-full max-w-sm text-center ${
+            className={`mt-4 px-4 py-3 rounded-xl w-full max-w-sm text-center border-2 ${
               answerResult === 'correct'
-                ? 'bg-green-50 border border-green-200'
-                : 'bg-red-50 border border-red-200'
+                ? 'bg-jade/5 border-jade/30'
+                : 'bg-coral/5 border-coral/30'
             }`}
           >
             {answerResult === 'correct' ? (
-              <p className="text-green-700 font-medium">Correct!</p>
+              <p className="font-bold" style={{ color: 'var(--color-jade)' }}>Correct!</p>
             ) : (
               <>
-                <p className="text-red-700 font-medium">Not quite</p>
+                <p className="font-bold" style={{ color: 'var(--color-coral)' }}>Not quite</p>
                 <p className="text-text-muted text-sm mt-1">
                   Answer:{' '}
-                  <span className="font-medium text-text">{expectedAnswer}</span>
+                  <span className="font-semibold text-text">{expectedAnswer}</span>
                 </p>
               </>
             )}
@@ -630,13 +639,13 @@ export default function Flashcards() {
         <div className="flex justify-center gap-4">
           <button
             onClick={() => handleReview(false)}
-            className="px-6 py-2.5 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 transition-colors font-medium"
+            className="px-6 py-2.5 bg-coral/10 border-2 border-coral/30 text-coral rounded-xl hover:bg-coral/20 transition-colors font-semibold"
           >
             ← Still Learning
           </button>
           <button
             onClick={() => handleReview(true)}
-            className="px-6 py-2.5 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors font-medium"
+            className="px-6 py-2.5 bg-jade/10 border-2 border-jade/30 text-jade rounded-xl hover:bg-jade/20 transition-colors font-semibold"
           >
             Got It →
           </button>
@@ -648,17 +657,17 @@ export default function Flashcards() {
           {answerResult === 'incorrect' && (
             <button
               onClick={() => handleReview(false)}
-              className="px-6 py-2.5 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 transition-colors font-medium"
+              className="px-6 py-2.5 bg-coral/10 border-2 border-coral/30 text-coral rounded-xl hover:bg-coral/20 transition-colors font-semibold"
             >
               ← Still Learning
             </button>
           )}
           <button
             onClick={() => handleReview(answerResult === 'correct')}
-            className={`px-6 py-2.5 rounded-lg transition-colors font-medium ${
+            className={`px-6 py-2.5 rounded-xl border-2 transition-colors font-semibold ${
               answerResult === 'correct'
-                ? 'bg-green-100 text-green-700 hover:bg-green-200'
-                : 'bg-gray-100 text-text hover:bg-gray-200'
+                ? 'bg-jade/10 border-jade/30 text-jade hover:bg-jade/20'
+                : 'bg-gray-100 border-gray-200 text-text hover:bg-gray-200'
             }`}
           >
             {answerResult === 'correct' ? 'Got It →' : 'Next →'}
@@ -670,14 +679,14 @@ export default function Flashcards() {
       {answerMode === 'flip' && (
         <p className="text-xs text-text-muted text-center">
           Keyboard:{' '}
-          <kbd className="bg-gray-100 px-1 rounded">Space</kbd> flip ·{' '}
-          <kbd className="bg-gray-100 px-1 rounded">→</kbd> got it ·{' '}
-          <kbd className="bg-gray-100 px-1 rounded">←</kbd> still learning
+          <kbd className="bg-indigo-50 border border-indigo-100 px-1.5 rounded text-primary font-mono">Space</kbd> flip ·{' '}
+          <kbd className="bg-indigo-50 border border-indigo-100 px-1.5 rounded text-primary font-mono">→</kbd> got it ·{' '}
+          <kbd className="bg-indigo-50 border border-indigo-100 px-1.5 rounded text-primary font-mono">←</kbd> still learning
         </p>
       )}
       {answerMode === 'type' && (
         <p className="text-xs text-text-muted text-center">
-          Keyboard: <kbd className="bg-gray-100 px-1 rounded">Enter</kbd> check answer
+          Keyboard: <kbd className="bg-indigo-50 border border-indigo-100 px-1.5 rounded text-primary font-mono">Enter</kbd> check answer
         </p>
       )}
 
@@ -685,7 +694,7 @@ export default function Flashcards() {
       <div className="flex justify-center gap-4 pt-1">
         <button
           onClick={startSession}
-          className="text-sm text-text-muted hover:text-primary transition-colors"
+          className="text-sm text-text-muted hover:text-grape transition-colors font-medium"
         >
           Restart session
         </button>
@@ -698,7 +707,7 @@ export default function Flashcards() {
                 startSession();
               }
             }}
-            className="text-sm text-text-muted hover:text-red-500 transition-colors"
+            className="text-sm text-text-muted hover:text-coral transition-colors font-medium"
           >
             Reset SRS
           </button>

--- a/src/components/GreekKeyboard.tsx
+++ b/src/components/GreekKeyboard.tsx
@@ -96,8 +96,8 @@ export default function GreekKeyboard() {
         onKeyDown={handleKeyDown}
         onChange={(e) => setText(e.target.value)}
         placeholder="Start typing in English to produce Greek text..."
-        className="w-full h-48 p-4 text-2xl font-serif rounded-lg border-2 border-gray-200 focus:border-primary focus:outline-none resize-y"
-        style={{ color: 'var(--color-greek)', fontFamily: 'serif' }}
+        className="w-full h-48 p-4 text-2xl rounded-xl border-2 border-indigo-100 focus:border-primary focus:outline-none resize-y bg-bg-card shadow-sm"
+        style={{ color: 'var(--color-greek)', fontFamily: 'var(--font-greek)' }}
         spellCheck={false}
         autoFocus
       />
@@ -105,40 +105,40 @@ export default function GreekKeyboard() {
       <div className="flex gap-3">
         <button
           onClick={handleCopy}
-          className="px-5 py-2 bg-primary text-white rounded-lg hover:bg-primary-light transition-colors font-medium"
+          className="px-5 py-2 bg-primary text-white rounded-lg hover:bg-primary-light transition-colors font-semibold shadow-sm"
         >
           {copied ? '✓ Copied!' : 'Copy to Clipboard'}
         </button>
         <button
           onClick={handleClear}
-          className="px-5 py-2 bg-gray-200 text-text rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          className="px-5 py-2 bg-bg-card text-text-muted border border-gray-200 rounded-lg hover:border-gray-300 hover:text-text transition-colors font-medium"
         >
           Clear
         </button>
       </div>
 
-      <details className="bg-bg-card rounded-lg border border-gray-200 p-4">
+      <details className="bg-bg-card rounded-xl border border-indigo-100 p-4 shadow-sm">
         <summary className="font-semibold cursor-pointer text-primary">Key Mappings Reference</summary>
         <div className="mt-3 grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-1 text-sm">
-          <div className="font-bold col-span-full mt-2 mb-1 text-text-muted">Letters</div>
+          <div className="font-bold col-span-full mt-2 mb-1 text-text-muted uppercase tracking-wide text-xs">Letters</div>
           {Object.entries(GREEK_MAP).filter(([k]) => k === k.toLowerCase()).map(([eng, grk]) => (
-            <div key={eng} className="flex gap-2">
-              <kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">{eng}</kbd>
-              <span>→</span>
-              <span className="font-serif text-lg" style={{ color: 'var(--color-greek)' }}>{grk}</span>
+            <div key={eng} className="flex gap-2 items-center">
+              <kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">{eng}</kbd>
+              <span className="text-text-muted">→</span>
+              <span className="text-lg" style={{ color: 'var(--color-greek)', fontFamily: 'var(--font-greek)' }}>{grk}</span>
             </div>
           ))}
-          <div className="font-bold col-span-full mt-4 mb-1 text-text-muted">Diacritics (type after the vowel)</div>
-          <div><kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">)</kbd> → smooth breathing ̓</div>
-          <div><kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">(</kbd> → rough breathing ̔</div>
-          <div><kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">/</kbd> → acute accent ́</div>
-          <div><kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">\</kbd> → grave accent ̀</div>
-          <div><kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">=</kbd> → circumflex ͂</div>
-          <div><kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">|</kbd> → iota subscript ͅ</div>
-          <div className="font-bold col-span-full mt-4 mb-1 text-text-muted">Punctuation</div>
-          <div><kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">?</kbd> → Greek question mark (;)</div>
-          <div><kbd className="bg-gray-100 px-1.5 py-0.5 rounded text-xs font-mono">:</kbd> → ano teleia (·)</div>
-          <div className="col-span-full mt-2 text-text-muted italic">Final sigma (ς) is applied automatically at word boundaries.</div>
+          <div className="font-bold col-span-full mt-4 mb-1 text-text-muted uppercase tracking-wide text-xs">Diacritics (type after the vowel)</div>
+          <div className="flex gap-2 items-center"><kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">)</kbd><span className="text-text-muted text-xs">smooth breathing ̓</span></div>
+          <div className="flex gap-2 items-center"><kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">(</kbd><span className="text-text-muted text-xs">rough breathing ̔</span></div>
+          <div className="flex gap-2 items-center"><kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">/</kbd><span className="text-text-muted text-xs">acute accent ́</span></div>
+          <div className="flex gap-2 items-center"><kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">\</kbd><span className="text-text-muted text-xs">grave accent ̀</span></div>
+          <div className="flex gap-2 items-center"><kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">=</kbd><span className="text-text-muted text-xs">circumflex ͂</span></div>
+          <div className="flex gap-2 items-center"><kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">|</kbd><span className="text-text-muted text-xs">iota subscript ͅ</span></div>
+          <div className="font-bold col-span-full mt-4 mb-1 text-text-muted uppercase tracking-wide text-xs">Punctuation</div>
+          <div className="flex gap-2 items-center"><kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">?</kbd><span className="text-text-muted text-xs">Greek question mark (;)</span></div>
+          <div className="flex gap-2 items-center"><kbd className="bg-indigo-50 border border-indigo-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">:</kbd><span className="text-text-muted text-xs">ano teleia (·)</span></div>
+          <div className="col-span-full mt-2 text-text-muted italic text-xs">Final sigma (ς) is applied automatically at word boundaries.</div>
         </div>
       </details>
     </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,15 @@ interface Props {
 }
 
 const { title, description = "Free tools for Koine Greek students — keyboard, flashcards, and more." } = Astro.props;
+
+const navLinks = [
+  { href: '/keyboard',       label: 'Keyboard'        },
+  { href: '/flashcards',     label: 'Flashcards'      },
+  { href: '/transliteration', label: 'Transliteration' },
+  { href: '/grammar',        label: 'Grammar'         },
+];
+
+const currentPath = Astro.url.pathname;
 ---
 
 <!doctype html>
@@ -17,28 +26,94 @@ const { title, description = "Free tools for Koine Greek students — keyboard, 
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{title} | greek.tools</title>
+
+    <!-- Google Fonts: Plus Jakarta Sans (all UI) + Noto Sans (Greek text rendering) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Noto+Sans:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
+
   <body class="bg-bg text-text min-h-screen flex flex-col">
-    <nav class="bg-primary text-white px-6 py-4">
+
+    <!-- ── Rainbow accent line at top of page ─────────────────────────── -->
+    <div
+      class="h-1 w-full"
+      style="background: linear-gradient(90deg, #1D4ED8 0%, #7C3AED 30%, #F43F5E 55%, #F59E0B 75%, #059669 100%);"
+    ></div>
+
+    <!-- ── Nav ────────────────────────────────────────────────────────── -->
+    <nav class="bg-primary text-white px-6 py-4 shadow-md">
       <div class="max-w-5xl mx-auto flex items-center justify-between">
-        <a href="/" class="text-xl font-bold tracking-wide hover:text-accent-light transition-colors">
-          greek.tools
+
+        <!-- Logo -->
+        <a
+          href="/"
+          class="group flex items-baseline gap-0 hover:opacity-90 transition-opacity"
+          aria-label="greek.tools home"
+        >
+          <span class="text-xl font-extrabold tracking-tight leading-none">
+            greek
+          </span>
+          <span class="text-xl font-extrabold tracking-tight leading-none text-accent-light">
+            .tools
+          </span>
         </a>
-        <div class="flex gap-6 text-sm">
-          <a href="/keyboard" class="hover:text-accent-light transition-colors">Keyboard</a>
-          <a href="/flashcards" class="hover:text-accent-light transition-colors">Flashcards</a>
-          <a href="/transliteration" class="hover:text-accent-light transition-colors">Transliteration</a>
-          <a href="/grammar" class="hover:text-accent-light transition-colors">Grammar</a>
+
+        <!-- Nav links -->
+        <div class="flex gap-1">
+          {navLinks.map(({ href, label }) => {
+            const isActive = currentPath.startsWith(href);
+            return (
+              <a
+                href={href}
+                class={[
+                  'px-3 py-1.5 rounded-md text-sm font-semibold transition-colors',
+                  isActive
+                    ? 'bg-white/20 text-white'
+                    : 'text-white/80 hover:text-white hover:bg-white/10',
+                ].join(' ')}
+              >
+                {label}
+              </a>
+            );
+          })}
         </div>
+
       </div>
     </nav>
 
+    <!-- ── Main content ────────────────────────────────────────────────── -->
     <main class="flex-1 max-w-5xl mx-auto w-full px-6 py-8">
       <slot />
     </main>
 
-    <footer class="bg-primary text-white/60 text-sm text-center py-4">
-      <p>greek.tools — free utilities for Koine Greek students</p>
+    <!-- ── Footer ─────────────────────────────────────────────────────── -->
+    <footer class="bg-primary text-white/60 text-sm text-center py-5">
+      <p>
+        greek.tools — free utilities for Koine Greek students
+        <span class="mx-2 opacity-40">·</span>
+        <!-- Easter egg: ὁπλον means "tool" in ancient Greek -->
+        <span class="group relative inline-block cursor-help">
+          <span
+            class="opacity-30 group-hover:opacity-100 transition-all duration-300 group-hover:text-accent-light"
+            style="font-family: var(--font-greek);"
+          >
+            ὁπλον
+          </span>
+          <span class="
+            pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2
+            bg-text text-white text-xs px-3 py-1.5 rounded-lg whitespace-nowrap
+            opacity-0 group-hover:opacity-100 transition-opacity duration-200
+            shadow-lg
+          ">
+            ancient Greek for <em>"tool"</em>
+          </span>
+        </span>
+      </p>
     </footer>
+
   </body>
 </html>

--- a/src/pages/flashcards.astro
+++ b/src/pages/flashcards.astro
@@ -4,7 +4,16 @@ import Flashcards from '../components/Flashcards';
 ---
 
 <Layout title="Flashcards" description="Study Koine Greek vocabulary with flashcards sorted by frequency in the Greek New Testament.">
-  <h1 class="text-3xl font-bold text-primary mb-2">Vocabulary Flashcards</h1>
-  <p class="text-text-muted mb-6">Study the most common Koine Greek words from the New Testament. Cards are shuffled each session.</p>
+  <div class="mb-6">
+    <h1
+      class="text-3xl font-bold mb-1"
+      style="color: var(--color-grape);"
+    >
+      Vocabulary Flashcards
+    </h1>
+    <p class="text-text-muted">
+      Study the most common Koine Greek words from the New Testament. Cards are shuffled each session.
+    </p>
+  </div>
   <Flashcards client:load />
 </Layout>

--- a/src/pages/grammar.astro
+++ b/src/pages/grammar.astro
@@ -7,10 +7,17 @@ import GrammarReference from '../components/GrammarReference';
   title="Grammar Reference"
   description="Quick-reference paradigm tables for Koine Greek — noun declensions, verb conjugations, pronouns, prepositions, and accent rules."
 >
-  <h1 class="text-3xl font-bold text-primary mb-2">Grammar Reference</h1>
-  <p class="text-text-muted mb-8">
-    Paradigm tables for reading and translation work. Covers noun declensions, verb conjugations,
-    pronouns, prepositions, and accent rules.
-  </p>
+  <div class="mb-8">
+    <h1
+      class="text-3xl font-bold mb-1"
+      style="color: var(--color-coral);"
+    >
+      Grammar Reference
+    </h1>
+    <p class="text-text-muted">
+      Paradigm tables for reading and translation work. Covers noun declensions, verb conjugations,
+      pronouns, prepositions, and accent rules.
+    </p>
+  </div>
   <GrammarReference client:load />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,38 +1,109 @@
 ---
 import Layout from '../layouts/Layout.astro';
+
+const tools = [
+  {
+    href: '/keyboard',
+    icon: '⌨',
+    title: 'Greek Keyboard',
+    description: 'Type Koine Greek using your English keyboard. Supports breathing marks, accents, and iota subscripts.',
+    accentColor: '#1D4ED8',   // cobalt blue
+    bgColor: '#EEF2FF',
+  },
+  {
+    href: '/flashcards',
+    icon: '◫',
+    title: 'Flashcards',
+    description: 'Study vocabulary from the Greek New Testament with spaced-repetition. Learn the most common words first.',
+    accentColor: '#7C3AED',   // grape violet
+    bgColor: '#F5F3FF',
+  },
+  {
+    href: '/transliteration',
+    icon: 'Tt',
+    title: 'Transliteration',
+    description: 'Convert polytonic Greek to SBL romanized transliteration and back. Handles breathing marks, accents, and iota subscripts.',
+    accentColor: '#0D9488',   // teal
+    bgColor: '#F0FDFA',
+  },
+  {
+    href: '/grammar',
+    icon: '⊞',
+    title: 'Grammar Reference',
+    description: 'Paradigm tables for noun declensions, verb conjugations, pronouns, prepositions, and accent rules.',
+    accentColor: '#F43F5E',   // coral rose
+    bgColor: '#FFF1F2',
+  },
+] as const;
 ---
 
 <Layout title="Home">
-  <div class="text-center py-16">
-    <h1 class="text-4xl font-bold text-primary mb-4">greek.tools</h1>
-    <p class="text-lg text-text-muted max-w-2xl mx-auto mb-12">
-      Free, simple utilities for Koine Greek students. Type in Greek, study vocabulary, and strengthen your reading of the New Testament and Septuagint.
+
+  <!-- ── Hero ──────────────────────────────────────────────────────────── -->
+  <div class="text-center pt-12 pb-10">
+
+    <!-- Greek ornament -->
+    <p
+      class="text-5xl mb-4 select-none opacity-20"
+      style="font-family: var(--font-greek); color: var(--color-primary);"
+      aria-hidden="true"
+    >
+      Αα Ββ Γγ
     </p>
 
-    <div class="grid md:grid-cols-2 gap-8 max-w-3xl mx-auto">
-      <a href="/keyboard" class="block bg-bg-card rounded-xl shadow-md hover:shadow-lg transition-shadow p-8 text-left border border-gray-100">
-        <div class="text-3xl mb-3">⌨️</div>
-        <h2 class="text-xl font-semibold text-primary mb-2">Greek Keyboard</h2>
-        <p class="text-text-muted text-sm">
-          Type Koine Greek using your English keyboard. Supports breathing marks, accents, and iota subscripts. Copy and paste anywhere.
-        </p>
-      </a>
+    <h1
+      class="text-5xl font-extrabold mb-4 leading-tight"
+      style="color: var(--color-primary);"
+    >
+      greek<span style="color: var(--color-accent);">.tools</span>
+    </h1>
 
-      <a href="/flashcards" class="block bg-bg-card rounded-xl shadow-md hover:shadow-lg transition-shadow p-8 text-left border border-gray-100">
-        <div class="text-3xl mb-3">📇</div>
-        <h2 class="text-xl font-semibold text-primary mb-2">Flashcards</h2>
-        <p class="text-text-muted text-sm">
-          Study vocabulary from the Greek New Testament. Sorted by frequency so you learn the most common words first.
-        </p>
-      </a>
-
-      <a href="/transliteration" class="block bg-bg-card rounded-xl shadow-md hover:shadow-lg transition-shadow p-8 text-left border border-gray-100">
-        <div class="text-3xl mb-3">🔤</div>
-        <h2 class="text-xl font-semibold text-primary mb-2">Transliteration</h2>
-        <p class="text-text-muted text-sm">
-          Convert polytonic Greek to SBL romanized transliteration and back. Handles breathing marks, accents, and iota subscripts.
-        </p>
-      </a>
-    </div>
+    <p class="text-lg text-text-muted max-w-xl mx-auto leading-relaxed">
+      Free, simple utilities for Koine Greek students. Type, study, and
+      strengthen your reading of the New Testament and Septuagint.
+    </p>
   </div>
+
+  <!-- ── Tool cards ────────────────────────────────────────────────────── -->
+  <div class="grid md:grid-cols-3 gap-6 max-w-4xl mx-auto pb-16">
+    {tools.map(({ href, icon, title, description, accentColor, bgColor }) => (
+      <a
+        href={href}
+        class="group block bg-bg-card rounded-2xl shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden border border-white hover:-translate-y-0.5"
+      >
+        <!-- Colored top strip -->
+        <div class="h-1.5 w-full" style={`background: ${accentColor};`} />
+
+        <div class="p-6">
+          <!-- Icon badge -->
+          <div
+            class="w-12 h-12 rounded-xl flex items-center justify-center text-xl mb-4 font-mono font-bold"
+            style={`background: ${bgColor}; color: ${accentColor};`}
+          >
+            {icon}
+          </div>
+
+          <h2
+            class="text-lg font-bold mb-2 group-hover:opacity-80 transition-opacity"
+            style={`color: ${accentColor};`}
+          >
+            {title}
+          </h2>
+
+          <p class="text-text-muted text-sm leading-relaxed">
+            {description}
+          </p>
+        </div>
+
+        <!-- Footer hint -->
+        <div
+          class="px-6 pb-4 text-xs font-semibold flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+          style={`color: ${accentColor};`}
+        >
+          Open →
+        </div>
+      </a>
+    ))}
+  </div>
+
 </Layout>

--- a/src/pages/keyboard.astro
+++ b/src/pages/keyboard.astro
@@ -4,7 +4,16 @@ import GreekKeyboard from '../components/GreekKeyboard';
 ---
 
 <Layout title="Greek Keyboard" description="Type Koine Greek using your English keyboard. Supports diacritics, breathing marks, and final sigma.">
-  <h1 class="text-3xl font-bold text-primary mb-2">Greek Keyboard</h1>
-  <p class="text-text-muted mb-6">Type on your English keyboard to produce polytonic Koine Greek. Diacritics are typed after the letter.</p>
+  <div class="mb-6">
+    <h1
+      class="text-3xl font-bold mb-1"
+      style="color: var(--color-primary);"
+    >
+      Greek Keyboard
+    </h1>
+    <p class="text-text-muted">
+      Type on your English keyboard to produce polytonic Koine Greek. Diacritics are typed after the letter.
+    </p>
+  </div>
   <GreekKeyboard client:load />
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,13 +1,53 @@
 @import "tailwindcss";
 
+/* ─── Design Tokens ─────────────────────────────────────────────────────────
+   Single source of truth for the design system.
+   All --color-* values become Tailwind utilities (bg-*, text-*, border-*).
+   All --font-* values become Tailwind utilities (font-*).
+   ──────────────────────────────────────────────────────────────────────── */
+
 @theme {
-  --color-primary: #1e3a5f;
-  --color-primary-light: #2d5a8e;
-  --color-accent: #c49b3c;
-  --color-accent-light: #d4af5f;
-  --color-bg: #faf8f5;
-  --color-bg-card: #ffffff;
-  --color-text: #2c2c2c;
-  --color-text-muted: #6b7280;
-  --color-greek: #8b4513;
+  /* ── Brand palette ──────────────────────────────────────────────────── */
+  --color-primary:        #1D4ED8;   /* Cobalt blue — nav, buttons, links        */
+  --color-primary-light:  #3B82F6;   /* Sky blue — hover state                   */
+
+  --color-accent:         #F59E0B;   /* Amber gold — streak, highlights          */
+  --color-accent-light:   #FCD34D;   /* Pale gold — soft accents                 */
+
+  /* ── Vibrant accent palette ─────────────────────────────────────────── */
+  --color-coral:          #F43F5E;   /* Rose coral — danger / still-learning     */
+  --color-jade:           #059669;   /* Emerald green — correct / success        */
+  --color-grape:          #7C3AED;   /* Violet — tertiary accent                 */
+
+  /* ── Surfaces ───────────────────────────────────────────────────────── */
+  --color-bg:             #F0F4FF;   /* Indigo-tinted page background            */
+  --color-bg-card:        #FFFFFF;   /* Pure white cards                         */
+
+  /* ── Text ───────────────────────────────────────────────────────────── */
+  --color-text:           #1E1B4B;   /* Deep indigo — primary text               */
+  --color-text-muted:     #6B7280;   /* Cool gray — secondary / hint text        */
+
+  /* ── Greek script color (alias for grape) ───────────────────────────── */
+  --color-greek:          #7C3AED;   /* Vivid violet — Greek text rendering      */
+
+  /* ── Typography ─────────────────────────────────────────────────────── */
+  --font-sans:   'Plus Jakarta Sans', system-ui, sans-serif;
+  --font-greek:  'Noto Sans', system-ui, sans-serif;   /* Greek-script text */
+}
+
+/* ─── Base Styles ──────────────────────────────────────────────────────────
+   Keep this section minimal — component-specific styles live in the
+   components themselves via Tailwind utilities.
+   ──────────────────────────────────────────────────────────────────────── */
+
+@layer base {
+  body {
+    font-family: var(--font-sans);
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }


### PR DESCRIPTION
## Summary

- **New color palette**: cobalt blue primary, grape violet for Greek text, coral/jade for feedback states, amber gold for streak/accents — all defined as `@theme` tokens in `global.css` (single source of truth, ~55 lines)
- **Fonts**: Plus Jakarta Sans for all UI, Noto Sans for Greek script rendering — no serifs
- **Layout**: Rainbow gradient stripe at the top of every page; bright cobalt nav with active-link highlighting; homepage redesigned as a three-column card grid with per-tool accent colors (blue/violet/coral)
- **Components**: Flashcard controls use grape pill buttons; stats bar uses semantic colors; keyboard/reference elements get indigo-tinted borders
- **Easter egg**: `ὁπλον` (ancient Greek for "tool") sits at 30% opacity in the footer — hover to reveal it in amber with a tooltip
- **CSP**: Updated `_headers` to allow `fonts.googleapis.com` and `fonts.gstatic.com`

## Test plan

- [ ] Homepage loads with three-column card grid and rainbow top bar
- [ ] Each page heading renders in its accent color (cobalt/grape/coral)
- [ ] Flashcards — Greek text on card renders in violet Noto Sans, correct/incorrect feedback shows jade/coral
- [ ] Keyboard — textarea renders typed Greek in violet Noto Sans
- [ ] Footer `ὁπλον` is barely visible at rest; hover reveals amber text and tooltip
- [ ] No console errors in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)