### PR TITLE
Update Daily Dose button copy

### DIFF
--- a/src/components/DailyVerse.tsx
+++ b/src/components/DailyVerse.tsx
@@ -154,7 +154,7 @@ export default function DailyVerse() {
                     aria-label="Watch analysis from Daily Dose of Greek"
                     className="px-3 py-1.5 rounded-lg text-sm border border-accent/30 text-accent hover:border-accent hover:bg-accent/5 transition-colors"
                   >
-                    Watch an analysis ↗
+                    Watch the Daily Dose ↗
                   </a>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- Changes the Daily Verse page button text from "Watch an analysis" to "Watch the Daily Dose" for clearer branding

## Test plan
- [ ] Verify button text reads "Watch the Daily Dose ↗" on the Daily page when a Daily Dose link is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)