### PR TITLE
Add GNT Reader with MorphGNT data pipeline

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,10 +2,10 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "greek-tools-dev",
+      "name": "greek-tools-nervous-borg",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
-      "port": 4321
+      "runtimeArgs": ["run", "dev", "--", "--port", "4324"],
+      "port": 4324
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ pnpm-debug.log*
 # jetbrains setting folder
 .idea/
 
+# Generated MorphGNT data files (produced by scripts/build-morphgnt.mjs)
+public/data/
+
 # Claude Code worktrees
 .claude/worktrees/
 

--- a/docs/prd/gnt-reader.md
+++ b/docs/prd/gnt-reader.md
@@ -6,6 +6,12 @@ A passage reader for the Greek New Testament with inline vocabulary help and mor
 
 ---
 
+## Priority
+
+High — foundational feature; Daily Verse Reader and Verse Memorization both depend on it.
+
+---
+
 ## Goals
 
 - Let students read GNT passages directly in the browser without a physical interlinear
@@ -26,12 +32,13 @@ The dataset provides per word: word form, normalized form, lemma, part of speech
 
 ### 1. Passage Selection
 
-Student selects a passage to read by book, chapter, and verse range.
+Student selects a passage to read by book and chapter. The full chapter is always loaded.
 
 **Behavior:**
-- Dropdown or searchable selector: Book → Chapter → Verse(s)
-- URL reflects the selected passage (e.g., `/reader?ref=John.3.16`) for shareability and bookmarking
-- Default on first load: John 1:1
+- Dropdown or searchable selector: Book → Chapter
+- URL reflects the selected passage (e.g., `/reader?ref=John.3`) for shareability and bookmarking
+- Default on first load: John 1
+- Individual verse anchors in the URL are supported for linking to a specific starting point within a chapter (e.g., `/reader?ref=John.3.16` scrolls to verse 16)
 
 ### 2. Greek Text Display
 
@@ -69,12 +76,12 @@ A toggle that shows a small gloss beneath every word simultaneously, turning the
 
 ### 5. Reading History
 
-Track which passages the student has opened.
+Remember the student's most recent passage so they can pick up where they left off.
 
 **Behavior:**
-- Store last 10 passages visited in localStorage
-- "Recently read" list on the reader page for quick return
-- No account required
+- Store the single most recently visited passage reference in localStorage
+- Homepage shows a "Continue reading: [Book Chapter:Verse]" link when a prior passage exists
+- No list, no account required
 
 ---
 
@@ -91,4 +98,9 @@ Track which passages the student has opened.
 
 - **Dataset:** MorphGNT (decided)
 - **Bundling strategy:** Per-book JSON files generated at build time from MorphGNT source, output to `public/data/morphgnt/` (e.g., `JHN.json`, `ROM.json`). Fetched on demand at runtime when the user selects a passage; cached in memory for the session. Cloudflare Workers serves these with Brotli compression automatically.
+- **Passage granularity:** Chapter at a time. The selector is Book → Chapter. Individual verse anchors are supported in the URL for deep-linking.
+- **Gloss data source:** MorphGNT provides lemmas but not English glosses. The existing `vocabulary.ts` dataset (high-frequency GNT words with glosses) will be the primary source. For lemmas not covered by that list, display the lemma only with no English gloss — this is acceptable since lower-frequency words are less likely to be needed on demand. A fuller open lexicon can be added later if the gap is significant.
+- **Greek font:** GFS Didot (open source, LGPL) as the default; SBL Greek listed as an alternative note in the UI since it requires a separate download and has distribution restrictions.
+- **Mobile tap interaction:** Use tap delay + movement detection on touch devices. On `touchstart`, start a short timer; if the finger moves more than ~5px before `touchend` (scroll intent), cancel the popup. If the finger lifts without moving, open the popup. This is invisible to the user and avoids accidental popups while scrolling.
+- **Flashcards integration:** SRS card keys will be normalized to individual lemma forms (e.g., `'ὁ'` not `'ὁ, ἡ, τό'`) so they match MorphGNT lemmas directly. This requires bumping the store to `greek-tools-srs-v2` with a one-time migration from `v1`. The Reader reads studied words via a `getStudiedLemmas(): Set<string>` helper exported from `srs.ts`.
 - **LXX:** Out of scope for v1.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "packageManager": "pnpm@10.28.0",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "node scripts/build-morphgnt.mjs && astro build",
+    "build:data": "node scripts/build-morphgnt.mjs",
+    "build:data:force": "node scripts/build-morphgnt.mjs --force",
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest",

--- a/scripts/build-morphgnt.mjs
+++ b/scripts/build-morphgnt.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Build script: fetches MorphGNT source files from GitHub and outputs
+ * per-book JSON files to public/data/morphgnt/.
+ *
+ * Each book file (e.g. JHN.json) is structured as:
+ *   { [chapter: string]: { [verse: string]: MorphWord[] } }
+ *
+ * MorphWord: { text, lemma, pos, parsing }
+ *
+ * Run: node scripts/build-morphgnt.mjs
+ * Force re-fetch: node scripts/build-morphgnt.mjs --force
+ */
+
+import { mkdir, writeFile, access } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = join(__dirname, '..', 'public', 'data', 'morphgnt');
+const BASE_URL = 'https://raw.githubusercontent.com/morphgnt/sblgnt/master';
+const FORCE = process.argv.includes('--force');
+
+// MorphGNT book numbering: 61 = Matthew, 87 = Revelation
+const BOOKS = [
+  { num: 61, file: '61-Mt-morphgnt.txt',  code: 'MAT', name: 'Matthew' },
+  { num: 62, file: '62-Mk-morphgnt.txt',  code: 'MRK', name: 'Mark' },
+  { num: 63, file: '63-Lk-morphgnt.txt',  code: 'LUK', name: 'Luke' },
+  { num: 64, file: '64-Jn-morphgnt.txt',  code: 'JHN', name: 'John' },
+  { num: 65, file: '65-Ac-morphgnt.txt',  code: 'ACT', name: 'Acts' },
+  { num: 66, file: '66-Ro-morphgnt.txt',  code: 'ROM', name: 'Romans' },
+  { num: 67, file: '67-1Co-morphgnt.txt', code: '1CO', name: '1 Corinthians' },
+  { num: 68, file: '68-2Co-morphgnt.txt', code: '2CO', name: '2 Corinthians' },
+  { num: 69, file: '69-Ga-morphgnt.txt',  code: 'GAL', name: 'Galatians' },
+  { num: 70, file: '70-Eph-morphgnt.txt', code: 'EPH', name: 'Ephesians' },
+  { num: 71, file: '71-Php-morphgnt.txt', code: 'PHP', name: 'Philippians' },
+  { num: 72, file: '72-Col-morphgnt.txt', code: 'COL', name: 'Colossians' },
+  { num: 73, file: '73-1Th-morphgnt.txt', code: '1TH', name: '1 Thessalonians' },
+  { num: 74, file: '74-2Th-morphgnt.txt', code: '2TH', name: '2 Thessalonians' },
+  { num: 75, file: '75-1Ti-morphgnt.txt', code: '1TI', name: '1 Timothy' },
+  { num: 76, file: '76-2Ti-morphgnt.txt', code: '2TI', name: '2 Timothy' },
+  { num: 77, file: '77-Tit-morphgnt.txt', code: 'TIT', name: 'Titus' },
+  { num: 78, file: '78-Phm-morphgnt.txt', code: 'PHM', name: 'Philemon' },
+  { num: 79, file: '79-Heb-morphgnt.txt', code: 'HEB', name: 'Hebrews' },
+  { num: 80, file: '80-Jas-morphgnt.txt', code: 'JAS', name: 'James' },
+  { num: 81, file: '81-1Pe-morphgnt.txt', code: '1PE', name: '1 Peter' },
+  { num: 82, file: '82-2Pe-morphgnt.txt', code: '2PE', name: '2 Peter' },
+  { num: 83, file: '83-1Jn-morphgnt.txt', code: '1JN', name: '1 John' },
+  { num: 84, file: '84-2Jn-morphgnt.txt', code: '2JN', name: '2 John' },
+  { num: 85, file: '85-3Jn-morphgnt.txt', code: '3JN', name: '3 John' },
+  { num: 86, file: '86-Jud-morphgnt.txt', code: 'JUD', name: 'Jude' },
+  { num: 87, file: '87-Re-morphgnt.txt',  code: 'REV', name: 'Revelation' },
+];
+
+/**
+ * Parse MorphGNT text format into a chapter→verse→words structure.
+ *
+ * Each line: BBCCVV POS PARSING TEXT WORD NORMALIZED LEMMA
+ *   BBCCVV = 6-digit compact reference (2-digit book, 2-digit chapter, 2-digit verse)
+ *   e.g. "040101" = John (book 4) chapter 1 verse 1
+ *
+ * We store only: text, lemma, pos, parsing (omitting word + normalized to reduce size).
+ */
+function parseMorphGNT(raw) {
+  /** @type {Record<string, Record<string, Array<{text:string,lemma:string,pos:string,parsing:string}>>>} */
+  const chapters = {};
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const parts = trimmed.split(' ');
+    // Expect exactly 7 fields; skip malformed lines
+    if (parts.length < 7) continue;
+
+    const [ref, pos, parsing, text, , , lemma] = parts;
+    // Reference is BBCCVV — extract chapter (digits 2-3) and verse (digits 4-5)
+    if (ref.length < 6) continue;
+    const ch = String(parseInt(ref.slice(2, 4), 10));
+    const v  = String(parseInt(ref.slice(4, 6), 10));
+
+    if (!chapters[ch]) chapters[ch] = {};
+    if (!chapters[ch][v]) chapters[ch][v] = [];
+
+    chapters[ch][v].push({ text, lemma, pos, parsing });
+  }
+
+  return chapters;
+}
+
+async function fileExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function processBook(book) {
+  const outPath = join(OUT_DIR, `${book.code}.json`);
+
+  if (!FORCE && await fileExists(outPath)) {
+    console.log(`  Skipping ${book.name} (already exists; use --force to re-fetch)`);
+    // Still need to return chapter count
+    const existing = JSON.parse(await (await import('node:fs/promises')).readFile(outPath, 'utf-8'));
+    return { code: book.code, name: book.name, chapters: Object.keys(existing).length };
+  }
+
+  const url = `${BASE_URL}/${book.file}`;
+  console.log(`  Fetching ${book.name} from ${url}`);
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} fetching ${url}\n  Check that the file exists at this path in the morphgnt/sblgnt repository.`);
+  }
+
+  const raw = await res.text();
+  const chapters = parseMorphGNT(raw);
+  const chapterCount = Object.keys(chapters).length;
+
+  if (chapterCount === 0) {
+    throw new Error(`Parsed 0 chapters from ${book.file} — check the file format`);
+  }
+
+  await writeFile(outPath, JSON.stringify(chapters), 'utf-8');
+  console.log(`    → ${book.code}.json (${chapterCount} chapters)`);
+
+  return { code: book.code, name: book.name, chapters: chapterCount };
+}
+
+async function main() {
+  console.log('Building MorphGNT data files...\n');
+  await mkdir(OUT_DIR, { recursive: true });
+
+  const bookIndex = [];
+  let errors = 0;
+
+  for (const book of BOOKS) {
+    try {
+      const info = await processBook(book);
+      bookIndex.push(info);
+    } catch (err) {
+      console.error(`  ERROR processing ${book.name}: ${err.message}`);
+      errors++;
+    }
+  }
+
+  if (bookIndex.length > 0) {
+    await writeFile(
+      join(OUT_DIR, 'books.json'),
+      JSON.stringify(bookIndex, null, 2),
+      'utf-8',
+    );
+    console.log(`\nWrote books.json (${bookIndex.length} books)`);
+  }
+
+  if (errors > 0) {
+    console.error(`\n${errors} book(s) failed. Run with --force to retry.`);
+    process.exit(1);
+  }
+
+  console.log('Done.');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/Flashcards.tsx
+++ b/src/components/Flashcards.tsx
@@ -3,7 +3,7 @@ import { vocabulary, type VocabWord } from '../data/vocabulary';
 import {
   type SRSCard,
   loadSRSStore, saveSRSStore, loadStats, saveStats,
-  recordReview, newCard, nextSRS, isDue, STREAK_THRESHOLD,
+  recordReview, newCard, nextSRS, isDue, STREAK_THRESHOLD, normalizeKey,
 } from '../data/srs';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -68,7 +68,7 @@ function buildQueue(
   const due: VocabWord[] = [];
   const fresh: VocabWord[] = [];
   for (const w of vocab) {
-    const c = store[w.greek];
+    const c = store[normalizeKey(w.greek)];
     if (!c) fresh.push(w);
     else if (isDue(c)) due.push(w);
   }
@@ -125,11 +125,11 @@ export default function Flashcards() {
 
   // SRS stats for display
   const dueCount = useMemo(
-    () => filteredVocab.filter(w => { const c = srsStore[w.greek]; return c ? isDue(c) : false; }).length,
+    () => filteredVocab.filter(w => { const c = srsStore[normalizeKey(w.greek)]; return c ? isDue(c) : false; }).length,
     [filteredVocab, srsStore],
   );
   const newCount = useMemo(
-    () => filteredVocab.filter(w => !srsStore[w.greek]).length,
+    () => filteredVocab.filter(w => !srsStore[normalizeKey(w.greek)]).length,
     [filteredVocab, srsStore],
   );
 
@@ -178,9 +178,10 @@ export default function Flashcards() {
 
       if (studyMode === 'srs') {
         setSrsStore(prev => {
-          const existing = prev[card.greek] ?? newCard(card.greek);
+          const k = normalizeKey(card.greek);
+          const existing = prev[k] ?? newCard(k);
           const updated = nextSRS(existing, correct ? 4 : 1);
-          const next = { ...prev, [card.greek]: updated };
+          const next = { ...prev, [k]: updated };
           saveSRSStore(next);
           return next;
         });

--- a/src/components/GNTReader.tsx
+++ b/src/components/GNTReader.tsx
@@ -1,0 +1,438 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  type MorphWord, type MorphBook, type BookMeta,
+  fetchBook, fetchBooks, formatParse, splitWordPunct,
+  saveLastPassage,
+} from '../data/morphgnt';
+import { vocabulary } from '../data/vocabulary';
+import { getStudiedLemmas } from '../data/srs';
+
+// ─── Vocabulary lookup ────────────────────────────────────────────────────────
+
+interface VocabEntry { gloss: string; frequency: number }
+
+function buildVocabLookup(): Map<string, VocabEntry> {
+  const map = new Map<string, VocabEntry>();
+  for (const w of vocabulary) {
+    for (const form of w.greek.split(', ')) {
+      map.set(form.trim(), { gloss: w.gloss, frequency: w.frequency });
+    }
+  }
+  return map;
+}
+
+const vocabLookup = buildVocabLookup();
+
+// ─── URL helpers ──────────────────────────────────────────────────────────────
+
+function parseRef(ref: string): { book: string; chapter: number; verse?: number } {
+  const parts = ref.split('.');
+  const book = parts[0] || 'JHN';
+  const chapter = parseInt(parts[1] ?? '1', 10) || 1;
+  const verse = parts[2] ? parseInt(parts[2], 10) || undefined : undefined;
+  return { book, chapter, verse };
+}
+
+function getUrlRef(): string | null {
+  if (typeof window === 'undefined') return null;
+  return new URLSearchParams(window.location.search).get('ref');
+}
+
+function setUrlRef(book: string, chapter: number): void {
+  const url = new URL(window.location.href);
+  url.searchParams.set('ref', `${book}.${chapter}`);
+  history.replaceState(null, '', url.toString());
+}
+
+// ─── WordPopup ────────────────────────────────────────────────────────────────
+
+interface ActiveWord { word: MorphWord; rect: DOMRect }
+
+function WordPopup({ active, onClose }: { active: ActiveWord; onClose: () => void }) {
+  const { word, rect } = active;
+  const vocab = vocabLookup.get(word.lemma);
+  const parse = formatParse(word.pos, word.parsing);
+
+  // Position: below the word, kept within viewport
+  const top = rect.bottom + window.scrollY + 6;
+  const left = Math.max(8, Math.min(rect.left + window.scrollX, window.innerWidth - 288 - 8));
+
+  // Dismiss on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // Dismiss on scroll (popup would visually drift from word)
+  useEffect(() => {
+    const handler = () => onClose();
+    window.addEventListener('scroll', handler, { passive: true, once: true });
+    return () => window.removeEventListener('scroll', handler);
+  }, [onClose]);
+
+  const popup = (
+    <div
+      role="dialog"
+      aria-label={`Word info: ${word.lemma}`}
+      style={{ position: 'absolute', top, left, zIndex: 50, width: 272 }}
+      className="bg-bg-card border border-gray-200 rounded-xl shadow-xl p-4 text-sm"
+      // Stop clicks inside from bubbling to the overlay
+      onClick={e => e.stopPropagation()}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <span
+          className="font-serif text-2xl leading-tight"
+          style={{ color: 'var(--color-greek)' }}
+        >
+          {word.lemma}
+        </span>
+        <button
+          onClick={onClose}
+          className="text-text-muted hover:text-text transition-colors mt-1 text-xs"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      {vocab ? (
+        <p className="text-text mb-1">{vocab.gloss}</p>
+      ) : (
+        <p className="text-text-muted italic mb-1">gloss not available</p>
+      )}
+
+      <p className="text-text-muted text-xs">{parse}</p>
+
+      {vocab && (
+        <p className="text-text-muted text-xs mt-1">
+          {vocab.frequency.toLocaleString()}× in GNT
+        </p>
+      )}
+
+      <a
+        href="/flashcards"
+        className="mt-3 block text-center text-xs px-3 py-1.5 rounded-lg border border-primary/30 text-primary hover:bg-primary/5 transition-colors"
+      >
+        Study in Flashcards →
+      </a>
+    </div>
+  );
+
+  return createPortal(popup, document.body);
+}
+
+// ─── WordToken ────────────────────────────────────────────────────────────────
+
+function WordToken({
+  word,
+  showGloss,
+  studied,
+  onActivate,
+}: {
+  word: MorphWord;
+  showGloss: boolean;
+  studied: boolean;
+  onActivate: (word: MorphWord, rect: DOMRect) => void;
+}) {
+  const [wordText, punct] = splitWordPunct(word.text);
+  const spanRef = useRef<HTMLSpanElement>(null);
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (spanRef.current) onActivate(word, spanRef.current.getBoundingClientRect());
+  }, [word, onActivate]);
+
+  return (
+    // inline-flex column so gloss stacks below the word without breaking flow
+    <span
+      className="inline-flex flex-col items-center"
+      style={{ verticalAlign: 'top', marginRight: '0.25em' }}
+    >
+      <span className="flex items-baseline">
+        <span
+          ref={spanRef}
+          onClick={handleClick}
+          className={`font-serif cursor-pointer rounded px-0.5 hover:bg-accent/10 transition-colors ${
+            studied ? 'underline decoration-accent/60 decoration-dotted underline-offset-2' : ''
+          }`}
+          style={{
+            fontSize: '1.35rem',
+            lineHeight: '1.6',
+            color: 'var(--color-greek)',
+            // Remove 300ms tap delay on touch devices; browser handles scroll vs tap discrimination
+            touchAction: 'manipulation',
+          }}
+        >
+          {wordText}
+        </span>
+        {punct && (
+          <span className="text-text" style={{ fontSize: '1.1rem', lineHeight: '1.6' }}>
+            {punct}
+          </span>
+        )}
+      </span>
+
+      {showGloss && (
+        <span className="text-text-muted" style={{ fontSize: '0.62rem', lineHeight: 1.2, maxWidth: '5rem', textAlign: 'center' }}>
+          {vocabLookup.get(word.lemma)?.gloss?.split(',')[0] ?? word.lemma}
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ─── VerseDisplay ─────────────────────────────────────────────────────────────
+
+function VerseDisplay({
+  verseNum,
+  words,
+  showGlosses,
+  studiedLemmas,
+  activeWord,
+  onActivate,
+}: {
+  verseNum: number;
+  words: MorphWord[];
+  showGlosses: boolean;
+  studiedLemmas: Set<string>;
+  activeWord: MorphWord | null;
+  onActivate: (word: MorphWord, rect: DOMRect) => void;
+}) {
+  return (
+    <span id={`verse-${verseNum}`} className="inline">
+      <sup className="text-text-muted text-xs font-normal select-none mr-0.5 relative top-0">
+        {verseNum}
+      </sup>
+      {words.map((word, i) => (
+        <WordToken
+          key={i}
+          word={word}
+          showGloss={showGlosses}
+          studied={studiedLemmas.has(word.lemma)}
+          onActivate={onActivate}
+        />
+      ))}
+    </span>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function GNTReader() {
+  const [books, setBooks] = useState<BookMeta[]>([]);
+  const [book, setBook] = useState('JHN');
+  const [chapter, setChapter] = useState(1);
+  const [bookData, setBookData] = useState<MorphBook | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeWord, setActiveWord] = useState<ActiveWord | null>(null);
+  const [showGlosses, setShowGlosses] = useState(false);
+  const [studiedLemmas] = useState<Set<string>>(() => {
+    try { return getStudiedLemmas(); } catch { return new Set(); }
+  });
+
+  // Load book list once on mount; also read initial passage from URL
+  useEffect(() => {
+    fetchBooks()
+      .then(list => { setBooks(list); })
+      .catch(() => { /* books.json not yet built; list will be empty */ });
+
+    const ref = getUrlRef();
+    if (ref) {
+      const { book: b, chapter: ch } = parseRef(ref);
+      setBook(b);
+      setChapter(ch);
+    }
+  }, []);
+
+  // Fetch book data whenever book changes
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setBookData(null);
+
+    fetchBook(book)
+      .then(data => { if (!cancelled) { setBookData(data); setLoading(false); } })
+      .catch(err => {
+        if (!cancelled) {
+          setError((err as Error).message);
+          setLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [book]);
+
+  // Update URL and save history whenever passage changes
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setUrlRef(book, chapter);
+    saveLastPassage(`${book}.${chapter}`);
+  }, [book, chapter]);
+
+  // Scroll to verse anchor on initial load if ref includes verse
+  const didScrollRef = useRef(false);
+  useEffect(() => {
+    if (!bookData || didScrollRef.current) return;
+    const ref = getUrlRef();
+    if (!ref) return;
+    const { verse } = parseRef(ref);
+    if (verse) {
+      const el = document.getElementById(`verse-${verse}`);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        didScrollRef.current = true;
+      }
+    }
+  }, [bookData]);
+
+  // Reset scroll flag when chapter changes
+  useEffect(() => { didScrollRef.current = false; }, [book, chapter]);
+
+  const handleActivate = useCallback((word: MorphWord, rect: DOMRect) => {
+    setActiveWord(prev =>
+      prev?.word === word ? null : { word, rect },
+    );
+  }, []);
+
+  const handleClosePopup = useCallback(() => setActiveWord(null), []);
+
+  const currentBook = books.find(b => b.code === book);
+  const chapterCount = currentBook?.chapters ?? 0;
+  const chapterVerses = bookData?.[String(chapter)] ?? {};
+  const verseNums = Object.keys(chapterVerses)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  return (
+    // Overlay click closes popup
+    <div onClick={handleClosePopup}>
+
+      {/* ── Toolbar ───────────────────────────────────────────────────────── */}
+      <div
+        className="flex flex-wrap items-center gap-3 mb-6"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Book selector */}
+        <select
+          value={book}
+          onChange={e => { setBook(e.target.value); setChapter(1); }}
+          className="px-3 py-1.5 border border-gray-200 rounded-lg text-sm bg-bg-card focus:border-primary focus:outline-none"
+        >
+          {books.length === 0 ? (
+            <option value={book}>{book}</option>
+          ) : (
+            books.map(b => (
+              <option key={b.code} value={b.code}>{b.name}</option>
+            ))
+          )}
+        </select>
+
+        {/* Chapter selector */}
+        <select
+          value={chapter}
+          onChange={e => setChapter(Number(e.target.value))}
+          className="px-3 py-1.5 border border-gray-200 rounded-lg text-sm bg-bg-card focus:border-primary focus:outline-none"
+        >
+          {chapterCount === 0 ? (
+            <option value={chapter}>Chapter {chapter}</option>
+          ) : (
+            Array.from({ length: chapterCount }, (_, i) => i + 1).map(n => (
+              <option key={n} value={n}>Chapter {n}</option>
+            ))
+          )}
+        </select>
+
+        {/* Chapter navigation arrows */}
+        <div className="flex gap-1">
+          <button
+            onClick={e => { e.stopPropagation(); setChapter(c => Math.max(1, c - 1)); }}
+            disabled={chapter <= 1}
+            className="px-2 py-1.5 border border-gray-200 rounded-lg text-sm hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            aria-label="Previous chapter"
+          >
+            ←
+          </button>
+          <button
+            onClick={e => { e.stopPropagation(); setChapter(c => chapterCount ? Math.min(chapterCount, c + 1) : c + 1); }}
+            disabled={chapterCount > 0 && chapter >= chapterCount}
+            className="px-2 py-1.5 border border-gray-200 rounded-lg text-sm hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            aria-label="Next chapter"
+          >
+            →
+          </button>
+        </div>
+
+        {/* Gloss toggle */}
+        <button
+          onClick={e => { e.stopPropagation(); setShowGlosses(g => !g); }}
+          className={`ml-auto px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+            showGlosses
+              ? 'border-primary bg-primary text-white'
+              : 'border-gray-200 text-text-muted hover:border-gray-300 hover:text-text'
+          }`}
+        >
+          {showGlosses ? 'Hide glosses' : 'Show glosses'}
+        </button>
+      </div>
+
+      {/* ── Chapter heading ────────────────────────────────────────────────── */}
+      {currentBook && (
+        <h2 className="text-text-muted text-sm font-medium mb-4 select-none">
+          {currentBook.name} {chapter}
+        </h2>
+      )}
+
+      {/* ── Text area ─────────────────────────────────────────────────────── */}
+      {loading && (
+        <p className="text-text-muted text-center py-16">Loading…</p>
+      )}
+
+      {error && (
+        <div className="text-center py-16 space-y-3">
+          <p className="text-red-600 text-sm">
+            Could not load {book}: {error}
+          </p>
+          <p className="text-text-muted text-xs">
+            Run <code className="bg-gray-100 px-1 rounded">pnpm run build:data</code> to generate the data files.
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && bookData && (
+        <div
+          className="leading-relaxed max-w-2xl"
+          style={{ wordSpacing: showGlosses ? '0.3em' : undefined }}
+        >
+          {verseNums.map(v => (
+            <VerseDisplay
+              key={v}
+              verseNum={v}
+              words={chapterVerses[String(v)] ?? []}
+              showGlosses={showGlosses}
+              studiedLemmas={studiedLemmas}
+              activeWord={activeWord?.word ?? null}
+              onActivate={handleActivate}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* ── Legend ────────────────────────────────────────────────────────── */}
+      {!loading && !error && bookData && studiedLemmas.size > 0 && (
+        <p className="text-text-muted text-xs mt-6 select-none">
+          <span className="underline decoration-accent/60 decoration-dotted underline-offset-2">dotted underline</span>
+          {' '}= word you've studied in Flashcards
+        </p>
+      )}
+
+      {/* ── Word popup ────────────────────────────────────────────────────── */}
+      {activeWord && (
+        <WordPopup active={activeWord} onClose={handleClosePopup} />
+      )}
+    </div>
+  );
+}

--- a/src/data/morphgnt.ts
+++ b/src/data/morphgnt.ts
@@ -1,0 +1,128 @@
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MorphWord {
+  text: string;     // word as it appears in text (may include trailing punctuation)
+  lemma: string;    // lexical form (matches MorphGNT lemma)
+  pos: string;      // part-of-speech code (e.g. "N-", "V-", "P-")
+  parsing: string;  // 8-char parse code (person/tense/voice/mood/case/number/gender/degree)
+}
+
+export type MorphVerse = MorphWord[];
+// chapter string key → verse string key → words
+export type MorphBook = Record<string, Record<string, MorphVerse>>;
+
+export interface BookMeta {
+  code: string;
+  name: string;
+  chapters: number;
+}
+
+// ─── Parse code → human-readable string ──────────────────────────────────────
+
+const TENSE: Record<string, string> = {
+  P: 'Present', I: 'Imperfect', F: 'Future', A: 'Aorist', X: 'Perfect', Y: 'Pluperfect',
+};
+const VOICE: Record<string, string> = { A: 'Active', M: 'Middle', P: 'Passive' };
+const MOOD: Record<string, string> = {
+  I: 'Indicative', D: 'Imperative', S: 'Subjunctive', O: 'Optative', N: 'Infinitive', P: 'Participle',
+};
+const CASE: Record<string, string> = {
+  N: 'Nominative', G: 'Genitive', D: 'Dative', A: 'Accusative', V: 'Vocative',
+};
+const NUMBER: Record<string, string> = { S: 'Singular', P: 'Plural' };
+const GENDER: Record<string, string> = { M: 'Masculine', F: 'Feminine', N: 'Neuter' };
+const PERSON: Record<string, string> = { '1': '1st', '2': '2nd', '3': '3rd' };
+
+const POS_LABEL: Record<string, string> = {
+  'N-': 'Noun',
+  'A-': 'Adjective',
+  'RA': 'Article',
+  'RP': 'Personal Pronoun',
+  'RR': 'Relative Pronoun',
+  'RD': 'Demonstrative Pronoun',
+  'RI': 'Interrogative Pronoun',
+  'RX': 'Reflexive Pronoun',
+  'V-': 'Verb',
+  'P-': 'Preposition',
+  'D-': 'Adverb',
+  'CC': 'Conjunction',
+  'CS': 'Conjunction',
+  'I-': 'Interjection',
+  'X-': 'Particle',
+};
+
+const get = (map: Record<string, string>, key: string): string => map[key] ?? '';
+
+export function formatParse(pos: string, parsing: string): string {
+  if (!parsing || parsing.length < 8) return POS_LABEL[pos] ?? pos;
+
+  const [p1, p2, p3, p4, p5, p6, p7] = parsing;
+  const label = POS_LABEL[pos] ?? pos;
+
+  if (pos === 'V-') {
+    if (p4 === 'N') {
+      // Infinitive: tense + voice
+      return `Verb — ${get(TENSE, p2)} ${get(VOICE, p3)} Infinitive`.trim();
+    }
+    if (p4 === 'P') {
+      // Participle: tense + voice + case + number + gender
+      const parts = [
+        get(TENSE, p2), get(VOICE, p3), 'Participle',
+        get(CASE, p5), get(NUMBER, p6), get(GENDER, p7),
+      ].filter(Boolean);
+      return `Verb — ${parts.join(' ')}`;
+    }
+    // Finite verb: person + tense + voice + mood + number
+    const parts = [
+      get(PERSON, p1), get(TENSE, p2), get(VOICE, p3), get(MOOD, p4), get(NUMBER, p6),
+    ].filter(Boolean);
+    return `Verb — ${parts.join(' ')}`;
+  }
+
+  if (['N-', 'A-', 'RA', 'RP', 'RR', 'RD', 'RI', 'RX'].includes(pos)) {
+    const parts = [get(CASE, p5), get(NUMBER, p6), get(GENDER, p7)].filter(Boolean);
+    return parts.length ? `${label} — ${parts.join(' ')}` : label;
+  }
+
+  return label;
+}
+
+// ─── Display helpers ──────────────────────────────────────────────────────────
+
+/** Split a MorphGNT text field into the word and trailing punctuation. */
+export function splitWordPunct(text: string): [word: string, punct: string] {
+  const match = /^([\s\S]*?)([,.:;·—?!\u00B7]*)$/.exec(text);
+  if (!match) return [text, ''];
+  return [match[1], match[2]];
+}
+
+// ─── Client-side book cache + fetch ──────────────────────────────────────────
+
+const bookCache = new Map<string, MorphBook>();
+
+export async function fetchBook(code: string): Promise<MorphBook> {
+  if (bookCache.has(code)) return bookCache.get(code)!;
+  const res = await fetch(`/data/morphgnt/${code}.json`);
+  if (!res.ok) throw new Error(`Failed to load ${code}: HTTP ${res.status}`);
+  const data = await res.json() as MorphBook;
+  bookCache.set(code, data);
+  return data;
+}
+
+export async function fetchBooks(): Promise<BookMeta[]> {
+  const res = await fetch('/data/morphgnt/books.json');
+  if (!res.ok) throw new Error(`Failed to load books index: HTTP ${res.status}`);
+  return res.json() as Promise<BookMeta[]>;
+}
+
+// ─── localStorage key for reading history ────────────────────────────────────
+
+export const READER_HISTORY_KEY = 'greek-tools-reader-last';
+
+export function saveLastPassage(ref: string): void {
+  try { localStorage.setItem(READER_HISTORY_KEY, ref); } catch { /* ignore */ }
+}
+
+export function loadLastPassage(): string | null {
+  try { return localStorage.getItem(READER_HISTORY_KEY); } catch { return null; }
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,10 +9,11 @@ interface Props {
 const { title, description = "Free tools for Koine Greek students — keyboard, flashcards, and more." } = Astro.props;
 
 const navLinks = [
-  { href: '/keyboard',       label: 'Keyboard'        },
-  { href: '/flashcards',     label: 'Flashcards'      },
+  { href: '/keyboard',        label: 'Keyboard'        },
+  { href: '/flashcards',      label: 'Flashcards'      },
+  { href: '/reader',          label: 'Reader'          },
   { href: '/transliteration', label: 'Transliteration' },
-  { href: '/grammar',        label: 'Grammar'         },
+  { href: '/grammar',         label: 'Grammar'         },
 ];
 
 const currentPath = Astro.url.pathname;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,6 +19,14 @@ const tools = [
     bgColor: '#F5F3FF',
   },
   {
+    href: '/reader',
+    icon: '𐤁',
+    title: 'GNT Reader',
+    description: 'Read the Greek New Testament chapter by chapter. Click any word for its lexical form, gloss, and full morphological parse.',
+    accentColor: '#8B4513',   // saddle brown (matches --color-greek)
+    bgColor: '#FDF6EE',
+  },
+  {
     href: '/transliteration',
     icon: 'Tt',
     title: 'Transliteration',
@@ -107,3 +115,46 @@ const tools = [
   </div>
 
 </Layout>
+
+<script>
+  // Show "Continue reading" label on the Reader card if a prior passage is saved
+  const READER_HISTORY_KEY = 'greek-tools-reader-last';
+  try {
+    const last = localStorage.getItem(READER_HISTORY_KEY);
+    if (last) {
+      const parts = last.split('.');
+      const bookCode = parts[0];
+      const chapter = parts[1];
+
+      const card = document.querySelector('a[href="/reader"]') as HTMLAnchorElement | null;
+      if (!card) return;
+
+      // Point the card to the last passage
+      card.href = `/reader?ref=${last}`;
+
+      // Resolve book name from books.json if available; fall back to code
+      let label = `${bookCode} ${chapter}`;
+
+      const inject = () => {
+        const p = document.createElement('p');
+        p.className = 'text-xs mt-2 font-medium';
+        p.style.color = '#8B4513';
+        p.textContent = `Continue reading: ${label}`;
+        card.querySelector('.p-6')?.appendChild(p);
+      };
+
+      fetch('/data/morphgnt/books.json')
+        .then(r => r.ok ? r.json() : null)
+        .then((books: Array<{ code: string; name: string }> | null) => {
+          if (books) {
+            const match = books.find(b => b.code === bookCode);
+            if (match) label = `${match.name} ${chapter}`;
+          }
+          inject();
+        })
+        .catch(inject);
+    }
+  } catch {
+    // localStorage unavailable — no-op
+  }
+</script>

--- a/src/pages/reader.astro
+++ b/src/pages/reader.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../layouts/Layout.astro';
+import GNTReader from '../components/GNTReader';
+---
+
+<Layout
+  title="GNT Reader"
+  description="Read the Greek New Testament with on-demand vocabulary and parsing help."
+>
+  <GNTReader client:load />
+</Layout>


### PR DESCRIPTION
## Overview

Implements a full-featured Greek New Testament reader with interactive word glosses and morphological parsing.

## Changes

### New Features
- **GNT Reader component** (`src/components/GNTReader.tsx`): Interactive chapter reader with:
  - Book/chapter selection with URL routing (e.g., `/reader?ref=John.3`)
  - Click any word to view lemma, gloss, and parse
  - Toggle glosses below all words simultaneously
  - Visual marking of studied vocabulary (dotted underline)
  - Responsive touch-friendly UI

- **MorphGNT data pipeline** (`scripts/build-morphgnt.mjs`):
  - Fetches all 27 NT books from MorphGNT source at build time
  - Parses TSV format into per-book JSON (e.g., `JHN.json`)
  - Outputs to `public/data/morphgnt/` with book index
  - Supports incremental builds (skip cached files) and force re-fetch

- **SRS integration**:
  - Normalized key storage (lemmas like `'ὁ'` instead of `'ὁ, ἡ, τό'`)
  - One-time v1→v2 migration in localStorage
  - `getStudiedLemmas()` helper for Reader to mark known words

- **Homepage updates**:
  - Reader card with "Continue reading" label if prior passage exists
  - Links to reading history in localStorage

### Build
- Updated `package.json` scripts: `build` now runs data pipeline first
- Added `build:data` and `build:data:force` commands
- Updated `.gitignore` to exclude generated data files

### Data
- Vocabulary lookup via existing `vocabulary.ts` for glosses
- Falls back to lemma-only display for lower-frequency words
- Touch-friendly tap detection (no 300ms delay on mobile)