### PR TITLE
Specify pnpm version to fix deployment lockfile error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "greek-tools",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@10.28.0",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Summary

- Adds `packageManager: pnpm@10.28.0` to `package.json` so Cloudflare Pages uses pnpm 10, which supports lockfile v9 with per-package `specifier` fields

## Test plan

- [ ] Verify deployment install step succeeds on Cloudflare Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)