### PR TITLE
feat(grammar): add contract verbs and liquid verbs reference sections

### DIFF
--- a/docs/prd/contract-verbs.md
+++ b/docs/prd/contract-verbs.md
@@ -1,0 +1,127 @@
+# PRD: Contract Verbs Reference & Drills
+
+## Overview
+
+A dedicated reference and practice module for Greek contract verbs — verbs whose stems end in α, ε, or ο. These vowels contract with the following endings according to fixed rules, producing forms that look nothing like the standard λύω paradigm. Contract verbs are extremely common in the GNT (ἀγαπάω, ποιέω, πληρόω, etc.), so students need both a clear reference and targeted practice recognizing contracted forms.
+
+---
+
+## Status
+
+**Complete.** Implemented as a new section within the Grammar Reference page (`/grammar`).
+
+- Contraction rules table (7-row reference card: following vowel × α/ε/ο stem result) with examples on hover
+- Contract type tabs: α-contract (ἀγαπάω) | ε-contract (ποιέω) | ο-contract (πληρόω)
+- Paradigm selector (4 paradigms per type: pres act ind, pres mid/pass ind, impf act ind, impf mid/pass ind)
+- Paradigm table: contracted form prominent, uncontracted form shown muted alongside
+- Common GNT contract verbs list (21 verbs across all 3 types), grouped with color-coded type badges
+- Paradigms also exposed in the Paradigm Quiz (`/paradigms`) Verbs tab via `buildContractVerbTables()` in `paradigm-quiz.ts`
+
+**Key files:**
+- Data: `src/data/grammar.ts` — `ContractVerbParadigm`, `ContractionRule`, `CommonContractVerb` types + data arrays
+- Component: `src/components/GrammarReference.tsx` — `ContractVerbsSection`, `ContractParadigmTable`, `ContractionRulesCard`
+- Quiz: `src/lib/paradigm-quiz.ts` — `buildContractVerbTables()`
+- Tests: `src/lib/paradigm-quiz.test.ts`
+
+---
+
+## Goals
+
+- Give students a concise reference for contraction rules and paradigms, separated from the base λύω tables in the Grammar Reference
+- Help students decode contracted forms they encounter in GNT reading
+- Provide targeted drills so students can recognize and parse contracted forms quickly
+- Surface the most common GNT contract verbs as primary examples
+
+---
+
+## Features
+
+### 1. Contraction Rules Table
+
+A compact reference card showing how the three stem vowels contract with following vowels and diphthongs.
+
+**Content:**
+
+Display contraction outcomes organized by stem vowel (α, ε, ο) vs. the vowel/diphthong that follows:
+
+| Stem + Following | α-contract | ε-contract | ο-contract |
+|---|---|---|---|
+| + ε | ā (long α) | ει | ου |
+| + ο | ω | ου | ω |
+| + ει | ᾳ | ει | οι |
+| + ου | ω | ου | ου |
+| + η | ā | η | ω |
+| + ω | ω | ω | ω |
+| + οι | ῳ | οι | οι |
+
+**Behavior:**
+- Hovering a cell shows a worked example (e.g., ε + ει → ει: ποι**ε** + **εις** → ποι**εῖς**)
+- A "Key Rules" callout highlights the two most important: (1) like vowels contract to the long form, (2) ο is dominant over α and ε
+
+### 2. Contract Verb Paradigm Tables
+
+Full conjugation tables for the three contract verb types in the tenses/moods most needed for GNT reading.
+
+**Representative verbs:**
+- α-contract: ἀγαπάω (I love)
+- ε-contract: ποιέω (I do/make)
+- ο-contract: πληρόω (I fill/fulfill)
+
+**Tables to include per verb:**
+- Present active indicative (all six persons)
+- Present middle/passive indicative
+- Imperfect active indicative
+- Imperfect middle/passive indicative
+- Present active subjunctive
+- Present active imperative
+- Present active/passive infinitive
+- Present active participle (Nom sg M/F/N)
+
+**Behavior:**
+- Tabs or a selector to switch between the three contract types
+- Contracted form shown prominently; uncontracted form shown in a muted style underneath (e.g., ἀγαπ**ῶ** / ἀγαπά**ω**)
+- Toggle to show either contracted forms only or contracted + uncontracted side-by-side
+- Hover any cell to confirm the full parse
+- Visual highlight showing which letters contracted (stem vowel + ending vowel → result)
+
+### 3. Common GNT Contract Verbs List
+
+A scannable reference list of the most frequent contract verbs a student will encounter in the GNT.
+
+**Content (sorted by GNT frequency):**
+- ε-contracts: ποιέω, λαλέω, καλέω, ζητέω, θεωρέω, εὐλογέω, τηρέω, προσκυνέω, μαρτυρέω, ἀκολουθέω
+- α-contracts: ἀγαπάω, ὁράω, ἐρωτάω, νικάω, πλανάω, τιμάω, γεννάω
+- ο-contracts: πληρόω, δηλόω, δικαιόω, σταυρόω, ἐλευθερόω
+
+**Behavior:**
+- Each entry links to its paradigm table
+- Frequency rank shown (GNT occurrence count)
+- Click any verb to filter the paradigm table to that verb
+
+### 4. Contract Verb Parsing Drill
+
+Targeted parsing practice on contracted forms, integrated with the broader Parsing & Drills page.
+
+**Behavior:**
+- Present a contracted form (e.g., ποιεῖτε) and ask the student to identify: Tense, Voice, Mood, Person, Number, and Lexical Form
+- Input method: dropdowns for parse fields, text input (with Greek keyboard) for lexical form
+- After submission: show the correct parse, the uncontracted form alongside the contracted form, and which contraction rule applied
+- Drill set drawn from high-frequency GNT contract verbs; optionally filterable by contract type (α / ε / ο)
+- Track accuracy per contract type so students can see where they struggle
+
+---
+
+## Out of Scope
+
+- Contract adjectives or nouns (ὀστοῦν, etc.) — this PRD covers verbs only
+- Attic contracts or dialectal variations — focus on Koine
+- Future and aorist tenses of contract verbs (these follow regular patterns after the stem is treated; see Liquid Verbs PRD for a parallel case of irregular futures)
+
+---
+
+## Decisions
+
+- **Location:** Section within Grammar Reference (`/grammar`), not a standalone route. Keeps all paradigm reference in one place.
+- **Uncontracted display:** Third column in the paradigm table, muted gray text. Cleanest way to show both forms without adding a toggle.
+- **Drill integration:** Contract paradigms added to the Paradigm Quiz Verbs tab rather than a separate drill page. Re-uses existing quiz infrastructure with zero new UI.
+- **Scope:** Covered pres act ind, pres mid/pass ind, impf act ind, impf mid/pass ind for all three types (12 paradigms total). Present subjunctive and imperative deferred — less critical for initial reading.

--- a/docs/prd/liquid-verbs.md
+++ b/docs/prd/liquid-verbs.md
@@ -1,0 +1,133 @@
+# PRD: Liquid Verbs Reference & Drills
+
+## Overview
+
+A dedicated reference and practice module for Greek liquid verbs — verbs whose stems end in a liquid consonant (λ, μ, ν, or ρ). Liquid verbs are irregular in a predictable way: they lack the sigma (σ) of the standard future and instead use a contracted future form, and their aorists often show distinctive patterns. Because common GNT verbs like βάλλω, κρίνω, μένω, and αἴρω are liquids, students frequently encounter forms they cannot parse using the standard λύω paradigm.
+
+---
+
+## Status
+
+**Complete.** Implemented as a new section within the Grammar Reference page (`/grammar`).
+
+- σ-drop explainer callout card (amber, explains the phonological reason liquids are irregular)
+- Side-by-side future comparison table: Standard λύσω vs. Liquid βαλῶ, all 6 persons, liquid column highlighted in amber
+- Three numbered aorist pattern cards: (1) Sigmatic with stem change (μένω→ἔμεινα), (2) Asigmatic/2nd aorist (βάλλω→ἔβαλον), (3) Stem + augment irregularity (αἴρω→ἦρα)
+- Principal parts table for 8 high-frequency GNT liquid verbs (βάλλω, αἴρω, ἀποστέλλω, κρίνω, μένω, ἐγείρω, ἀγγέλλω, φαίνω)
+- Liquid future paradigm (βαλῶ) also exposed in the Paradigm Quiz Verbs tab via `buildLiquidVerbTables()`
+
+**Key files:**
+- Data: `src/data/grammar.ts` — `LiquidFutureRow`, `LiquidPrincipalParts` types + data arrays
+- Component: `src/components/GrammarReference.tsx` — `LiquidVerbsSection`
+- Quiz: `src/lib/paradigm-quiz.ts` — `buildLiquidVerbTables()`
+- Tests: `src/lib/paradigm-quiz.test.ts`
+
+---
+
+## Goals
+
+- Explain the underlying phonological reason liquids behave differently (sigma drops between a liquid and a vowel, triggering compensatory lengthening or contraction)
+- Provide paradigm tables for the tenses where liquid verbs deviate from the norm
+- List the most common GNT liquid verbs with their principal parts
+- Offer targeted drilling on the future and aorist forms that trip students up most
+
+---
+
+## Features
+
+### 1. Liquid Verb Explainer
+
+A brief, focused explanation of why liquid verbs are irregular — no more than a short summary card.
+
+**Content:**
+- Definition: liquid consonants are λ, μ, ν, ρ (so called because they "flow" — the voice is not completely blocked)
+- The problem: when the future-tense σ is added to a stem ending in a liquid, the σ is unstable between a liquid and a vowel and drops out
+- The result: the future uses ε-contract endings instead of the standard -σω/-σεις pattern (e.g., βαλ + σω → βαλῶ, not βαλσω)
+- The aorist: sigmatic aorist (ε + stem + σ + α) is also affected; many liquid verbs form a non-sigmatic (asigmatic) aorist with a distinctive stem vowel change (e.g., βάλλω → ἔβαλον)
+- Visual: a simple diagram showing σ-drop and compensatory contraction
+
+### 2. Liquid Future Paradigm Table
+
+A comparison table showing the liquid future alongside the standard future so students see exactly where the forms diverge.
+
+**Representative verb:** βάλλω (I throw) — stem βαλ-, future βαλῶ
+
+| Person | Standard Future (λύσω) | Liquid Future (βαλῶ) |
+|---|---|---|
+| 1sg | λύσω | βαλῶ |
+| 2sg | λύσεις | βαλεῖς |
+| 3sg | λύσει | βαλεῖ |
+| 1pl | λύσομεν | βαλοῦμεν |
+| 2pl | λύσετε | βαλεῖτε |
+| 3pl | λύσουσι(ν) | βαλοῦσι(ν) |
+
+**Behavior:**
+- Side-by-side layout (standard vs. liquid) with differences highlighted
+- Toggle to show middle/passive future forms as well
+- Hover any form for full parse confirmation
+- Additional verb selector: switch example verb among common GNT liquid futures (βαλῶ, μενῶ, κρινῶ, ἀρῶ, ἀποστελῶ)
+
+### 3. Liquid Aorist Patterns
+
+Reference section covering the aorist forms of common liquid verbs, which vary more than the future.
+
+**Content — three aorist patterns to document:**
+
+1. **Sigmatic aorist with stem change:** stem vowel lengthens to compensate for sigma loss
+   - μένω → ἔμεινα (stem: μεν- → μειν-)
+   - κρίνω → ἔκρινα (stem regular, sigma drops cleanly)
+
+2. **Asigmatic (second) aorist:** no sigma at all, with a distinct stem
+   - βάλλω → ἔβαλον
+   - ἔρχομαι → ἦλθον (suppletive, listed for cross-reference)
+
+3. **Verbs with multiple irregularities:** augment + liquid + stem change
+   - αἴρω → ἦρα (stem ἀρ-, augment + ε → η, no sigma)
+   - ἀποστέλλω → ἀπέστειλα
+
+**Behavior:**
+- Tabbed display: "Future" | "Aorist Active" | "Aorist Passive"
+- For each pattern, show the full 6-person paradigm of a representative verb
+- Brief note on which pattern a given verb follows
+
+### 4. Common GNT Liquid Verbs — Principal Parts List
+
+A reference table of the ~25 most frequent GNT liquid verbs with all six principal parts.
+
+**Columns:** Lexical Form | Meaning | Future | Aorist Act | Perfect Act | Perfect M/P | Aorist Pass
+
+**Verbs to include (by GNT frequency):**
+- βάλλω, αἴρω, ἀποστέλλω, κρίνω, μένω, ἀγγέλλω, ἐγείρω, αἰτέω (if treated as liquid context), σώζω (ζ-stem, for contrast), φαίνω, σπείρω, κλίνω, ὀφείλω, βουλεύομαι (deponent liquid), στέλλω, χαίρω, ἀποθνῄσκω (for contrast with true liquids)
+
+**Behavior:**
+- Sortable by verb or by frequency
+- Click a verb to jump to its paradigm in the table above
+- Cells with irregular or unexpected forms highlighted; hover for explanation
+
+### 5. Liquid Verb Parsing Drill
+
+Targeted drilling on the forms students are most likely to misparse: liquid futures (mistaken for present or epsilon-contract forms) and liquid aorists (mistaken for imperfects or second aorists).
+
+**Behavior:**
+- Present a form (e.g., βαλεῖτε or ἔμεινεν) and ask: Tense, Voice, Mood, Person, Number, Lexical Form
+- After submission: show correct parse, call out what makes this a liquid verb form, and identify which pattern it follows (σ-drop future, asigmatic aorist, etc.)
+- Drill set drawn from high-frequency GNT liquid verb forms
+- Filter option: Future only | Aorist only | Mixed
+- Track accuracy per tense to identify trouble spots
+
+---
+
+## Out of Scope
+
+- Liquid nouns or adjectives
+- Full treatment of second aorists generally (βάλλω/ἔβαλον is covered as a liquid example; second aorist as a system belongs in the Parsing Drills PRD or Grammar Reference)
+- Attic or non-Koine dialectal liquid patterns
+
+---
+
+## Decisions
+
+- **Location:** Section within Grammar Reference (`/grammar`), not a standalone route.
+- **σ-drop explainer:** Featured prominently as a callout card at the top of the section. The "why" is included because understanding the phonological rule (σ is unstable between liquid + vowel) helps students recognize other liquid futures they haven't memorized.
+- **Quiz integration:** Only the liquid future of βαλῶ is added to the Paradigm Quiz — the principal parts table is reference-only, not quiz-able in this version.
+- **Principal parts scope:** 8 highest-frequency GNT liquid verbs chosen. Curated separately from the Parsing & Drills principal parts drill; a shared data source can be established if that feature is built.

--- a/src/components/ParadigmQuiz.test.tsx
+++ b/src/components/ParadigmQuiz.test.tsx
@@ -62,7 +62,8 @@ describe('ParadigmQuiz — select phase', () => {
     const user = userEvent.setup();
     render(<ParadigmQuiz />);
     await user.click(screen.getByRole('button', { name: 'Verbs' }));
-    expect(screen.getByRole('button', { name: /Present Active Indicative/i })).toBeInTheDocument();
+    // Multiple paradigms share "Present Active Indicative" (λύω + contract verbs) so use getAllByRole
+    expect(screen.getAllByRole('button', { name: /Present Active Indicative/i }).length).toBeGreaterThan(0);
   });
 
   it('switching to Pronouns shows pronoun paradigms', async () => {

--- a/src/data/grammar.ts
+++ b/src/data/grammar.ts
@@ -158,6 +158,63 @@ export interface PrepEntry {
 }
 
 // ---------------------------------------------------------------------------
+// Contract verb types
+// ---------------------------------------------------------------------------
+
+export type ContractType = 'alpha' | 'epsilon' | 'omicron';
+
+/** One row in the contraction rules reference table. */
+export interface ContractionRule {
+  /** The vowel or diphthong following the stem vowel, e.g. "+ ε" */
+  following: string;
+  /** Contraction result for α-stems */
+  alpha: string;
+  /** Contraction result for ε-stems */
+  epsilon: string;
+  /** Contraction result for ο-stems */
+  omicron: string;
+}
+
+export interface ContractVerbParadigm {
+  id: string;
+  label: string;
+  contractType: ContractType;
+  group: 'indicative' | 'subjunctive' | 'imperative';
+  /** Contracted forms — what students see in GNT texts */
+  forms: Partial<Record<PersonNum, string>>;
+  /** Uncontracted forms — shown as muted reference */
+  uncontracted: Partial<Record<PersonNum, string>>;
+}
+
+export interface CommonContractVerb {
+  greek: string;
+  type: ContractType;
+  gloss: string;
+}
+
+// ---------------------------------------------------------------------------
+// Liquid verb types
+// ---------------------------------------------------------------------------
+
+/** One row in the standard-vs-liquid future comparison table. */
+export interface LiquidFutureRow {
+  person: PersonNum;
+  standard: string;
+  liquid: string;
+}
+
+export interface LiquidPrincipalParts {
+  id: string;
+  lexical: string;
+  gloss: string;
+  future: string;
+  aoristAct: string;
+  perfectAct: string;
+  perfectMidPass: string;
+  aoristPass: string;
+}
+
+// ---------------------------------------------------------------------------
 // Accent rule types
 // ---------------------------------------------------------------------------
 
@@ -652,6 +709,257 @@ export function getArticle(
   };
   return articleForms[caseKey][numKey][gMap[gender]];
 }
+
+// ---------------------------------------------------------------------------
+// Accent rules
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Contract verbs
+// ---------------------------------------------------------------------------
+
+export const contractionRules: ContractionRule[] = [
+  { following: '+ ε',  alpha: 'ᾱ (α)', epsilon: 'ει', omicron: 'ου' },
+  { following: '+ ει', alpha: 'ᾳ',     epsilon: 'ει', omicron: 'οι' },
+  { following: '+ η',  alpha: 'ᾱ (α)', epsilon: 'η',  omicron: 'ω'  },
+  { following: '+ ο',  alpha: 'ω',     epsilon: 'ου', omicron: 'ου' },
+  { following: '+ οι', alpha: 'ῳ',     epsilon: 'οι', omicron: 'οι' },
+  { following: '+ ου', alpha: 'ω',     epsilon: 'ου', omicron: 'ου' },
+  { following: '+ ω',  alpha: 'ω',     epsilon: 'ω',  omicron: 'ω'  },
+];
+
+export const contractVerbParadigms: ContractVerbParadigm[] = [
+  // -------------------------------------------------------------------------
+  // α-contract — ἀγαπάω (I love)
+  // -------------------------------------------------------------------------
+  {
+    id: 'alpha-pres-act-ind',
+    label: 'Present Active Indicative',
+    contractType: 'alpha',
+    group: 'indicative',
+    forms:       { '1sg': 'ἀγαπῶ',      '2sg': 'ἀγαπᾷς',     '3sg': 'ἀγαπᾷ',     '1pl': 'ἀγαπῶμεν',  '2pl': 'ἀγαπᾶτε',   '3pl': 'ἀγαπῶσι(ν)' },
+    uncontracted:{ '1sg': 'ἀγαπάω',     '2sg': 'ἀγαπάεις',   '3sg': 'ἀγαπάει',   '1pl': 'ἀγαπάομεν', '2pl': 'ἀγαπάετε',  '3pl': 'ἀγαπάουσι(ν)' },
+  },
+  {
+    id: 'alpha-pres-mid-ind',
+    label: 'Present Middle/Passive Indicative',
+    contractType: 'alpha',
+    group: 'indicative',
+    forms:       { '1sg': 'ἀγαπῶμαι',   '2sg': 'ἀγαπᾷ',      '3sg': 'ἀγαπᾶται',  '1pl': 'ἀγαπώμεθα', '2pl': 'ἀγαπᾶσθε',  '3pl': 'ἀγαπῶνται' },
+    uncontracted:{ '1sg': 'ἀγαπάομαι',  '2sg': 'ἀγαπάεσαι',  '3sg': 'ἀγαπάεται', '1pl': 'ἀγαπαόμεθα','2pl': 'ἀγαπάεσθε', '3pl': 'ἀγαπάονται' },
+  },
+  {
+    id: 'alpha-impf-act-ind',
+    label: 'Imperfect Active Indicative',
+    contractType: 'alpha',
+    group: 'indicative',
+    forms:       { '1sg': 'ἠγάπων',     '2sg': 'ἠγάπας',     '3sg': 'ἠγάπα',     '1pl': 'ἠγαπῶμεν',  '2pl': 'ἠγαπᾶτε',   '3pl': 'ἠγάπων' },
+    uncontracted:{ '1sg': 'ἠγάπαον',    '2sg': 'ἠγάπαες',    '3sg': 'ἠγάπαε',    '1pl': 'ἠγαπάομεν', '2pl': 'ἠγαπάετε',  '3pl': 'ἠγάπαον' },
+  },
+  {
+    id: 'alpha-impf-mid-ind',
+    label: 'Imperfect Middle/Passive Indicative',
+    contractType: 'alpha',
+    group: 'indicative',
+    forms:       { '1sg': 'ἠγαπώμην',   '2sg': 'ἠγαπῶ',      '3sg': 'ἠγαπᾶτο',   '1pl': 'ἠγαπώμεθα', '2pl': 'ἠγαπᾶσθε',  '3pl': 'ἠγαπῶντο' },
+    uncontracted:{ '1sg': 'ἠγαπαόμην',  '2sg': 'ἠγαπάου',    '3sg': 'ἠγαπάετο',  '1pl': 'ἠγαπαόμεθα','2pl': 'ἠγαπάεσθε', '3pl': 'ἠγαπάοντο' },
+  },
+
+  // -------------------------------------------------------------------------
+  // ε-contract — ποιέω (I do, make)
+  // -------------------------------------------------------------------------
+  {
+    id: 'epsilon-pres-act-ind',
+    label: 'Present Active Indicative',
+    contractType: 'epsilon',
+    group: 'indicative',
+    forms:       { '1sg': 'ποιῶ',       '2sg': 'ποιεῖς',     '3sg': 'ποιεῖ',      '1pl': 'ποιοῦμεν',   '2pl': 'ποιεῖτε',    '3pl': 'ποιοῦσι(ν)' },
+    uncontracted:{ '1sg': 'ποιέω',      '2sg': 'ποιέεις',    '3sg': 'ποιέει',     '1pl': 'ποιέομεν',   '2pl': 'ποιέετε',    '3pl': 'ποιέουσι(ν)' },
+  },
+  {
+    id: 'epsilon-pres-mid-ind',
+    label: 'Present Middle/Passive Indicative',
+    contractType: 'epsilon',
+    group: 'indicative',
+    forms:       { '1sg': 'ποιοῦμαι',   '2sg': 'ποιῇ',       '3sg': 'ποιεῖται',   '1pl': 'ποιούμεθα',  '2pl': 'ποιεῖσθε',   '3pl': 'ποιοῦνται' },
+    uncontracted:{ '1sg': 'ποιέομαι',   '2sg': 'ποιέεσαι',   '3sg': 'ποιέεται',   '1pl': 'ποιεόμεθα',  '2pl': 'ποιέεσθε',   '3pl': 'ποιέονται' },
+  },
+  {
+    id: 'epsilon-impf-act-ind',
+    label: 'Imperfect Active Indicative',
+    contractType: 'epsilon',
+    group: 'indicative',
+    forms:       { '1sg': 'ἐποίουν',    '2sg': 'ἐποίεις',    '3sg': 'ἐποίει',     '1pl': 'ἐποιοῦμεν',  '2pl': 'ἐποιεῖτε',   '3pl': 'ἐποίουν' },
+    uncontracted:{ '1sg': 'ἐποίεον',    '2sg': 'ἐποίεες',    '3sg': 'ἐποίεε',     '1pl': 'ἐποιέομεν',  '2pl': 'ἐποιέετε',   '3pl': 'ἐποίεον' },
+  },
+  {
+    id: 'epsilon-impf-mid-ind',
+    label: 'Imperfect Middle/Passive Indicative',
+    contractType: 'epsilon',
+    group: 'indicative',
+    forms:       { '1sg': 'ἐποιούμην',  '2sg': 'ἐποιοῦ',     '3sg': 'ἐποιεῖτο',   '1pl': 'ἐποιούμεθα', '2pl': 'ἐποιεῖσθε',  '3pl': 'ἐποιοῦντο' },
+    uncontracted:{ '1sg': 'ἐποιεόμην',  '2sg': 'ἐποιέου',    '3sg': 'ἐποιέετο',   '1pl': 'ἐποιεόμεθα', '2pl': 'ἐποιέεσθε',  '3pl': 'ἐποιέοντο' },
+  },
+
+  // -------------------------------------------------------------------------
+  // ο-contract — πληρόω (I fill, fulfill)
+  // -------------------------------------------------------------------------
+  {
+    id: 'omicron-pres-act-ind',
+    label: 'Present Active Indicative',
+    contractType: 'omicron',
+    group: 'indicative',
+    forms:       { '1sg': 'πληρῶ',      '2sg': 'πληροῖς',    '3sg': 'πληροῖ',     '1pl': 'πληροῦμεν',  '2pl': 'πληροῦτε',   '3pl': 'πληροῦσι(ν)' },
+    uncontracted:{ '1sg': 'πληρόω',     '2sg': 'πληρόεις',   '3sg': 'πληρόει',    '1pl': 'πληρόομεν',  '2pl': 'πληρόετε',   '3pl': 'πληρόουσι(ν)' },
+  },
+  {
+    id: 'omicron-pres-mid-ind',
+    label: 'Present Middle/Passive Indicative',
+    contractType: 'omicron',
+    group: 'indicative',
+    forms:       { '1sg': 'πληροῦμαι',  '2sg': 'πληροῖ',     '3sg': 'πληροῦται',  '1pl': 'πληρούμεθα', '2pl': 'πληροῦσθε',  '3pl': 'πληροῦνται' },
+    uncontracted:{ '1sg': 'πληρόομαι',  '2sg': 'πληρόεσαι',  '3sg': 'πληρόεται',  '1pl': 'πληροόμεθα', '2pl': 'πληρόεσθε',  '3pl': 'πληρόονται' },
+  },
+  {
+    id: 'omicron-impf-act-ind',
+    label: 'Imperfect Active Indicative',
+    contractType: 'omicron',
+    group: 'indicative',
+    forms:       { '1sg': 'ἐπλήρουν',   '2sg': 'ἐπλήρους',   '3sg': 'ἐπλήρου',    '1pl': 'ἐπληροῦμεν', '2pl': 'ἐπληροῦτε',  '3pl': 'ἐπλήρουν' },
+    uncontracted:{ '1sg': 'ἐπλήρόον',   '2sg': 'ἐπλήρόες',   '3sg': 'ἐπλήρόε',    '1pl': 'ἐπληρόομεν', '2pl': 'ἐπληρόετε',  '3pl': 'ἐπλήρόον' },
+  },
+  {
+    id: 'omicron-impf-mid-ind',
+    label: 'Imperfect Middle/Passive Indicative',
+    contractType: 'omicron',
+    group: 'indicative',
+    forms:       { '1sg': 'ἐπληρούμην', '2sg': 'ἐπληροῦ',    '3sg': 'ἐπληροῦτο',  '1pl': 'ἐπληρούμεθα','2pl': 'ἐπληροῦσθε', '3pl': 'ἐπληροῦντο' },
+    uncontracted:{ '1sg': 'ἐπληροόμην', '2sg': 'ἐπληρόου',   '3sg': 'ἐπληρόετο',  '1pl': 'ἐπληροόμεθα','2pl': 'ἐπληρόεσθε', '3pl': 'ἐπληρόοντο' },
+  },
+];
+
+export const commonContractVerbs: CommonContractVerb[] = [
+  // α-contracts
+  { greek: 'ἀγαπάω',   type: 'alpha',   gloss: 'I love'              },
+  { greek: 'ὁράω',     type: 'alpha',   gloss: 'I see'               },
+  { greek: 'ἐρωτάω',   type: 'alpha',   gloss: 'I ask'               },
+  { greek: 'νικάω',    type: 'alpha',   gloss: 'I conquer'           },
+  { greek: 'τιμάω',    type: 'alpha',   gloss: 'I honor'             },
+  { greek: 'γεννάω',   type: 'alpha',   gloss: 'I beget, give birth' },
+  { greek: 'πλανάω',   type: 'alpha',   gloss: 'I lead astray'       },
+  // ε-contracts
+  { greek: 'ποιέω',    type: 'epsilon', gloss: 'I do, make'          },
+  { greek: 'λαλέω',    type: 'epsilon', gloss: 'I speak'             },
+  { greek: 'καλέω',    type: 'epsilon', gloss: 'I call'              },
+  { greek: 'ζητέω',    type: 'epsilon', gloss: 'I seek'              },
+  { greek: 'θεωρέω',   type: 'epsilon', gloss: 'I see, observe'      },
+  { greek: 'τηρέω',    type: 'epsilon', gloss: 'I keep, guard'       },
+  { greek: 'μαρτυρέω', type: 'epsilon', gloss: 'I bear witness'      },
+  { greek: 'ἀκολουθέω',type: 'epsilon', gloss: 'I follow'            },
+  { greek: 'προσκυνέω',type: 'epsilon', gloss: 'I worship'           },
+  // ο-contracts
+  { greek: 'πληρόω',   type: 'omicron', gloss: 'I fill, fulfill'     },
+  { greek: 'δικαιόω',  type: 'omicron', gloss: 'I justify'           },
+  { greek: 'σταυρόω',  type: 'omicron', gloss: 'I crucify'           },
+  { greek: 'φανερόω',  type: 'omicron', gloss: 'I reveal, manifest'  },
+  { greek: 'ἐλευθερόω',type: 'omicron', gloss: 'I set free'          },
+];
+
+// ---------------------------------------------------------------------------
+// Liquid verbs
+// ---------------------------------------------------------------------------
+
+export const liquidFutureComparison: LiquidFutureRow[] = [
+  { person: '1sg', standard: 'λύσω',        liquid: 'βαλῶ'        },
+  { person: '2sg', standard: 'λύσεις',      liquid: 'βαλεῖς'      },
+  { person: '3sg', standard: 'λύσει',       liquid: 'βαλεῖ'       },
+  { person: '1pl', standard: 'λύσομεν',     liquid: 'βαλοῦμεν'    },
+  { person: '2pl', standard: 'λύσετε',      liquid: 'βαλεῖτε'     },
+  { person: '3pl', standard: 'λύσουσι(ν)', liquid: 'βαλοῦσι(ν)' },
+];
+
+export const liquidPrincipalParts: LiquidPrincipalParts[] = [
+  {
+    id: 'ballo',
+    lexical: 'βάλλω',
+    gloss: 'I throw, put',
+    future: 'βαλῶ',
+    aoristAct: 'ἔβαλον',
+    perfectAct: 'βέβληκα',
+    perfectMidPass: 'βέβλημαι',
+    aoristPass: 'ἐβλήθην',
+  },
+  {
+    id: 'airo',
+    lexical: 'αἴρω',
+    gloss: 'I lift, take away',
+    future: 'ἀρῶ',
+    aoristAct: 'ἦρα',
+    perfectAct: 'ἦρκα',
+    perfectMidPass: 'ἦρμαι',
+    aoristPass: 'ἤρθην',
+  },
+  {
+    id: 'apostello',
+    lexical: 'ἀποστέλλω',
+    gloss: 'I send (out)',
+    future: 'ἀποστελῶ',
+    aoristAct: 'ἀπέστειλα',
+    perfectAct: 'ἀπέσταλκα',
+    perfectMidPass: 'ἀπέσταλμαι',
+    aoristPass: 'ἀπεστάλην',
+  },
+  {
+    id: 'krino',
+    lexical: 'κρίνω',
+    gloss: 'I judge',
+    future: 'κρινῶ',
+    aoristAct: 'ἔκρινα',
+    perfectAct: 'κέκρικα',
+    perfectMidPass: 'κέκριμαι',
+    aoristPass: 'ἐκρίθην',
+  },
+  {
+    id: 'meno',
+    lexical: 'μένω',
+    gloss: 'I remain, stay',
+    future: 'μενῶ',
+    aoristAct: 'ἔμεινα',
+    perfectAct: 'μεμένηκα',
+    perfectMidPass: '—',
+    aoristPass: '—',
+  },
+  {
+    id: 'egeiro',
+    lexical: 'ἐγείρω',
+    gloss: 'I raise up, wake',
+    future: 'ἐγερῶ',
+    aoristAct: 'ἤγειρα',
+    perfectAct: 'ἐγήγερκα',
+    perfectMidPass: 'ἐγήγερμαι',
+    aoristPass: 'ἠγέρθην',
+  },
+  {
+    id: 'aggello',
+    lexical: 'ἀγγέλλω',
+    gloss: 'I announce, report',
+    future: 'ἀγγελῶ',
+    aoristAct: 'ἤγγειλα',
+    perfectAct: 'ἤγγελκα',
+    perfectMidPass: 'ἤγγελμαι',
+    aoristPass: 'ἠγγέλην',
+  },
+  {
+    id: 'phaino',
+    lexical: 'φαίνω',
+    gloss: 'I shine; appear (mid.)',
+    future: 'φανῶ',
+    aoristAct: 'ἔφηνα',
+    perfectAct: 'πέφηνα',
+    perfectMidPass: '—',
+    aoristPass: 'ἐφάνην',
+  },
+];
 
 // ---------------------------------------------------------------------------
 // Accent rules

--- a/src/lib/paradigm-quiz.test.ts
+++ b/src/lib/paradigm-quiz.test.ts
@@ -8,6 +8,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildTableModels,
+  buildContractVerbTables,
+  buildLiquidVerbTables,
   getQuizCells,
   applyDensity,
   ALL_CATEGORIES,
@@ -391,5 +393,136 @@ describe('CATEGORY_LABELS', () => {
     for (const cat of ALL_CATEGORIES) {
       expect(CATEGORY_LABELS[cat]).toBeTruthy();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildContractVerbTables
+// ---------------------------------------------------------------------------
+
+describe('buildContractVerbTables', () => {
+  it('returns 12 tables (4 paradigms × 3 contract types)', () => {
+    const tables = buildContractVerbTables();
+    expect(tables).toHaveLength(12);
+  });
+
+  it('all tables have category "verb"', () => {
+    const tables = buildContractVerbTables();
+    expect(tables.every(t => t.category === 'verb')).toBe(true);
+  });
+
+  it('all tables have ids prefixed with "contract-"', () => {
+    const tables = buildContractVerbTables();
+    expect(tables.every(t => t.id.startsWith('contract-'))).toBe(true);
+  });
+
+  it('all tables have 1 column (Form)', () => {
+    const tables = buildContractVerbTables();
+    for (const t of tables) {
+      expect(t.cols).toHaveLength(1);
+      expect(t.cols[0]).toBe('Form');
+    }
+  });
+
+  it('all tables have 6 rows (one per person-number)', () => {
+    const tables = buildContractVerbTables();
+    for (const t of tables) {
+      expect(t.rows).toHaveLength(6);
+    }
+  });
+
+  it('α-contract pres act ind 1sg is ἀγαπῶ', () => {
+    const tables = buildContractVerbTables();
+    const table = tables.find(t => t.id === 'contract-alpha-pres-act-ind')!;
+    expect(table).toBeDefined();
+    expect(table.rows[0].answers[0]).toBe('ἀγαπῶ');
+  });
+
+  it('ε-contract pres act ind 2pl is ποιεῖτε', () => {
+    const tables = buildContractVerbTables();
+    const table = tables.find(t => t.id === 'contract-epsilon-pres-act-ind')!;
+    expect(table).toBeDefined();
+    // 2pl is index 4 in PERSONS order: 1sg, 2sg, 3sg, 1pl, 2pl, 3pl
+    expect(table.rows[4].answers[0]).toBe('ποιεῖτε');
+  });
+
+  it('ο-contract impf act ind 3sg is ἐπλήρου', () => {
+    const tables = buildContractVerbTables();
+    const table = tables.find(t => t.id === 'contract-omicron-impf-act-ind')!;
+    expect(table).toBeDefined();
+    // 3sg is index 2
+    expect(table.rows[2].answers[0]).toBe('ἐπλήρου');
+  });
+
+  it('labels include the contract type identifier', () => {
+    const tables = buildContractVerbTables();
+    const alphaTable = tables.find(t => t.id.startsWith('contract-alpha'))!;
+    expect(alphaTable.label).toContain('ἀγαπάω');
+    const epsilonTable = tables.find(t => t.id.startsWith('contract-epsilon'))!;
+    expect(epsilonTable.label).toContain('ποιέω');
+    const omicronTable = tables.find(t => t.id.startsWith('contract-omicron'))!;
+    expect(omicronTable.label).toContain('πληρόω');
+  });
+
+  it('each row has answers matching the cols count', () => {
+    const tables = buildContractVerbTables();
+    for (const t of tables) {
+      for (const row of t.rows) {
+        expect(row.answers).toHaveLength(t.cols.length);
+      }
+    }
+  });
+
+  it('contract verb tables are included in buildTableModels', () => {
+    const all = buildTableModels();
+    const contractIds = all.filter(t => t.id.startsWith('contract-')).map(t => t.id);
+    expect(contractIds.length).toBe(12);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildLiquidVerbTables
+// ---------------------------------------------------------------------------
+
+describe('buildLiquidVerbTables', () => {
+  it('returns 1 table (liquid future for βαλῶ)', () => {
+    const tables = buildLiquidVerbTables();
+    expect(tables).toHaveLength(1);
+  });
+
+  it('table has id "liquid-future-ballo"', () => {
+    const tables = buildLiquidVerbTables();
+    expect(tables[0].id).toBe('liquid-future-ballo');
+  });
+
+  it('table has category "verb"', () => {
+    const tables = buildLiquidVerbTables();
+    expect(tables[0].category).toBe('verb');
+  });
+
+  it('table has 6 rows (one per person-number)', () => {
+    const tables = buildLiquidVerbTables();
+    expect(tables[0].rows).toHaveLength(6);
+  });
+
+  it('1sg form is βαλῶ', () => {
+    const tables = buildLiquidVerbTables();
+    expect(tables[0].rows[0].answers[0]).toBe('βαλῶ');
+  });
+
+  it('2sg form is βαλεῖς', () => {
+    const tables = buildLiquidVerbTables();
+    expect(tables[0].rows[1].answers[0]).toBe('βαλεῖς');
+  });
+
+  it('3pl form is βαλοῦσι(ν)', () => {
+    const tables = buildLiquidVerbTables();
+    expect(tables[0].rows[5].answers[0]).toBe('βαλοῦσι(ν)');
+  });
+
+  it('liquid verb table is included in buildTableModels', () => {
+    const all = buildTableModels();
+    const liquid = all.find(t => t.id === 'liquid-future-ballo');
+    expect(liquid).toBeDefined();
   });
 });

--- a/src/lib/paradigm-quiz.ts
+++ b/src/lib/paradigm-quiz.ts
@@ -23,6 +23,8 @@ import {
   personalPronouns12,
   genderedPronouns,
   articleForms,
+  contractVerbParadigms,
+  liquidFutureComparison,
 } from '../data/grammar';
 
 // ---------------------------------------------------------------------------
@@ -76,6 +78,8 @@ export function buildTableModels(): TableModel[] {
     ...buildNounTables(),
     ...buildAdjTables(),
     ...buildVerbTables(),
+    ...buildContractVerbTables(),
+    ...buildLiquidVerbTables(),
     ...buildPronounTables(),
     buildArticleTable(),
   ];
@@ -187,6 +191,46 @@ function buildPronounTables(): TableModel[] {
   }));
 
   return [...personal, ...gendered];
+}
+
+/**
+ * Contract verb paradigms: one table per paradigm, rows = persons, col = contracted form.
+ * Labelled with the contract type so students know which pattern they're drilling.
+ */
+export function buildContractVerbTables(): TableModel[] {
+  const typeLabel: Record<string, string> = {
+    alpha:   'α-contract (ἀγαπάω)',
+    epsilon: 'ε-contract (ποιέω)',
+    omicron: 'ο-contract (πληρόω)',
+  };
+  return contractVerbParadigms.map(p => ({
+    id: `contract-${p.id}`,
+    label: `${p.label} — ${typeLabel[p.contractType]}`,
+    category: 'verb' as const,
+    cols: ['Form'],
+    rows: PERSONS.map(pn => ({
+      label: PERSON_LABELS[pn],
+      answers: [p.forms[pn] ?? null],
+    })),
+  }));
+}
+
+/**
+ * Liquid verb table: the future active of βαλῶ as a single quiz-able paradigm.
+ */
+export function buildLiquidVerbTables(): TableModel[] {
+  return [
+    {
+      id: 'liquid-future-ballo',
+      label: 'Liquid Future Active — βαλῶ (βάλλω)',
+      category: 'verb' as const,
+      cols: ['Form'],
+      rows: liquidFutureComparison.map(row => ({
+        label: PERSON_LABELS[row.person],
+        answers: [row.liquid],
+      })),
+    },
+  ];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds **Contract Verbs** section to Grammar Reference: contraction rules table, α/ε/ο type tabs, 12 paradigms (pres/impf × act/mid-pass × 3 types) showing contracted + uncontracted forms, and a list of 21 high-frequency GNT contract verbs
- Adds **Liquid Verbs** section to Grammar Reference: σ-drop explainer callout, future comparison table (λύσω vs βαλῶ), three numbered aorist pattern cards, and a principal parts table for 8 common GNT liquid verbs
- Both new paradigm sets are also exposed in the Paradigm Quiz Verbs tab
- Adds PRDs for both features (`docs/prd/contract-verbs.md`, `docs/prd/liquid-verbs.md`)

## Test plan

- [x] 276 unit/integration tests passing (`pnpm test --run`)
- [x] Contract Verbs section visible in Grammar Reference with working type tabs and paradigm selector
- [x] Switching α/ε/ο tabs updates paradigm table and selector list
- [x] Liquid Verbs section renders σ-drop explainer, future comparison table, aorist pattern cards, and principal parts table
- [x] Paradigm Quiz Verbs tab includes new contract verb and liquid future paradigms
- [x] Fixed pre-existing ParadigmQuiz test that used `getByRole` on a label now shared by multiple paradigms

🤖 Generated with [Claude Code](https://claude.com/claude-code)