### PR TITLE
Allow build scripts for esbuild, sharp, and workerd

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   },
   "devDependencies": {
     "wrangler": "^4.68.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild", "sharp", "workerd"]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `pnpm.onlyBuiltDependencies` to `package.json` for `esbuild`, `sharp`, and `workerd`
- pnpm 10 blocks postinstall scripts by default — without this, native binaries for these packages won't be built and the deployment will fail

## Test plan

- [ ] Verify Cloudflare Pages deployment succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)