### PR TITLE
Credit Daily Dose of Greek in Daily page copy

### DIFF
--- a/docs/prd/daily-dose-integration.md
+++ b/docs/prd/daily-dose-integration.md
@@ -16,7 +16,7 @@ Integrate the [Daily Dose of Greek](https://dailydoseofgreek.com) verse-of-the-d
 
 ## Status
 
-**Not started.**
+**Complete.** All features implemented: `fetchDailyDoseVerse()` in `src/data/dailyDose.ts` with reference parsing, sessionStorage caching, and 5s timeout; `DailyVerse.tsx` updated to resolve Daily Dose verse first with curated-list fallback; "Watch the analysis" link shown when Daily Dose is active. 19 tests in `dailyDose.test.ts`.
 
 ---
 

--- a/docs/prd/daily-page-copy-polish.md
+++ b/docs/prd/daily-page-copy-polish.md
@@ -1,0 +1,69 @@
+# PRD: Daily Page Copy Polish
+
+## Overview
+
+Update the Daily Verse page copy and accessibility to properly credit [Daily Dose of Greek](https://dailydoseofgreek.com) — the source of the daily verse — and improve the alt text on the external link button.
+
+---
+
+## Goals
+
+- Give users context about *where* the daily verse comes from before they interact with the page
+- Improve accessibility by adding descriptive alt text to the "Watch the analysis" link
+
+---
+
+## Status
+
+**Complete.** Subtitle copy updated in `daily.astro` to mention Daily Dose of Greek with a link. `aria-label` added to the "Watch the analysis" button in `DailyVerse.tsx`.
+
+---
+
+## Priority
+
+Low
+
+---
+
+## Features
+
+### 1. Page Description Copy
+
+Update the subtitle text on `daily.astro` to mention Daily Dose of Greek as the verse source.
+
+**Behavior:**
+
+- The subtitle below the "Daily Verse" heading explains that the verse is sourced from Daily Dose of Greek
+- When the Daily Dose API is unavailable (fallback to curated list), the page copy still works — it references Daily Dose without making a hard promise about today's specific verse
+
+### 2. Accessible Link Label
+
+Add an `aria-label` to the "Watch the analysis" button in `DailyVerse.tsx`.
+
+**Behavior:**
+
+- `aria-label="Watch analysis from Daily Dose of Greek"` on the external link
+- Screen readers announce the full destination context rather than just "Watch the analysis"
+
+---
+
+## File Changes
+
+| File | Change |
+|---|---|
+| `src/pages/daily.astro` | Update subtitle copy to mention Daily Dose of Greek |
+| `src/components/DailyVerse.tsx` | Add `aria-label` to the Daily Dose link |
+
+---
+
+## Out of Scope
+
+- Changing the page layout or visual design
+- Adding a Daily Dose of Greek logo or branding
+- Modifying the fallback behavior
+
+---
+
+## Decisions
+
+- **Copy mentions Daily Dose generically:** The subtitle doesn't promise "today's verse is from Daily Dose" since the fallback curated list may be active. Instead it frames Daily Dose as the usual source.

--- a/src/components/DailyVerse.tsx
+++ b/src/components/DailyVerse.tsx
@@ -151,9 +151,10 @@ export default function DailyVerse() {
                     href={dailyDoseLink}
                     target="_blank"
                     rel="noopener noreferrer"
+                    aria-label="Watch analysis from Daily Dose of Greek"
                     className="px-3 py-1.5 rounded-lg text-sm border border-accent/30 text-accent hover:border-accent hover:bg-accent/5 transition-colors"
                   >
-                    Watch the analysis ↗
+                    Watch an analysis ↗
                   </a>
                 )}
               </div>

--- a/src/pages/daily.astro
+++ b/src/pages/daily.astro
@@ -15,7 +15,7 @@ import DailyVerse from '../components/DailyVerse';
       Daily Verse
     </h1>
     <p class="text-text-muted">
-      One verse per day in the original Greek. Click any word for its lexical form, gloss, and parse.
+      Read the verse of the day from <a href="https://dailydoseofgreek.com" target="_blank" rel="noopener noreferrer" class="underline hover:text-text transition-colors">Daily Dose of Greek</a> in the original Greek. Click any word for its lexical form, gloss, and parse.
     </p>
   </div>
 


### PR DESCRIPTION
## Summary
- Updated the Daily Verse page subtitle to mention and link to Daily Dose of Greek as the verse source
- Added `aria-label="Watch analysis from Daily Dose of Greek"` to the external link button for screen reader accessibility
- Changed button text from "Watch the analysis" to "Watch an analysis"
- Created PRD (`docs/prd/daily-page-copy-polish.md`) and updated Daily Dose integration PRD status to complete

## Test plan
- [x] Build passes
- [x] All 342 tests pass
- [x] Verified visually via dev server — subtitle copy renders with link, button text updated
- [x] Confirmed aria-label via accessibility snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)