### PR TITLE
fix: use Noto Sans for Greek text to prevent accent rendering issues

### DIFF
--- a/src/components/GrammarReference.tsx
+++ b/src/components/GrammarReference.tsx
@@ -127,7 +127,7 @@ function NounParadigmCard({ paradigm }: { paradigm: NounParadigm }) {
                     return (
                       <td
                         key={numKey}
-                        className="px-4 py-2 text-center font-serif text-base cursor-default rounded transition-colors"
+                        className="px-4 py-2 text-center font-greek text-base cursor-default rounded transition-colors"
                         style={{ color: 'var(--color-greek)' }}
                         onMouseEnter={() => handleCell(c, numKey)}
                         onMouseLeave={() => setDescription(null)}
@@ -231,7 +231,7 @@ function VerbSection() {
                           {PERSON_LABELS[p]}
                         </td>
                         <td
-                          className="px-4 py-2 font-serif text-lg cursor-default"
+                          className="px-4 py-2 font-greek text-lg cursor-default"
                           style={{ color: 'var(--color-greek)' }}
                           onMouseEnter={() => setDescription(`${activeParsed.label} — ${PERSON_FULL_LABELS[p]}`)}
                           onMouseLeave={() => setDescription(null)}
@@ -265,7 +265,7 @@ function VerbSection() {
                 {infinitiveForms.map(({ label, form }, i) => (
                   <tr key={label} style={{ background: i % 2 === 0 ? 'var(--color-bg-card)' : 'rgba(30,58,95,0.03)' }}>
                     <td className="px-4 py-2 text-xs" style={{ color: 'var(--color-text-muted)' }}>{label}</td>
-                    <td className="px-4 py-2 font-serif text-base" style={{ color: 'var(--color-greek)' }}>{form}</td>
+                    <td className="px-4 py-2 font-greek text-base" style={{ color: 'var(--color-greek)' }}>{form}</td>
                   </tr>
                 ))}
               </tbody>
@@ -295,7 +295,7 @@ function VerbSection() {
                   <tr key={row.label} style={{ background: i % 2 === 0 ? 'var(--color-bg-card)' : 'rgba(30,58,95,0.03)' }}>
                     <td className="px-3 py-2 text-xs" style={{ color: 'var(--color-text-muted)' }}>{row.label}</td>
                     {(['m', 'f', 'n'] as GenderKey[]).map(g => (
-                      <td key={g} className="px-3 py-2 text-center font-serif text-sm" style={{ color: 'var(--color-greek)' }}>
+                      <td key={g} className="px-3 py-2 text-center font-greek text-sm" style={{ color: 'var(--color-greek)' }}>
                         {row[g]}
                       </td>
                     ))}
@@ -346,7 +346,7 @@ function PronounCard12({ pronoun }: { pronoun: PersonalPronoun12 }) {
                 {(['sg', 'pl'] as NumKey[]).map(num => (
                   <td
                     key={num}
-                    className="px-4 py-2 text-center font-serif text-base cursor-default"
+                    className="px-4 py-2 text-center font-greek text-base cursor-default"
                     style={{ color: 'var(--color-greek)' }}
                     onMouseEnter={() => setDescription(`${CASE_DESCRIPTIONS[c].split(' — ')[0]} ${NUM_LABELS[num]} — ${CASE_DESCRIPTIONS[c].split(' — ')[1]}`)}
                     onMouseLeave={() => setDescription(null)}
@@ -390,7 +390,7 @@ function PrepCard({ entry }: { entry: (typeof prepositions)[number] }) {
       style={{ background: 'var(--color-bg-card)', border: '1px solid #e5e7eb' }}
     >
       <div className="flex items-center gap-3">
-        <span className="font-serif text-2xl" style={{ color: 'var(--color-greek)' }}>{entry.greek}</span>
+        <span className="font-greek text-2xl" style={{ color: 'var(--color-greek)' }}>{entry.greek}</span>
         <div className="flex gap-1 flex-wrap">
           {entry.cases.map(c => (
             <span
@@ -461,9 +461,9 @@ function ContractionRulesCard() {
                 <td className="px-3 py-2 text-xs font-mono font-medium" style={{ color: 'var(--color-text-muted)' }}>
                   {rule.following}
                 </td>
-                <td className="px-4 py-2 text-center font-serif text-base" style={{ color: 'var(--color-greek)' }}>{rule.alpha}</td>
-                <td className="px-4 py-2 text-center font-serif text-base" style={{ color: 'var(--color-greek)' }}>{rule.epsilon}</td>
-                <td className="px-4 py-2 text-center font-serif text-base" style={{ color: 'var(--color-greek)' }}>{rule.omicron}</td>
+                <td className="px-4 py-2 text-center font-greek text-base" style={{ color: 'var(--color-greek)' }}>{rule.alpha}</td>
+                <td className="px-4 py-2 text-center font-greek text-base" style={{ color: 'var(--color-greek)' }}>{rule.epsilon}</td>
+                <td className="px-4 py-2 text-center font-greek text-base" style={{ color: 'var(--color-greek)' }}>{rule.omicron}</td>
               </tr>
             ))}
           </tbody>
@@ -501,7 +501,7 @@ function ContractParadigmTable({ paradigm }: { paradigm: ContractVerbParadigm })
                     {PERSON_LABELS[p]}
                   </td>
                   <td
-                    className="px-4 py-2 font-serif text-lg cursor-default"
+                    className="px-4 py-2 font-greek text-lg cursor-default"
                     style={{ color: 'var(--color-greek)' }}
                     onMouseEnter={() => setDescription(`${paradigm.label} — ${PERSON_FULL_LABELS[p]}`)}
                     onMouseLeave={() => setDescription(null)}
@@ -509,7 +509,7 @@ function ContractParadigmTable({ paradigm }: { paradigm: ContractVerbParadigm })
                   >
                     {contracted}
                   </td>
-                  <td className="px-4 py-2 font-serif text-sm" style={{ color: 'var(--color-text-muted)' }}>
+                  <td className="px-4 py-2 font-greek text-sm" style={{ color: 'var(--color-text-muted)' }}>
                     {raw ?? ''}
                   </td>
                 </tr>
@@ -620,7 +620,7 @@ function ContractVerbsSection() {
                   <span
                     key={v.greek}
                     className="text-sm px-2.5 py-1 rounded-lg"
-                    style={{ background: 'var(--color-bg-card)', border: '1px solid #e5e7eb', color: 'var(--color-greek)', fontFamily: 'serif' }}
+                    style={{ background: 'var(--color-bg-card)', border: '1px solid #e5e7eb', color: 'var(--color-greek)', fontFamily: 'var(--font-greek)' }}
                     title={v.gloss}
                   >
                     {v.greek}
@@ -723,10 +723,10 @@ function LiquidVerbsSection() {
                     <td className="px-4 py-2 text-xs font-medium" style={{ color: 'var(--color-text-muted)' }}>
                       {PERSON_LABELS[row.person]}
                     </td>
-                    <td className="px-4 py-2 text-center font-serif text-base" style={{ color: 'var(--color-text-muted)' }}>
+                    <td className="px-4 py-2 text-center font-greek text-base" style={{ color: 'var(--color-text-muted)' }}>
                       {row.standard}
                     </td>
-                    <td className="px-4 py-2 text-center font-serif text-lg font-medium" style={{ color: 'var(--color-greek)' }}>
+                    <td className="px-4 py-2 text-center font-greek text-lg font-medium" style={{ color: 'var(--color-greek)' }}>
                       {row.liquid}
                     </td>
                   </tr>
@@ -762,9 +762,9 @@ function LiquidVerbsSection() {
               <div className="space-y-1 ml-7">
                 {pattern.examples.map(ex => (
                   <div key={ex.verb} className="flex flex-wrap items-baseline gap-x-2 text-sm">
-                    <span className="font-serif" style={{ color: 'var(--color-greek)' }}>{ex.verb}</span>
+                    <span className="font-greek" style={{ color: 'var(--color-greek)' }}>{ex.verb}</span>
                     <span style={{ color: 'var(--color-text-muted)' }}>→</span>
-                    <span className="font-serif font-medium" style={{ color: 'var(--color-greek)' }}>{ex.aorist}</span>
+                    <span className="font-greek font-medium" style={{ color: 'var(--color-greek)' }}>{ex.aorist}</span>
                     <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>({ex.note})</span>
                   </div>
                 ))}
@@ -795,13 +795,13 @@ function LiquidVerbsSection() {
               <tbody>
                 {liquidPrincipalParts.map((verb, i) => (
                   <tr key={verb.id} style={{ background: i % 2 === 0 ? 'var(--color-bg-card)' : 'rgba(30,58,95,0.03)' }}>
-                    <td className="px-3 py-2 font-serif text-base whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.lexical}</td>
+                    <td className="px-3 py-2 font-greek text-base whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.lexical}</td>
                     <td className="px-3 py-2 text-xs whitespace-nowrap" style={{ color: 'var(--color-text-muted)' }}>{verb.gloss}</td>
-                    <td className="px-3 py-2 font-serif text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.future}</td>
-                    <td className="px-3 py-2 font-serif text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.aoristAct}</td>
-                    <td className="px-3 py-2 font-serif text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.perfectAct}</td>
-                    <td className="px-3 py-2 font-serif text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.perfectMidPass}</td>
-                    <td className="px-3 py-2 font-serif text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.aoristPass}</td>
+                    <td className="px-3 py-2 font-greek text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.future}</td>
+                    <td className="px-3 py-2 font-greek text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.aoristAct}</td>
+                    <td className="px-3 py-2 font-greek text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.perfectAct}</td>
+                    <td className="px-3 py-2 font-greek text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.perfectMidPass}</td>
+                    <td className="px-3 py-2 font-greek text-sm whitespace-nowrap" style={{ color: 'var(--color-greek)' }}>{verb.aoristPass}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/components/GreekText.tsx
+++ b/src/components/GreekText.tsx
@@ -60,7 +60,7 @@ export function WordPopup({ active, onClose }: { active: ActiveWord; onClose: ()
     >
       <div className="flex items-start justify-between gap-2 mb-2">
         <span
-          className="font-serif text-2xl leading-tight"
+          className="font-greek text-2xl leading-tight"
           style={{ color: 'var(--color-greek)' }}
         >
           {word.lemma}
@@ -131,7 +131,7 @@ export function WordToken({
         <span
           ref={spanRef}
           onClick={handleClick}
-          className={`font-serif cursor-pointer rounded px-0.5 hover:bg-accent/10 transition-colors ${
+          className={`font-greek cursor-pointer rounded px-0.5 hover:bg-accent/10 transition-colors ${
             studied ? 'underline decoration-accent/60 decoration-dotted underline-offset-2' : ''
           }`}
           style={{

--- a/src/components/ParadigmQuiz.tsx
+++ b/src/components/ParadigmQuiz.tsx
@@ -149,7 +149,7 @@ function BetaCodeReference() {
                 </kbd>
                 <span style={{ color: 'var(--color-text-muted)' }}>{name}</span>
                 <span
-                  className="ml-auto font-serif"
+                  className="ml-auto font-greek"
                   style={{ color: 'var(--color-greek)', fontFamily: 'var(--font-greek)' }}
                 >
                   {example}
@@ -488,7 +488,7 @@ function QuizTable({ table, cells, inputs, onInputChange, submitted, results, ac
                   return (
                     <td
                       key={colIndex}
-                      className="px-3 py-2 text-center font-serif text-base"
+                      className="px-3 py-2 text-center font-greek text-base"
                       style={{ color: 'var(--color-greek)' }}
                     >
                       {answer}
@@ -508,7 +508,7 @@ function QuizTable({ table, cells, inputs, onInputChange, submitted, results, ac
                   return (
                     <td key={colIndex} className="px-2 py-1.5 text-center">
                       <div
-                        className="rounded px-1.5 py-1 text-sm font-serif"
+                        className="rounded px-1.5 py-1 text-sm font-greek"
                         style={{ background: style.bg, border: `1px solid ${style.border}`, color: style.text }}
                       >
                         {displayResult === 'correct' ? (

--- a/src/components/Transliteration.tsx
+++ b/src/components/Transliteration.tsx
@@ -50,7 +50,7 @@ export default function Transliteration() {
             onChange={handleGreekChange}
             placeholder="Paste or type Greek text…"
             className={textareaClass}
-            style={{ color: 'var(--color-greek)', fontFamily: 'serif', fontSize: '1.25rem' }}
+            style={{ color: 'var(--color-greek)', fontFamily: 'var(--font-greek)', fontSize: '1.25rem' }}
             spellCheck={false}
             autoFocus
           />
@@ -97,7 +97,7 @@ export default function Transliteration() {
             ['ο', 'o'], ['υ', 'y'], ['ω', 'ō'],
           ].map(([grk, lat]) => (
             <div key={grk} className="flex gap-2 items-center">
-              <span className="font-serif text-lg" style={{ color: 'var(--color-greek)' }}>{grk}</span>
+              <span className="font-greek text-lg" style={{ color: 'var(--color-greek)' }}>{grk}</span>
               <span className="text-text-muted">→</span>
               <span className="font-mono">{lat}</span>
             </div>
@@ -112,7 +112,7 @@ export default function Transliteration() {
             ['τ', 't'],
           ].map(([grk, lat]) => (
             <div key={grk} className="flex gap-2 items-center">
-              <span className="font-serif text-lg" style={{ color: 'var(--color-greek)' }}>{grk}</span>
+              <span className="font-greek text-lg" style={{ color: 'var(--color-greek)' }}>{grk}</span>
               <span className="text-text-muted">→</span>
               <span className="font-mono">{lat}</span>
             </div>
@@ -126,7 +126,7 @@ export default function Transliteration() {
               ['rough breathing', 'h (prefixed)'],
             ].map(([grk, lat]) => (
               <div key={grk} className="flex gap-2 items-center">
-                <span className="font-serif" style={{ color: 'var(--color-greek)' }}>{grk}</span>
+                <span className="font-greek" style={{ color: 'var(--color-greek)' }}>{grk}</span>
                 <span className="text-text-muted">→</span>
                 <span className="font-mono">{lat}</span>
               </div>

--- a/src/components/grammar/AdjParadigmCard.tsx
+++ b/src/components/grammar/AdjParadigmCard.tsx
@@ -93,7 +93,7 @@ export default function AdjParadigmCard({ paradigm }: { paradigm: AdjParadigm })
                   GENDERS.map(g => (
                     <td
                       key={`${num}-${g}`}
-                      className="px-3 py-2 text-center font-serif text-sm cursor-default"
+                      className="px-3 py-2 text-center font-greek text-sm cursor-default"
                       style={{ color: 'var(--color-greek)' }}
                       onMouseEnter={() => handleCell(c, num, g)}
                       onMouseLeave={() => setDescription(null)}
@@ -142,7 +142,7 @@ export default function AdjParadigmCard({ paradigm }: { paradigm: AdjParadigm })
                 {GENDERS.map(g => (
                   <td
                     key={g}
-                    className="px-3 py-2 text-center font-serif text-sm cursor-default"
+                    className="px-3 py-2 text-center font-greek text-sm cursor-default"
                     style={{ color: 'var(--color-greek)' }}
                     onClick={() => handleCell(c, activeNumber, g)}
                   >

--- a/src/components/grammar/GenderedPronounCard.tsx
+++ b/src/components/grammar/GenderedPronounCard.tsx
@@ -84,7 +84,7 @@ export default function GenderedPronounCard({ pronoun }: { pronoun: GenderedPron
                     return (
                       <td
                         key={`${num}-${g}`}
-                        className="px-3 py-2 text-center font-serif text-sm cursor-default"
+                        className="px-3 py-2 text-center font-greek text-sm cursor-default"
                         style={{ color: 'var(--color-greek)' }}
                         onMouseEnter={() =>
                           handleCell(c, num, g)
@@ -137,7 +137,7 @@ export default function GenderedPronounCard({ pronoun }: { pronoun: GenderedPron
                   return (
                     <td
                       key={g}
-                      className="px-3 py-2 text-center font-serif text-sm cursor-default"
+                      className="px-3 py-2 text-center font-greek text-sm cursor-default"
                       style={{ color: 'var(--color-greek)' }}
                       onClick={() => handleCell(c, activeNumber, g)}
                     >

--- a/src/components/grammar/VerbParadigmGrid.tsx
+++ b/src/components/grammar/VerbParadigmGrid.tsx
@@ -246,7 +246,7 @@ export default function VerbParadigmGrid({
                       title={cell.paradigm.label}
                     >
                       {showFormPreview ? (
-                        <span className="font-serif text-sm">{preview}</span>
+                        <span className="font-greek text-sm">{preview}</span>
                       ) : labelParts ? (
                         <span>{labelParts}</span>
                       ) : (


### PR DESCRIPTION
## Summary
- Replaced all `font-serif` (system serif fallback) with `font-greek` (Noto Sans from Google Fonts) across 7 components that render Greek text
- Fixes backtick-like spacing artifacts around breathing marks and accents on machines where system serif fonts lack Greek Extended Unicode coverage (U+1F00–U+1FFF)
- The `--font-greek` CSS variable and Noto Sans font were already loaded — they just weren't being used consistently

## Test plan
- [x] `pnpm build` passes
- [x] All 323 tests pass
- [x] Reader page (John 1) renders Greek text cleanly
- [x] Grammar page paradigm tables render correctly
- [x] No remaining `font-serif` references in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)