### PR TITLE
Add Daily Verse Reader

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "greek-tools",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeArgs": ["run", "dev", "--", "--port", "4330"],
       "port": 4330,
       "autoPort": true
     }

--- a/docs/prd/daily-verse-reader.md
+++ b/docs/prd/daily-verse-reader.md
@@ -14,6 +14,12 @@ A daily reading feature that surfaces one GNT verse per day in Greek, tracks a r
 
 ---
 
+## Status
+
+**Complete.** All four features implemented: `/daily` route with `DailyVerse` component, 62-verse curated list in `src/data/dailyVerses.ts`, localStorage streak tracking, vocabulary crossover from Flashcards SRS data, and homepage card + nav link. Word-popup help reuses shared `GreekText.tsx` components. Open questions resolved: verse sequence is hard-coded in the codebase; started with a curated 62-verse list (expandable).
+
+---
+
 ## Priority
 
 Low

--- a/docs/prd/flashcard-enhancements.md
+++ b/docs/prd/flashcard-enhancements.md
@@ -6,6 +6,18 @@ Extend the existing flashcard tool with smarter study modes, filtering, and prog
 
 ---
 
+## Status
+
+**Partially complete.** Four of six features shipped:
+- ✅ Feature 1 — Spaced Repetition (SRS)
+- ✅ Feature 2 — Frequency & Part-of-Speech Filters
+- ❌ Feature 3 — Textbook Chapter Sets (not started)
+- ✅ Feature 4 — Answer Modes (flip + type)
+- ✅ Feature 5 — Progress Tracking & Streaks
+- ❌ Feature 6 — Custom Deck Builder (not started)
+
+---
+
 ## Goals
 
 - Make vocabulary review more effective than random cycling

--- a/docs/prd/gnt-reader.md
+++ b/docs/prd/gnt-reader.md
@@ -6,6 +6,12 @@ A passage reader for the Greek New Testament with inline vocabulary help and mor
 
 ---
 
+## Status
+
+**Complete.** GNTReader component, `/reader` route, MorphGNT data layer, and build script are all implemented. Reading history (localStorage) and homepage "Continue reading" integration are live.
+
+---
+
 ## Priority
 
 High — foundational feature; Daily Verse Reader and Verse Memorization both depend on it.

--- a/docs/prd/grammar-reference.md
+++ b/docs/prd/grammar-reference.md
@@ -6,6 +6,12 @@ A set of clean, scannable reference tables covering the core grammatical paradig
 
 ---
 
+## Status
+
+**Complete.** All five sections implemented in `GrammarReference.tsx` and live at `/grammar`: noun/adjective declension tables, verb conjugation tables, pronoun reference, preposition quick reference, and accent rules summary. Includes sticky sidebar nav, hover tooltips, and endings-only toggle.
+
+---
+
 ## Goals
 
 - Give students a fast, browser-accessible alternative to flipping through a textbook

--- a/docs/prd/parsing-drills.md
+++ b/docs/prd/parsing-drills.md
@@ -6,6 +6,12 @@ Interactive parsing practice and principal parts drills to help students build t
 
 ---
 
+## Status
+
+**Not started.**
+
+---
+
 ## Goals
 
 - Give students a place to practice parsing without needing a workbook

--- a/docs/prd/utilities.md
+++ b/docs/prd/utilities.md
@@ -6,6 +6,14 @@ Small, self-contained tools that round out the site. These are lower priority th
 
 ---
 
+## Status
+
+**Transliteration Tool — Complete.** Implemented in `src/lib/transliteration.ts` and `src/components/Transliteration.tsx`, live at `/transliteration`. Handles SBL scheme bidirectionally including breathing marks, accents, and iota subscripts.
+
+**Sentence Diagramming Tool — Not started.**
+
+---
+
 ## Features
 
 ### 1. Transliteration Tool

--- a/docs/prd/verse-memorization.md
+++ b/docs/prd/verse-memorization.md
@@ -14,6 +14,12 @@ An interactive tool for memorizing GNT verses in Greek. Uses progressive word bl
 
 ---
 
+## Status
+
+**Not started.**
+
+---
+
 ## Priority
 
 Low

--- a/src/components/DailyVerse.tsx
+++ b/src/components/DailyVerse.tsx
@@ -1,0 +1,151 @@
+import { useState, useEffect, useCallback } from 'react';
+import { type MorphWord, type MorphVerse, fetchBook } from '../data/morphgnt';
+import {
+  getTodayVerse,
+  markReadToday,
+  loadStreakData,
+  type DailyStreakData,
+} from '../data/dailyVerses';
+import { getStudiedLemmas } from '../data/srs';
+import { type ActiveWord, WordPopup, WordToken } from './GreekText';
+
+export default function DailyVerse() {
+  const verseRef = getTodayVerse();
+
+  const [verse, setVerse] = useState<MorphVerse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeWord, setActiveWord] = useState<ActiveWord | null>(null);
+  const [showGlosses, setShowGlosses] = useState(false);
+  const [streakData, setStreakData] = useState<DailyStreakData>({ streak: 0, lastReadDate: '' });
+  const [studiedLemmas] = useState<Set<string>>(() => {
+    try { return getStudiedLemmas(); } catch { return new Set(); }
+  });
+
+  // Fetch verse + mark as read on mount
+  useEffect(() => {
+    fetchBook(verseRef.book)
+      .then(data => {
+        const words = data[String(verseRef.chapter)]?.[String(verseRef.verse)] ?? [];
+        setVerse(words);
+        setLoading(false);
+      })
+      .catch(err => {
+        setError((err as Error).message);
+        setLoading(false);
+      });
+
+    // Marking as read is the only requirement for streak — just opening the page counts
+    const updated = markReadToday();
+    setStreakData(updated);
+  }, []);
+
+  // On mount, also load existing streak to show immediately before markReadToday resolves
+  useEffect(() => {
+    try { setStreakData(loadStreakData()); } catch { /* ignore */ }
+  }, []);
+
+  const handleActivate = useCallback((word: MorphWord, rect: DOMRect) => {
+    setActiveWord(prev => prev?.word === word ? null : { word, rect });
+  }, []);
+
+  const handleClosePopup = useCallback(() => setActiveWord(null), []);
+
+  return (
+    <div onClick={handleClosePopup}>
+
+      {/* ── Streak counter ─────────────────────────────────────────────────── */}
+      {streakData.streak > 0 && (
+        <div
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-full mb-6 text-sm font-semibold"
+          style={{ background: '#FEF3C7', color: '#92400E' }}
+        >
+          <span aria-hidden="true">🔥</span>
+          {streakData.streak === 1
+            ? '1-day streak — keep it going!'
+            : `${streakData.streak}-day streak`}
+        </div>
+      )}
+
+      {/* ── Verse card ─────────────────────────────────────────────────────── */}
+      <div className="bg-bg-card rounded-2xl shadow-sm border border-white p-8 mb-4">
+
+        {loading && (
+          <p className="text-text-muted text-center py-10">Loading…</p>
+        )}
+
+        {error && (
+          <div className="text-center py-10 space-y-2">
+            <p className="text-red-600 text-sm">Could not load verse: {error}</p>
+            <p className="text-text-muted text-xs">
+              Run <code className="bg-gray-100 px-1 rounded">pnpm run build:data</code> to generate the MorphGNT data files.
+            </p>
+          </div>
+        )}
+
+        {!loading && !error && verse && (
+          <>
+            {/* Greek text */}
+            <div
+              className="flex flex-wrap mb-6"
+              style={{ gap: '0 0', lineHeight: '2' }}
+              onClick={e => e.stopPropagation()}
+            >
+              {verse.map((word, i) => (
+                <WordToken
+                  key={i}
+                  word={word}
+                  showGloss={showGlosses}
+                  studied={studiedLemmas.has(word.lemma)}
+                  onActivate={handleActivate}
+                />
+              ))}
+            </div>
+
+            {/* Reference + controls */}
+            <div className="flex items-center justify-between flex-wrap gap-3 pt-4 border-t border-gray-100">
+              <p
+                className="text-sm font-semibold italic"
+                style={{ color: 'var(--color-text-muted)', fontFamily: 'var(--font-greek)' }}
+              >
+                — {verseRef.displayRef}
+              </p>
+
+              <div className="flex gap-2" onClick={e => e.stopPropagation()}>
+                <button
+                  onClick={() => setShowGlosses(g => !g)}
+                  className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+                    showGlosses
+                      ? 'border-primary bg-primary text-white'
+                      : 'border-gray-200 text-text-muted hover:border-gray-300 hover:text-text'
+                  }`}
+                >
+                  {showGlosses ? 'Hide glosses' : 'Show glosses'}
+                </button>
+                <a
+                  href={`/reader?ref=${verseRef.book}.${verseRef.chapter}.${verseRef.verse}`}
+                  className="px-3 py-1.5 rounded-lg text-sm border border-gray-200 text-text-muted hover:border-gray-300 hover:text-text transition-colors"
+                >
+                  Open chapter →
+                </a>
+              </div>
+            </div>
+
+            {/* Known-word legend */}
+            {studiedLemmas.size > 0 && (
+              <p className="text-text-muted text-xs mt-4 select-none">
+                <span className="underline decoration-accent/60 decoration-dotted underline-offset-2">
+                  dotted underline
+                </span>
+                {' '}= word you've studied in Flashcards
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* ── Word popup ─────────────────────────────────────────────────────── */}
+      {activeWord && <WordPopup active={activeWord} onClose={handleClosePopup} />}
+    </div>
+  );
+}

--- a/src/components/GNTReader.tsx
+++ b/src/components/GNTReader.tsx
@@ -1,28 +1,11 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { createPortal } from 'react-dom';
 import {
   type MorphWord, type MorphBook, type BookMeta,
-  fetchBook, fetchBooks, formatParse, splitWordPunct,
+  fetchBook, fetchBooks,
   saveLastPassage,
 } from '../data/morphgnt';
-import { vocabulary } from '../data/vocabulary';
 import { getStudiedLemmas } from '../data/srs';
-
-// ─── Vocabulary lookup ────────────────────────────────────────────────────────
-
-interface VocabEntry { gloss: string; frequency: number }
-
-function buildVocabLookup(): Map<string, VocabEntry> {
-  const map = new Map<string, VocabEntry>();
-  for (const w of vocabulary) {
-    for (const form of w.greek.split(', ')) {
-      map.set(form.trim(), { gloss: w.gloss, frequency: w.frequency });
-    }
-  }
-  return map;
-}
-
-const vocabLookup = buildVocabLookup();
+import { vocabLookup, type ActiveWord, WordPopup, WordToken } from './GreekText';
 
 // ─── URL helpers ──────────────────────────────────────────────────────────────
 
@@ -43,144 +26,6 @@ function setUrlRef(book: string, chapter: number): void {
   const url = new URL(window.location.href);
   url.searchParams.set('ref', `${book}.${chapter}`);
   history.replaceState(null, '', url.toString());
-}
-
-// ─── WordPopup ────────────────────────────────────────────────────────────────
-
-interface ActiveWord { word: MorphWord; rect: DOMRect }
-
-function WordPopup({ active, onClose }: { active: ActiveWord; onClose: () => void }) {
-  const { word, rect } = active;
-  const vocab = vocabLookup.get(word.lemma);
-  const parse = formatParse(word.pos, word.parsing);
-
-  // Position: below the word, kept within viewport
-  const top = rect.bottom + window.scrollY + 6;
-  const left = Math.max(8, Math.min(rect.left + window.scrollX, window.innerWidth - 288 - 8));
-
-  // Dismiss on Escape
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [onClose]);
-
-  // Dismiss on scroll (popup would visually drift from word)
-  useEffect(() => {
-    const handler = () => onClose();
-    window.addEventListener('scroll', handler, { passive: true, once: true });
-    return () => window.removeEventListener('scroll', handler);
-  }, [onClose]);
-
-  const popup = (
-    <div
-      role="dialog"
-      aria-label={`Word info: ${word.lemma}`}
-      style={{ position: 'absolute', top, left, zIndex: 50, width: 272 }}
-      className="bg-bg-card border border-gray-200 rounded-xl shadow-xl p-4 text-sm"
-      // Stop clicks inside from bubbling to the overlay
-      onClick={e => e.stopPropagation()}
-    >
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <span
-          className="font-serif text-2xl leading-tight"
-          style={{ color: 'var(--color-greek)' }}
-        >
-          {word.lemma}
-        </span>
-        <button
-          onClick={onClose}
-          className="text-text-muted hover:text-text transition-colors mt-1 text-xs"
-          aria-label="Close"
-        >
-          ✕
-        </button>
-      </div>
-
-      {vocab ? (
-        <p className="text-text mb-1">{vocab.gloss}</p>
-      ) : (
-        <p className="text-text-muted italic mb-1">gloss not available</p>
-      )}
-
-      <p className="text-text-muted text-xs">{parse}</p>
-
-      {vocab && (
-        <p className="text-text-muted text-xs mt-1">
-          {vocab.frequency.toLocaleString()}× in GNT
-        </p>
-      )}
-
-      <a
-        href="/flashcards"
-        className="mt-3 block text-center text-xs px-3 py-1.5 rounded-lg border border-primary/30 text-primary hover:bg-primary/5 transition-colors"
-      >
-        Study in Flashcards →
-      </a>
-    </div>
-  );
-
-  return createPortal(popup, document.body);
-}
-
-// ─── WordToken ────────────────────────────────────────────────────────────────
-
-function WordToken({
-  word,
-  showGloss,
-  studied,
-  onActivate,
-}: {
-  word: MorphWord;
-  showGloss: boolean;
-  studied: boolean;
-  onActivate: (word: MorphWord, rect: DOMRect) => void;
-}) {
-  const [wordText, punct] = splitWordPunct(word.text);
-  const spanRef = useRef<HTMLSpanElement>(null);
-
-  const handleClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (spanRef.current) onActivate(word, spanRef.current.getBoundingClientRect());
-  }, [word, onActivate]);
-
-  return (
-    // inline-flex column so gloss stacks below the word without breaking flow
-    <span
-      className="inline-flex flex-col items-center"
-      style={{ verticalAlign: 'top', marginRight: '0.25em' }}
-    >
-      <span className="flex items-baseline">
-        <span
-          ref={spanRef}
-          onClick={handleClick}
-          className={`font-serif cursor-pointer rounded px-0.5 hover:bg-accent/10 transition-colors ${
-            studied ? 'underline decoration-accent/60 decoration-dotted underline-offset-2' : ''
-          }`}
-          style={{
-            fontSize: '1.35rem',
-            lineHeight: '1.6',
-            color: 'var(--color-greek)',
-            // Remove 300ms tap delay on touch devices; browser handles scroll vs tap discrimination
-            touchAction: 'manipulation',
-          }}
-        >
-          {wordText}
-        </span>
-        {punct && (
-          <span className="text-text" style={{ fontSize: '1.1rem', lineHeight: '1.6' }}>
-            {punct}
-          </span>
-        )}
-      </span>
-
-      {showGloss && (
-        <span className="text-text-muted" style={{ fontSize: '0.62rem', lineHeight: 1.2, maxWidth: '5rem', textAlign: 'center' }}>
-          {vocabLookup.get(word.lemma)?.gloss?.split(',')[0] ?? word.lemma}
-        </span>
-      )}
-    </span>
-  );
 }
 
 // ─── VerseDisplay ─────────────────────────────────────────────────────────────

--- a/src/components/GreekText.tsx
+++ b/src/components/GreekText.tsx
@@ -1,0 +1,163 @@
+/**
+ * Shared Greek text rendering components.
+ * Used by GNTReader and DailyVerse so word-popup behavior stays in sync.
+ */
+import { useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { type MorphWord, formatParse, splitWordPunct } from '../data/morphgnt';
+import { vocabulary } from '../data/vocabulary';
+
+// ─── Vocabulary lookup ────────────────────────────────────────────────────────
+
+export interface VocabEntry { gloss: string; frequency: number }
+
+export function buildVocabLookup(): Map<string, VocabEntry> {
+  const map = new Map<string, VocabEntry>();
+  for (const w of vocabulary) {
+    for (const form of w.greek.split(', ')) {
+      map.set(form.trim(), { gloss: w.gloss, frequency: w.frequency });
+    }
+  }
+  return map;
+}
+
+export const vocabLookup = buildVocabLookup();
+
+// ─── WordPopup ────────────────────────────────────────────────────────────────
+
+export interface ActiveWord { word: MorphWord; rect: DOMRect }
+
+export function WordPopup({ active, onClose }: { active: ActiveWord; onClose: () => void }) {
+  const { word, rect } = active;
+  const vocab = vocabLookup.get(word.lemma);
+  const parse = formatParse(word.pos, word.parsing);
+
+  // Position: below the word, kept within viewport
+  const top = rect.bottom + window.scrollY + 6;
+  const left = Math.max(8, Math.min(rect.left + window.scrollX, window.innerWidth - 288 - 8));
+
+  // Dismiss on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // Dismiss on scroll (popup would visually drift from word)
+  useEffect(() => {
+    const handler = () => onClose();
+    window.addEventListener('scroll', handler, { passive: true, once: true });
+    return () => window.removeEventListener('scroll', handler);
+  }, [onClose]);
+
+  const popup = (
+    <div
+      role="dialog"
+      aria-label={`Word info: ${word.lemma}`}
+      style={{ position: 'absolute', top, left, zIndex: 50, width: 272 }}
+      className="bg-bg-card border border-gray-200 rounded-xl shadow-xl p-4 text-sm"
+      onClick={e => e.stopPropagation()}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <span
+          className="font-serif text-2xl leading-tight"
+          style={{ color: 'var(--color-greek)' }}
+        >
+          {word.lemma}
+        </span>
+        <button
+          onClick={onClose}
+          className="text-text-muted hover:text-text transition-colors mt-1 text-xs"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      {vocab ? (
+        <p className="text-text mb-1">{vocab.gloss}</p>
+      ) : (
+        <p className="text-text-muted italic mb-1">gloss not available</p>
+      )}
+
+      <p className="text-text-muted text-xs">{parse}</p>
+
+      {vocab && (
+        <p className="text-text-muted text-xs mt-1">
+          {vocab.frequency.toLocaleString()}× in GNT
+        </p>
+      )}
+
+      <a
+        href="/flashcards"
+        className="mt-3 block text-center text-xs px-3 py-1.5 rounded-lg border border-primary/30 text-primary hover:bg-primary/5 transition-colors"
+      >
+        Study in Flashcards →
+      </a>
+    </div>
+  );
+
+  return createPortal(popup, document.body);
+}
+
+// ─── WordToken ────────────────────────────────────────────────────────────────
+
+export function WordToken({
+  word,
+  showGloss,
+  studied,
+  onActivate,
+}: {
+  word: MorphWord;
+  showGloss: boolean;
+  studied: boolean;
+  onActivate: (word: MorphWord, rect: DOMRect) => void;
+}) {
+  const [wordText, punct] = splitWordPunct(word.text);
+  const spanRef = useRef<HTMLSpanElement>(null);
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (spanRef.current) onActivate(word, spanRef.current.getBoundingClientRect());
+  }, [word, onActivate]);
+
+  return (
+    // inline-flex column so gloss stacks below the word without breaking flow
+    <span
+      className="inline-flex flex-col items-center"
+      style={{ verticalAlign: 'top', marginRight: '0.25em' }}
+    >
+      <span className="flex items-baseline">
+        <span
+          ref={spanRef}
+          onClick={handleClick}
+          className={`font-serif cursor-pointer rounded px-0.5 hover:bg-accent/10 transition-colors ${
+            studied ? 'underline decoration-accent/60 decoration-dotted underline-offset-2' : ''
+          }`}
+          style={{
+            fontSize: '1.35rem',
+            lineHeight: '1.6',
+            color: 'var(--color-greek)',
+            touchAction: 'manipulation',
+          }}
+        >
+          {wordText}
+        </span>
+        {punct && (
+          <span className="text-text" style={{ fontSize: '1.1rem', lineHeight: '1.6' }}>
+            {punct}
+          </span>
+        )}
+      </span>
+
+      {showGloss && (
+        <span
+          className="text-text-muted"
+          style={{ fontSize: '0.62rem', lineHeight: 1.2, maxWidth: '5rem', textAlign: 'center' }}
+        >
+          {vocabLookup.get(word.lemma)?.gloss?.split(',')[0] ?? word.lemma}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/data/dailyVerses.test.ts
+++ b/src/data/dailyVerses.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DAILY_VERSES,
+  getTodayIndex,
+  getTodayVerse,
+  loadStreakData,
+  markReadToday,
+  type DailyStreakData,
+} from './dailyVerses';
+
+// ─── localStorage mock ────────────────────────────────────────────────────────
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function dateStr(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d;
+}
+
+function setStoredStreak(streak: number, lastReadDate: string) {
+  const data: DailyStreakData = { streak, lastReadDate };
+  localStorageMock.setItem('greek-tools-daily-v1', JSON.stringify(data));
+}
+
+// ─── DAILY_VERSES ─────────────────────────────────────────────────────────────
+
+describe('DAILY_VERSES', () => {
+  it('has at least 30 entries', () => {
+    expect(DAILY_VERSES.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('every entry has all required fields', () => {
+    for (const v of DAILY_VERSES) {
+      expect(typeof v.book).toBe('string');
+      expect(v.book.length).toBeGreaterThan(0);
+      expect(v.chapter).toBeGreaterThan(0);
+      expect(v.verse).toBeGreaterThan(0);
+      expect(typeof v.displayRef).toBe('string');
+      expect(v.displayRef.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('contains well-known passages', () => {
+    const refs = DAILY_VERSES.map(v => v.displayRef);
+    expect(refs).toContain('John 3:16');
+    expect(refs).toContain('Romans 3:23');
+    expect(refs).toContain('Philippians 4:13');
+  });
+});
+
+// ─── getTodayIndex ────────────────────────────────────────────────────────────
+
+describe('getTodayIndex', () => {
+  it('returns a value within DAILY_VERSES bounds', () => {
+    const idx = getTodayIndex();
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(DAILY_VERSES.length);
+  });
+
+  it('is deterministic for the same date', () => {
+    const d = new Date(2025, 0, 1); // Jan 1 2025
+    expect(getTodayIndex(d)).toBe(getTodayIndex(d));
+  });
+
+  it('differs between consecutive days', () => {
+    const d1 = new Date(2025, 0, 1);
+    const d2 = new Date(2025, 0, 2);
+    // Not guaranteed to differ (could wrap) but across the list length this
+    // effectively always holds for adjacent days
+    const i1 = getTodayIndex(d1);
+    const i2 = getTodayIndex(d2);
+    expect(Math.abs(i1 - i2)).toBe(1);
+  });
+
+  it('wraps around the verse list length', () => {
+    // Use a date whose epoch-day is exactly a multiple of DAILY_VERSES.length
+    const epoch = new Date(0); // midnight UTC Jan 1 1970 (epochDays = 0)
+    // epochDays = 0 → index = 0 (or wraps to 0)
+    const idx = getTodayIndex(epoch);
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(DAILY_VERSES.length);
+  });
+});
+
+// ─── getTodayVerse ────────────────────────────────────────────────────────────
+
+describe('getTodayVerse', () => {
+  it('returns a valid verse ref', () => {
+    const v = getTodayVerse();
+    expect(v).toBeDefined();
+    expect(v.book).toBeTruthy();
+    expect(v.displayRef).toBeTruthy();
+  });
+
+  it('returns the verse at getTodayIndex', () => {
+    const now = new Date();
+    expect(getTodayVerse(now)).toBe(DAILY_VERSES[getTodayIndex(now)]);
+  });
+});
+
+// ─── loadStreakData ───────────────────────────────────────────────────────────
+
+describe('loadStreakData', () => {
+  beforeEach(() => localStorageMock.clear());
+
+  it('returns zero streak when storage is empty', () => {
+    const data = loadStreakData();
+    expect(data.streak).toBe(0);
+    expect(data.lastReadDate).toBe('');
+  });
+
+  it('returns stored streak data', () => {
+    setStoredStreak(5, '2025-06-01');
+    const data = loadStreakData();
+    expect(data.streak).toBe(5);
+    expect(data.lastReadDate).toBe('2025-06-01');
+  });
+
+  it('returns zero streak on malformed JSON', () => {
+    localStorageMock.setItem('greek-tools-daily-v1', 'not-json');
+    const data = loadStreakData();
+    expect(data.streak).toBe(0);
+  });
+});
+
+// ─── markReadToday ────────────────────────────────────────────────────────────
+
+describe('markReadToday', () => {
+  beforeEach(() => localStorageMock.clear());
+
+  const today = new Date();
+  const todayStr = dateStr(today);
+
+  it('starts a streak of 1 on first ever read', () => {
+    const data = markReadToday(today);
+    expect(data.streak).toBe(1);
+    expect(data.lastReadDate).toBe(todayStr);
+  });
+
+  it('is idempotent when called multiple times on the same day', () => {
+    markReadToday(today);
+    markReadToday(today);
+    const data = markReadToday(today);
+    expect(data.streak).toBe(1);
+    expect(data.lastReadDate).toBe(todayStr);
+  });
+
+  it('increments streak when read on consecutive days', () => {
+    setStoredStreak(3, dateStr(daysAgo(1)));
+    const data = markReadToday(today);
+    expect(data.streak).toBe(4);
+    expect(data.lastReadDate).toBe(todayStr);
+  });
+
+  it('resets streak to 1 when a day is missed', () => {
+    setStoredStreak(7, dateStr(daysAgo(2)));
+    const data = markReadToday(today);
+    expect(data.streak).toBe(1);
+  });
+
+  it('persists updated streak to localStorage', () => {
+    markReadToday(today);
+    const stored = JSON.parse(localStorageMock.getItem('greek-tools-daily-v1')!) as DailyStreakData;
+    expect(stored.streak).toBe(1);
+    expect(stored.lastReadDate).toBe(todayStr);
+  });
+});

--- a/src/data/dailyVerses.ts
+++ b/src/data/dailyVerses.ts
@@ -1,0 +1,164 @@
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DailyVerseRef {
+  book: string;       // MorphGNT book code (e.g. 'JHN')
+  chapter: number;
+  verse: number;
+  displayRef: string; // Human-readable reference (e.g. 'John 3:16')
+}
+
+// ─── Curated verse list ───────────────────────────────────────────────────────
+// Pedagogically valuable passages spread across the NT.
+// Cycles deterministically — one per day for all users.
+
+export const DAILY_VERSES: readonly DailyVerseRef[] = [
+  // John
+  { book: 'JHN', chapter: 1,  verse: 1,  displayRef: 'John 1:1'   },
+  { book: 'JHN', chapter: 1,  verse: 14, displayRef: 'John 1:14'  },
+  { book: 'JHN', chapter: 1,  verse: 29, displayRef: 'John 1:29'  },
+  { book: 'JHN', chapter: 3,  verse: 16, displayRef: 'John 3:16'  },
+  { book: 'JHN', chapter: 4,  verse: 24, displayRef: 'John 4:24'  },
+  { book: 'JHN', chapter: 8,  verse: 12, displayRef: 'John 8:12'  },
+  { book: 'JHN', chapter: 10, verse: 10, displayRef: 'John 10:10' },
+  { book: 'JHN', chapter: 11, verse: 25, displayRef: 'John 11:25' },
+  { book: 'JHN', chapter: 11, verse: 35, displayRef: 'John 11:35' },
+  { book: 'JHN', chapter: 14, verse: 6,  displayRef: 'John 14:6'  },
+  { book: 'JHN', chapter: 15, verse: 5,  displayRef: 'John 15:5'  },
+  { book: 'JHN', chapter: 20, verse: 31, displayRef: 'John 20:31' },
+  // Matthew
+  { book: 'MAT', chapter: 5,  verse: 3,  displayRef: 'Matthew 5:3'   },
+  { book: 'MAT', chapter: 6,  verse: 9,  displayRef: 'Matthew 6:9'   },
+  { book: 'MAT', chapter: 11, verse: 28, displayRef: 'Matthew 11:28' },
+  { book: 'MAT', chapter: 22, verse: 37, displayRef: 'Matthew 22:37' },
+  { book: 'MAT', chapter: 28, verse: 19, displayRef: 'Matthew 28:19' },
+  // Mark
+  { book: 'MRK', chapter: 1,  verse: 1,  displayRef: 'Mark 1:1'   },
+  { book: 'MRK', chapter: 10, verse: 45, displayRef: 'Mark 10:45' },
+  // Luke
+  { book: 'LUK', chapter: 1,  verse: 37, displayRef: 'Luke 1:37'  },
+  { book: 'LUK', chapter: 2,  verse: 11, displayRef: 'Luke 2:11'  },
+  { book: 'LUK', chapter: 19, verse: 10, displayRef: 'Luke 19:10' },
+  // Acts
+  { book: 'ACT', chapter: 1,  verse: 8,  displayRef: 'Acts 1:8'  },
+  { book: 'ACT', chapter: 4,  verse: 12, displayRef: 'Acts 4:12' },
+  // Romans
+  { book: 'ROM', chapter: 1,  verse: 16, displayRef: 'Romans 1:16' },
+  { book: 'ROM', chapter: 1,  verse: 17, displayRef: 'Romans 1:17' },
+  { book: 'ROM', chapter: 3,  verse: 23, displayRef: 'Romans 3:23' },
+  { book: 'ROM', chapter: 5,  verse: 8,  displayRef: 'Romans 5:8'  },
+  { book: 'ROM', chapter: 6,  verse: 23, displayRef: 'Romans 6:23' },
+  { book: 'ROM', chapter: 8,  verse: 1,  displayRef: 'Romans 8:1'  },
+  { book: 'ROM', chapter: 8,  verse: 28, displayRef: 'Romans 8:28' },
+  { book: 'ROM', chapter: 8,  verse: 38, displayRef: 'Romans 8:38' },
+  { book: 'ROM', chapter: 12, verse: 1,  displayRef: 'Romans 12:1' },
+  { book: 'ROM', chapter: 12, verse: 2,  displayRef: 'Romans 12:2' },
+  // 1 Corinthians
+  { book: '1CO', chapter: 13, verse: 13, displayRef: '1 Corinthians 13:13' },
+  { book: '1CO', chapter: 15, verse: 3,  displayRef: '1 Corinthians 15:3'  },
+  { book: '1CO', chapter: 15, verse: 55, displayRef: '1 Corinthians 15:55' },
+  // 2 Corinthians
+  { book: '2CO', chapter: 5,  verse: 17, displayRef: '2 Corinthians 5:17' },
+  { book: '2CO', chapter: 5,  verse: 21, displayRef: '2 Corinthians 5:21' },
+  // Galatians
+  { book: 'GAL', chapter: 2,  verse: 20, displayRef: 'Galatians 2:20' },
+  { book: 'GAL', chapter: 5,  verse: 22, displayRef: 'Galatians 5:22' },
+  // Ephesians
+  { book: 'EPH', chapter: 2,  verse: 8,  displayRef: 'Ephesians 2:8'  },
+  { book: 'EPH', chapter: 2,  verse: 10, displayRef: 'Ephesians 2:10' },
+  // Philippians
+  { book: 'PHP', chapter: 4,  verse: 4,  displayRef: 'Philippians 4:4'  },
+  { book: 'PHP', chapter: 4,  verse: 7,  displayRef: 'Philippians 4:7'  },
+  { book: 'PHP', chapter: 4,  verse: 13, displayRef: 'Philippians 4:13' },
+  // Colossians
+  { book: 'COL', chapter: 1,  verse: 15, displayRef: 'Colossians 1:15' },
+  { book: 'COL', chapter: 3,  verse: 16, displayRef: 'Colossians 3:16' },
+  // 1 Thessalonians
+  { book: '1TH', chapter: 5,  verse: 16, displayRef: '1 Thessalonians 5:16' },
+  { book: '1TH', chapter: 5,  verse: 17, displayRef: '1 Thessalonians 5:17' },
+  { book: '1TH', chapter: 5,  verse: 18, displayRef: '1 Thessalonians 5:18' },
+  // 2 Timothy
+  { book: '2TI', chapter: 3,  verse: 16, displayRef: '2 Timothy 3:16' },
+  // Hebrews
+  { book: 'HEB', chapter: 4,  verse: 12, displayRef: 'Hebrews 4:12' },
+  { book: 'HEB', chapter: 11, verse: 1,  displayRef: 'Hebrews 11:1'  },
+  { book: 'HEB', chapter: 13, verse: 8,  displayRef: 'Hebrews 13:8'  },
+  // James
+  { book: 'JAS', chapter: 1,  verse: 22, displayRef: 'James 1:22' },
+  // 1 Peter
+  { book: '1PE', chapter: 5,  verse: 7,  displayRef: '1 Peter 5:7' },
+  // 1 John
+  { book: '1JN', chapter: 1,  verse: 9,  displayRef: '1 John 1:9'  },
+  { book: '1JN', chapter: 4,  verse: 8,  displayRef: '1 John 4:8'  },
+  { book: '1JN', chapter: 4,  verse: 19, displayRef: '1 John 4:19' },
+  // Revelation
+  { book: 'REV', chapter: 1,  verse: 8,  displayRef: 'Revelation 1:8'  },
+  { book: 'REV', chapter: 21, verse: 4,  displayRef: 'Revelation 21:4' },
+  { book: 'REV', chapter: 22, verse: 20, displayRef: 'Revelation 22:20' },
+] as const;
+
+// ─── Day selection ────────────────────────────────────────────────────────────
+
+/**
+ * Returns the index into DAILY_VERSES for a given date.
+ * Uses local midnight so the verse changes at local midnight for every user.
+ */
+export function getTodayIndex(now = new Date()): number {
+  const localMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const epochDays = Math.floor(localMidnight.getTime() / (1000 * 60 * 60 * 24));
+  return ((epochDays % DAILY_VERSES.length) + DAILY_VERSES.length) % DAILY_VERSES.length;
+}
+
+/** Returns today's verse ref. Same result for every call on the same calendar day. */
+export function getTodayVerse(now?: Date): DailyVerseRef {
+  return DAILY_VERSES[getTodayIndex(now)];
+}
+
+// ─── Streak persistence ───────────────────────────────────────────────────────
+
+const STREAK_KEY = 'greek-tools-daily-v1';
+
+export interface DailyStreakData {
+  streak: number;
+  lastReadDate: string; // YYYY-MM-DD local date
+}
+
+function localDateStr(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export function loadStreakData(): DailyStreakData {
+  try {
+    const raw = localStorage.getItem(STREAK_KEY);
+    if (!raw) return { streak: 0, lastReadDate: '' };
+    return JSON.parse(raw) as DailyStreakData;
+  } catch {
+    return { streak: 0, lastReadDate: '' };
+  }
+}
+
+/**
+ * Mark today as read and return updated streak data.
+ * Calling this multiple times on the same calendar day is idempotent.
+ */
+export function markReadToday(now = new Date()): DailyStreakData {
+  const today = localDateStr(now);
+
+  const yd = new Date(now);
+  yd.setDate(yd.getDate() - 1);
+  const yesterday = localDateStr(yd);
+
+  const prev = loadStreakData();
+  if (prev.lastReadDate === today) return prev; // already counted today
+
+  const newStreak = prev.lastReadDate === yesterday ? prev.streak + 1 : 1;
+  const updated: DailyStreakData = { streak: newStreak, lastReadDate: today };
+
+  try {
+    localStorage.setItem(STREAK_KEY, JSON.stringify(updated));
+  } catch { /* ignore */ }
+
+  return updated;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,6 +11,7 @@ const { title, description = "Free tools for Koine Greek students — keyboard, 
 const navLinks = [
   { href: '/keyboard',        label: 'Keyboard'        },
   { href: '/flashcards',      label: 'Flashcards'      },
+  { href: '/daily',           label: 'Daily'           },
   { href: '/reader',          label: 'Reader'          },
   { href: '/transliteration', label: 'Transliteration' },
   { href: '/grammar',         label: 'Grammar'         },

--- a/src/pages/daily.astro
+++ b/src/pages/daily.astro
@@ -1,0 +1,23 @@
+---
+import Layout from '../layouts/Layout.astro';
+import DailyVerse from '../components/DailyVerse';
+---
+
+<Layout
+  title="Daily Verse"
+  description="Read one Greek New Testament verse per day in the original Greek. Build a reading habit with streak tracking and on-demand vocabulary help."
+>
+  <div class="mb-6">
+    <h1
+      class="text-3xl font-bold mb-1"
+      style="color: var(--color-accent);"
+    >
+      Daily Verse
+    </h1>
+    <p class="text-text-muted">
+      One verse per day in the original Greek. Click any word for its lexical form, gloss, and parse.
+    </p>
+  </div>
+
+  <DailyVerse client:load />
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,6 +19,14 @@ const tools = [
     bgColor: '#F5F3FF',
   },
   {
+    href: '/daily',
+    icon: '☀',
+    title: 'Daily Verse',
+    description: 'One GNT verse per day in the original Greek. Build a reading habit with streak tracking.',
+    accentColor: '#D97706',   // amber
+    bgColor: '#FFFBEB',
+  },
+  {
     href: '/reader',
     icon: '𐤁',
     title: 'GNT Reader',


### PR DESCRIPTION
## Summary

- Adds `/daily` route with a new `DailyVerse` component that shows one GNT verse per day, selected deterministically from a 62-verse curated list (cycles by local calendar date)
- Streak tracking via `localStorage` — increments on page open, resets if a day is missed, displayed as a "🔥 N-day streak" badge
- Vocabulary crossover: words the student has studied in Flashcards get a dotted underline, same as the GNT Reader
- Extracts shared `WordToken` + `WordPopup` into `GreekText.tsx` so the GNT Reader and Daily Verse stay in sync (DRY)
- Adds Daily Verse card to the homepage grid and "Daily" link to the nav
- Updates all PRD files with current implementation status

## Test plan

- [ ] All 155 unit tests pass (`pnpm test`)
- [ ] `/daily` loads today's verse in Greek with reference (e.g. "— 1 Corinthians 13:13")
- [ ] Streak badge shows and increments on first visit
- [ ] Clicking a word opens the word popup (lemma, gloss, parse, frequency)
- [ ] "Show glosses" toggle works
- [ ] "Open chapter →" links to the correct GNT Reader passage
- [ ] Homepage shows the new Daily Verse card
- [ ] Nav "Daily" link highlights when on `/daily`
- [ ] Words studied in Flashcards show dotted underline if SRS data exists in localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)