### PR TITLE
feat(grammar): sticky segmented section nav for mobile

### DIFF
--- a/src/components/GrammarReference.tsx
+++ b/src/components/GrammarReference.tsx
@@ -61,15 +61,22 @@ import type { Mood } from './grammar/VerbParadigmGrid';
 // ---------------------------------------------------------------------------
 
 const NAV_SECTIONS = [
-  { id: 'nouns',          label: 'Nouns'          },
-  { id: 'adjectives',     label: 'Adjectives'     },
-  { id: 'verbs',          label: 'Verbs'          },
-  { id: 'contract-verbs', label: 'Contract Verbs' },
-  { id: 'liquid-verbs',   label: 'Liquid Verbs'   },
-  { id: 'pronouns',       label: 'Pronouns'       },
-  { id: 'prepositions',   label: 'Prepositions'   },
-  { id: 'accents',        label: 'Accents'        },
+  { id: 'nouns',          label: 'Nouns',          shortLabel: 'Nouns'  },
+  { id: 'adjectives',     label: 'Adjectives',     shortLabel: 'Adj'   },
+  { id: 'verbs',          label: 'Verbs',          shortLabel: 'Verbs' },
+  { id: 'contract-verbs', label: 'Contract Verbs', shortLabel: 'Contract' },
+  { id: 'liquid-verbs',   label: 'Liquid Verbs',   shortLabel: 'Liquid'   },
+  { id: 'pronouns',       label: 'Pronouns',       shortLabel: 'Pronouns'     },
+  { id: 'prepositions',   label: 'Prepositions',   shortLabel: 'Prepositions' },
+  { id: 'accents',        label: 'Accents',        shortLabel: 'Accents'      },
 ] as const;
+
+const PARADIGM_NAV = NAV_SECTIONS.filter(s =>
+  ['nouns', 'adjectives', 'verbs', 'contract-verbs', 'liquid-verbs'].includes(s.id)
+);
+const REFERENCE_NAV = NAV_SECTIONS.filter(s =>
+  ['pronouns', 'prepositions', 'accents'].includes(s.id)
+);
 
 // ---------------------------------------------------------------------------
 // Noun paradigm table (kept inline — simple, not reused)
@@ -849,28 +856,37 @@ export default function GrammarReference() {
         </nav>
       </aside>
 
-      {/* Mobile nav */}
-      <div className="lg:hidden fixed bottom-0 left-0 right-0 z-10 flex gap-1 overflow-x-auto px-4 py-2 shadow-lg"
-        style={{ background: 'var(--color-bg-card)', borderTop: '1px solid #e5e7eb' }}>
-        {NAV_SECTIONS.map(s => (
-          <a
-            key={s.id}
-            href={`#${s.id}`}
-            onClick={e => { e.preventDefault(); handleNavClick(s.id); }}
-            className="shrink-0 px-3 py-1.5 rounded-full text-xs font-medium transition-colors whitespace-nowrap"
-            style={
-              activeSection === s.id
-                ? { background: 'var(--color-primary)', color: '#fff' }
-                : { background: 'rgba(30,58,95,0.07)', color: 'var(--color-text-muted)' }
-            }
-          >
-            {s.label}
-          </a>
-        ))}
-      </div>
-
       {/* Content */}
-      <div className="flex-1 min-w-0 pb-16 lg:pb-0">
+      <div className="flex-1 min-w-0 pb-20 lg:pb-0">
+
+        {/* Mobile sticky section nav — segmented rows */}
+        <div className="lg:hidden sticky top-0 z-20 -mx-4 px-4 py-2"
+          style={{ background: 'var(--color-bg)', borderBottom: '1px solid #e5e7eb' }}>
+          {([['Paradigms', PARADIGM_NAV], ['Reference', REFERENCE_NAV]] as const).map(([group, items]) => (
+            <div key={group} className="mb-1 last:mb-0">
+              <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>
+                {group}
+              </span>
+              <div className="flex gap-1 mt-0.5">
+                {items.map(s => (
+                  <a
+                    key={s.id}
+                    href={`#${s.id}`}
+                    onClick={e => { e.preventDefault(); handleNavClick(s.id); }}
+                    className="px-2.5 py-1 rounded-full text-xs font-medium transition-colors whitespace-nowrap"
+                    style={
+                      activeSection === s.id
+                        ? { background: 'var(--color-primary)', color: '#fff' }
+                        : { background: 'rgba(30,58,95,0.07)', color: 'var(--color-text-muted)' }
+                    }
+                  >
+                    {s.shortLabel}
+                  </a>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
 
         {/* Nouns */}
         <section id="nouns" className="mb-16">


### PR DESCRIPTION
## Summary
- Replace the fixed bottom section nav (which was hidden behind the app's bottom tab bar) with a sticky top nav
- Use a two-row segmented chip grid: **Paradigms** (Nouns, Adj, Verbs, Contract, Liquid) and **Reference** (Pronouns, Prepositions, Accents)
- All 8 sections visible at a glance — no horizontal scrolling required
- Hidden on desktop (lg+) where the sidebar nav handles navigation

## Test plan
- [x] All 323 tests pass
- [ ] Mobile (375px): nav sticks to top on scroll, all 8 chips visible, tapping jumps to section
- [ ] Desktop (1280px): segmented nav hidden, sidebar nav unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)