### PR TITLE
docs(prd): reorganize and update PRDs

### DIFF
--- a/docs/prd/completed/contract-verbs.md
+++ b/docs/prd/completed/contract-verbs.md
@@ -1,0 +1,127 @@
+# PRD: Contract Verbs Reference & Drills
+
+## Overview
+
+A dedicated reference and practice module for Greek contract verbs — verbs whose stems end in α, ε, or ο. These vowels contract with the following endings according to fixed rules, producing forms that look nothing like the standard λύω paradigm. Contract verbs are extremely common in the GNT (ἀγαπάω, ποιέω, πληρόω, etc.), so students need both a clear reference and targeted practice recognizing contracted forms.
+
+---
+
+## Status
+
+**Complete.** Implemented as a new section within the Grammar Reference page (`/grammar`).
+
+- Contraction rules table (7-row reference card: following vowel × α/ε/ο stem result) with examples on hover
+- Contract type tabs: α-contract (ἀγαπάω) | ε-contract (ποιέω) | ο-contract (πληρόω)
+- Paradigm selector (4 paradigms per type: pres act ind, pres mid/pass ind, impf act ind, impf mid/pass ind)
+- Paradigm table: contracted form prominent, uncontracted form shown muted alongside
+- Common GNT contract verbs list (21 verbs across all 3 types), grouped with color-coded type badges
+- Paradigms also exposed in the Paradigm Quiz (`/paradigms`) Verbs tab via `buildContractVerbTables()` in `paradigm-quiz.ts`
+
+**Key files:**
+- Data: `src/data/grammar.ts` — `ContractVerbParadigm`, `ContractionRule`, `CommonContractVerb` types + data arrays
+- Component: `src/components/GrammarReference.tsx` — `ContractVerbsSection`, `ContractParadigmTable`, `ContractionRulesCard`
+- Quiz: `src/lib/paradigm-quiz.ts` — `buildContractVerbTables()`
+- Tests: `src/lib/paradigm-quiz.test.ts`
+
+---
+
+## Goals
+
+- Give students a concise reference for contraction rules and paradigms, separated from the base λύω tables in the Grammar Reference
+- Help students decode contracted forms they encounter in GNT reading
+- Provide targeted drills so students can recognize and parse contracted forms quickly
+- Surface the most common GNT contract verbs as primary examples
+
+---
+
+## Features
+
+### 1. Contraction Rules Table
+
+A compact reference card showing how the three stem vowels contract with following vowels and diphthongs.
+
+**Content:**
+
+Display contraction outcomes organized by stem vowel (α, ε, ο) vs. the vowel/diphthong that follows:
+
+| Stem + Following | α-contract | ε-contract | ο-contract |
+|---|---|---|---|
+| + ε | ā (long α) | ει | ου |
+| + ο | ω | ου | ω |
+| + ει | ᾳ | ει | οι |
+| + ου | ω | ου | ου |
+| + η | ā | η | ω |
+| + ω | ω | ω | ω |
+| + οι | ῳ | οι | οι |
+
+**Behavior:**
+- Hovering a cell shows a worked example (e.g., ε + ει → ει: ποι**ε** + **εις** → ποι**εῖς**)
+- A "Key Rules" callout highlights the two most important: (1) like vowels contract to the long form, (2) ο is dominant over α and ε
+
+### 2. Contract Verb Paradigm Tables
+
+Full conjugation tables for the three contract verb types in the tenses/moods most needed for GNT reading.
+
+**Representative verbs:**
+- α-contract: ἀγαπάω (I love)
+- ε-contract: ποιέω (I do/make)
+- ο-contract: πληρόω (I fill/fulfill)
+
+**Tables to include per verb:**
+- Present active indicative (all six persons)
+- Present middle/passive indicative
+- Imperfect active indicative
+- Imperfect middle/passive indicative
+- Present active subjunctive
+- Present active imperative
+- Present active/passive infinitive
+- Present active participle (Nom sg M/F/N)
+
+**Behavior:**
+- Tabs or a selector to switch between the three contract types
+- Contracted form shown prominently; uncontracted form shown in a muted style underneath (e.g., ἀγαπ**ῶ** / ἀγαπά**ω**)
+- Toggle to show either contracted forms only or contracted + uncontracted side-by-side
+- Hover any cell to confirm the full parse
+- Visual highlight showing which letters contracted (stem vowel + ending vowel → result)
+
+### 3. Common GNT Contract Verbs List
+
+A scannable reference list of the most frequent contract verbs a student will encounter in the GNT.
+
+**Content (sorted by GNT frequency):**
+- ε-contracts: ποιέω, λαλέω, καλέω, ζητέω, θεωρέω, εὐλογέω, τηρέω, προσκυνέω, μαρτυρέω, ἀκολουθέω
+- α-contracts: ἀγαπάω, ὁράω, ἐρωτάω, νικάω, πλανάω, τιμάω, γεννάω
+- ο-contracts: πληρόω, δηλόω, δικαιόω, σταυρόω, ἐλευθερόω
+
+**Behavior:**
+- Each entry links to its paradigm table
+- Frequency rank shown (GNT occurrence count)
+- Click any verb to filter the paradigm table to that verb
+
+### 4. Contract Verb Parsing Drill
+
+Targeted parsing practice on contracted forms, integrated with the broader Parsing & Drills page.
+
+**Behavior:**
+- Present a contracted form (e.g., ποιεῖτε) and ask the student to identify: Tense, Voice, Mood, Person, Number, and Lexical Form
+- Input method: dropdowns for parse fields, text input (with Greek keyboard) for lexical form
+- After submission: show the correct parse, the uncontracted form alongside the contracted form, and which contraction rule applied
+- Drill set drawn from high-frequency GNT contract verbs; optionally filterable by contract type (α / ε / ο)
+- Track accuracy per contract type so students can see where they struggle
+
+---
+
+## Out of Scope
+
+- Contract adjectives or nouns (ὀστοῦν, etc.) — this PRD covers verbs only
+- Attic contracts or dialectal variations — focus on Koine
+- Future and aorist tenses of contract verbs (these follow regular patterns after the stem is treated; see Liquid Verbs PRD for a parallel case of irregular futures)
+
+---
+
+## Decisions
+
+- **Location:** Section within Grammar Reference (`/grammar`), not a standalone route. Keeps all paradigm reference in one place.
+- **Uncontracted display:** Third column in the paradigm table, muted gray text. Cleanest way to show both forms without adding a toggle.
+- **Drill integration:** Contract paradigms added to the Paradigm Quiz Verbs tab rather than a separate drill page. Re-uses existing quiz infrastructure with zero new UI.
+- **Scope:** Covered pres act ind, pres mid/pass ind, impf act ind, impf mid/pass ind for all three types (12 paradigms total). Present subjunctive and imperative deferred — less critical for initial reading.

--- a/docs/prd/completed/daily-verse-reader.md
+++ b/docs/prd/completed/daily-verse-reader.md
@@ -1,0 +1,80 @@
+# PRD: Daily Verse Reader
+
+## Overview
+
+A daily reading feature that surfaces one GNT verse per day in Greek, tracks a reading streak, and connects naturally to the Flashcards and GNT Reader tools. Designed to build a consistent habit of reading Greek directly.
+
+---
+
+## Goals
+
+- Give students a low-friction daily touchpoint with the Greek text
+- Build and reinforce reading habit through streak tracking
+- Integrate with existing vocabulary help from the Flashcards tool
+
+---
+
+## Status
+
+**Complete.** All features implemented: `/daily` route with `DailyVerse` component, 62-verse curated list in `src/data/dailyVerses.ts`, localStorage streak tracking, vocabulary crossover from Flashcards SRS data, inline gloss toggle, and homepage card + nav link. Word-popup help reuses shared `GreekText.tsx` components.
+
+---
+
+## Priority
+
+Low
+
+---
+
+## Features
+
+### 1. Daily Verse Display
+
+Show one GNT verse per day in Greek with the same word-popup help as the GNT Reader (lexical form, gloss, parse, frequency on click/hover).
+
+**Behavior:**
+- Verse is the same for all users on a given calendar day (deterministic selection, not personalized)
+- Verse changes at midnight local time
+- Verse sequence: 62-verse hand-curated list hard-coded in `src/data/dailyVerses.ts`; cycles after the last verse
+- Verse reference displayed below the text (e.g., "John 3:16")
+- Link to open the full chapter in the GNT Reader
+- **Show/Hide glosses toggle** — inline gloss mode identical to the GNT Reader; displays a small English gloss beneath each Greek word. Toggle state is not persisted.
+
+### 2. Reading Streak
+
+Track consecutive days the student has opened the daily verse.
+
+**Behavior:**
+- A day counts as "read" once the page is opened (no quiz required)
+- Streak stored in `localStorage`; resets if a day is missed
+- Streak count displayed prominently (e.g., "🔥 7-day streak")
+- No account required
+
+### 3. Vocabulary Crossover
+
+Words in the verse that the student has already studied in Flashcards are visually distinguished (dotted underline).
+
+**Behavior:**
+- Reads studied lemma set from `localStorage` via `getStudiedLemmas()` from `srs.ts`
+- Words not yet studied are displayed normally
+- Gracefully degrades if no SRS data exists
+- A legend below the verse explains the dotted underline when SRS data is present
+
+### 4. Entry Point
+
+A dedicated `/daily` route plus a prominent card on the homepage directing students to the day's verse.
+
+---
+
+## Out of Scope
+
+- User-selected verse sequences or custom schedules
+- Push notifications or email reminders
+- Social sharing (see Share a Verse PRD)
+
+---
+
+## Decisions
+
+- **Verse sequence:** Hard-coded 62-verse curated list in `dailyVerses.ts`. Started with a manageable set rather than a full 365-verse list; can be expanded incrementally.
+- **Inline glosses:** Added Show/Hide glosses toggle (same as GNT Reader) since the shared `GreekText.tsx` `WordToken` component already supports it at zero extra cost.

--- a/docs/prd/completed/gnt-reader.md
+++ b/docs/prd/completed/gnt-reader.md
@@ -1,0 +1,114 @@
+# PRD: GNT Reader
+
+## Overview
+
+A passage reader for the Greek New Testament with inline vocabulary help and morphological data. Designed to support students who are beginning to read Greek texts directly, reducing friction without replacing the work of actual reading.
+
+---
+
+## Status
+
+**Complete.** GNTReader component, `/reader` route, MorphGNT data layer, and build script are all implemented. Reading history (localStorage) and homepage "Continue reading" integration are live. Chapter navigation arrows and verse-anchor scrolling are also implemented.
+
+---
+
+## Priority
+
+High — foundational feature; Daily Verse Reader and Verse Memorization both depend on it.
+
+---
+
+## Goals
+
+- Let students read GNT passages directly in the browser without a physical interlinear
+- Surface vocabulary and parsing help on demand (not by default, so students do the work first)
+- Connect reading to the vocabulary they've studied in Flashcards
+
+---
+
+## Data Source
+
+**MorphGNT** — SBLGNT base text with morphological tags. Licensed under CC BY 4.0 (text) and public domain (morphological data). Available at https://github.com/morphgnt/sblgnt.
+
+The dataset provides per word: word form, normalized form, lemma, part of speech, and a full morphological parse code (person, tense, voice, mood, case, number, gender, degree).
+
+---
+
+## Features
+
+### 1. Passage Selection
+
+Student selects a passage to read by book and chapter. The full chapter is always loaded.
+
+**Behavior:**
+- Two dropdowns: Book → Chapter
+- URL reflects the selected passage (e.g., `/reader?ref=JHN.3`) for shareability and bookmarking
+- Default on first load: John 1
+- Individual verse anchors in the URL are supported for deep-linking (e.g., `/reader?ref=JHN.3.16` scrolls to verse 16)
+- **Chapter navigation arrows (← →)** in the toolbar for sequential reading; previous button disabled on chapter 1, next disabled on the final chapter
+
+### 2. Greek Text Display
+
+Render the passage word by word, styled for comfortable reading.
+
+**Behavior:**
+- Words displayed in natural reading order, left to right, with line wrapping
+- Each word is an interactive element (click/tap triggers the word popup)
+- Font: GFS Didot (open source, LGPL) at 1.35rem
+- Verse numbers displayed inline as superscripts in a smaller, muted style
+- Punctuation preserved and displayed (separated from the word span so it doesn't interfere with tap targets)
+
+### 3. Word Popup (On Demand Help)
+
+Clicking or tapping a word reveals a small popup with:
+- The lexical form (lemma)
+- Gloss (English meaning, from `vocabulary.ts`)
+- Full morphological parse (e.g., "Verb — Present Active Indicative 3rd Singular")
+- Frequency in the GNT
+- Link to study this word in Flashcards
+
+**Behavior:**
+- Popup dismisses on click-away, scroll, or pressing Escape
+- Only one popup open at a time
+- Popup positioned below the tapped word, constrained within the viewport
+- Words the student has already studied in Flashcards marked with a dotted underline
+
+### 4. Inline Gloss Mode
+
+A toggle that shows a small gloss beneath every word simultaneously, turning the display into a quasi-interlinear.
+
+**Behavior:**
+- Toggle button in the toolbar ("Show glosses" / "Hide glosses")
+- Glosses appear in a smaller font (0.62rem) directly below each Greek word
+- First gloss segment only shown (before the first comma) to keep it compact
+- Toggle state is not persisted
+
+### 5. Reading History
+
+Remember the student's most recent passage so they can pick up where they left off.
+
+**Behavior:**
+- Store the single most recently visited passage reference in `localStorage` under `greek-tools-reader-last`
+- Homepage shows a "Continue reading: [Book Chapter]" link when a prior passage exists and routes directly to that passage
+
+---
+
+## Out of Scope
+
+- Audio pronunciation
+- Side-by-side English translation display
+- Syntactic diagram overlay
+- User notes or annotation
+
+---
+
+## Decisions
+
+- **Dataset:** MorphGNT (decided)
+- **Bundling strategy:** Per-book JSON files generated at build time from MorphGNT source, output to `public/data/morphgnt/` (e.g., `JHN.json`, `ROM.json`). Fetched on demand at runtime when the user selects a passage; cached in memory for the session. Cloudflare serves these with Brotli compression automatically.
+- **Passage granularity:** Chapter at a time. The selector is Book → Chapter. Individual verse anchors are supported in the URL for deep-linking.
+- **Gloss data source:** MorphGNT provides lemmas but not English glosses. The existing `vocabulary.ts` dataset is the primary source. For lemmas not covered, the popup shows "gloss not available" — acceptable since lower-frequency words are less likely to be needed on demand. A fuller open lexicon can be added later (see Lexicon PRD).
+- **Greek font:** GFS Didot (open source, LGPL).
+- **Mobile tap interaction:** `touchAction: 'manipulation'` on word tokens suppresses the 300ms tap delay and prevents double-tap zoom without requiring custom timer logic. The simpler approach was chosen over the described timer + movement detection.
+- **Flashcards integration:** SRS card keys are normalized to individual lemma forms so they match MorphGNT lemmas directly. The Reader reads studied words via `getStudiedLemmas(): Set<string>` exported from `srs.ts`.
+- **LXX:** Out of scope for v1 (see LXX Reader PRD).

--- a/docs/prd/completed/grammar-reference-mobile.md
+++ b/docs/prd/completed/grammar-reference-mobile.md
@@ -1,0 +1,163 @@
+# PRD: Grammar Reference Mobile Layout
+
+## Overview
+
+Fix the Grammar Reference page for mobile screens. The 6-column adjective and gendered pronoun tables overflow the viewport with no visible scroll affordance — plural forms are invisible unless you happen to swipe. The verb paradigm selector requires blind horizontal scrolling through 10+ pill buttons. This PRD addresses these layout issues with a singular/plural toggle, a compact verb grid, and better scroll indicators.
+
+---
+
+## Status
+
+**Complete.** Implemented in PR #19. Extracted 8 sub-components into `src/components/grammar/`, added Sg/Pl toggle for adjective and gendered pronoun tables on mobile, replaced verb pill-button nav with tense x voice grid (`VerbParadigmGrid`), and added scroll-fade CSS utility. Open questions resolved: Sg/Pl toggle defaults to Singular (no localStorage persistence); verb grid cells show 1sg form previews on the reference page.
+
+---
+
+## Priority
+
+**High.** The Grammar Reference is a primary study tool and mobile is the most common study context (phone on desk next to textbook). Half the content is currently unusable on a phone without accidentally discovering horizontal scroll.
+
+---
+
+## Problem
+
+Three layout issues on screens < 768px:
+
+### 1. Adjective tables — data hidden off-screen
+
+The 2-1-2 and 3-1-3 adjective tables have 7 columns (case label + 3 genders × 2 numbers). On a 375px screen, only Singular is visible. The entire Plural half is clipped with no scroll indicator.
+
+```
+What the student sees:              What's hidden off-screen:
+┌─────────────────────────┐ ┊ ┌─────────────────────────┐
+│      SINGULAR           │ ┊ │      PLURAL             │
+│      Masc.  Fem.  Neut. │ ┊ │      Masc.  Fem.  Neut. │
+│ NOM  ἀγαθός ἀγαθή ἀγαθόν│ ┊ │ NOM  ἀγαθοί ἀγαθαί ἀγαθά│
+│ GEN  ἀγαθοῦ ἀγαθῆς ...  │ ┊ │ GEN  ἀγαθῶν ...         │
+└─────────────────────────┘ ┊ └─────────────────────────┘
+                            ┊
+                       no scroll indicator
+```
+
+### 2. Gendered pronoun tables — same overflow
+
+αὐτός, οὗτος, ἐκεῖνος, ὅς, and τίς all use the same 6-column gender grid. Plural feminine and neuter forms are invisible.
+
+### 3. Verb paradigm selector — blind horizontal scroll
+
+10 indicative paradigms in a horizontal scroll row. Labels like "Present Middle/Passive Indicative" are ~280px wide. Only ~1.5 buttons visible at a time on a 375px screen. No way to see what's available without swiping through the entire list.
+
+---
+
+## Features
+
+### 1. Singular / Plural Toggle for Wide Tables
+
+On mobile (< 768px), replace the 6-column adjective and pronoun tables with a 3-column table plus a Sg/Pl toggle. Show one number at a time.
+
+**Mobile layout with toggle:**
+
+```
+┌─────────────────────────────────┐
+│ 2-1-2 Adjective — ἀγαθός       │
+│                    ┌───────────┐│
+│                    │ Sg · [Pl] ││
+│                    └───────────┘│
+├─────────────────────────────────┤
+│         Masc.    Fem.    Neut.  │
+│  NOM    ἀγαθοί   ἀγαθαί  ἀγαθά │
+│  GEN    ἀγαθῶν   ἀγαθῶν  ἀγαθῶν│
+│  DAT    ἀγαθοῖς  ἀγαθαῖς ἀγαθοῖς│
+│  ACC    ἀγαθούς  ἀγαθάς  ἀγαθά │
+│  VOC    ἀγαθοί   ἀγαθαί  ἀγαθά │
+├─────────────────────────────────┤
+│ Hover over a cell to see its... │
+└─────────────────────────────────┘
+```
+
+**Behavior:**
+- Toggle appears in the card header bar, next to the existing "Full forms / Endings only" toggle
+- Default: Singular selected
+- Tapping Pl swaps all cell values to plural forms
+- The toggle is a small pill: `[Sg] Pl` or `Sg [Pl]` with filled state on the active side
+- On desktop (≥ 768px), the full 6-column table remains unchanged — the toggle is hidden
+- Applies to: all adjective tables and all gendered pronoun tables (αὐτός, οὗτος, ἐκεῖνος, ὅς, τίς)
+- Does NOT apply to: noun tables or personal pronouns (1st/2nd person) — these already fit in 2 columns
+
+### 2. Verb Paradigm Grid (Reference Context)
+
+Replace the horizontal pill-button row with the same tense × voice grid pattern described in the Verb Paradigm Picker PRD, adapted for the reference page.
+
+**Mobile layout:**
+
+```
+┌─────────────────────────────────┐
+│ Verbs — λύω                     │
+│                                 │
+│ [Indicative]  Subjunctive  Imp. │
+│                                 │
+│            Act     M/P          │
+│  Pres     [ ● ]  [ ○ ]         │
+│  Impf     [ ○ ]  [ ○ ]         │
+│  Fut      [ ○ ]  [ ○ ]  ← Mid  │
+│  Aor      [ ○ ]  [ ○ ]  [ ○ ]  │
+│  Perf     [ ○ ]    —           │
+├─────────────────────────────────┤
+│ Present Active Indicative       │
+├─────────────────────────────────┤
+│  PERSON   FORM                  │
+│  1st sg   λύω                   │
+│  2nd sg   λύεις                 │
+│  3rd sg   λύει                  │
+│  1st pl   λύομεν                │
+│  2nd pl   λύετε                 │
+│  3rd pl   λύουσι(ν)             │
+└─────────────────────────────────┘
+```
+
+**Behavior:**
+- Same grid structure as the Verb Paradigm Picker PRD (rows = tenses, columns = voices)
+- Replaces the horizontal scroll nav on mobile only
+- On desktop, the existing vertical sidebar layout can remain, or be replaced with the grid — either works since the sidebar already fits
+- Tapping a grid cell updates the paradigm table below it
+- Selected cell is highlighted with primary color fill
+- The full paradigm label appears as the table card header after selection
+
+### 3. Scroll Fade Indicator (Fallback)
+
+For any remaining horizontal-scroll containers (if the toggle approach isn't applied everywhere), add a visual fade on the right edge to signal more content.
+
+**Behavior:**
+- A gradient fade (white → transparent, ~40px wide) appears on the trailing edge of any overflowing scroll container
+- Fade disappears when the user scrolls to the end
+- Implemented via CSS `mask-image` or a pseudo-element overlay — no JavaScript needed
+- Applies as a safety net to any `overflow-x-auto` container on mobile
+
+---
+
+## Summary of Changes by Section
+
+| Section | Current mobile state | Proposed fix |
+|---------|---------------------|-------------|
+| Nouns | 2 columns — fits fine | No change |
+| Adjectives | 6 columns — overflows, hidden | Sg/Pl toggle (Feature 1) |
+| Verbs (selector) | 10+ pill buttons — blind scroll | Tense × voice grid (Feature 2) |
+| Verbs (table) | 1 column — fits fine | No change |
+| Pronouns (1st/2nd) | 2 columns — fits fine | No change |
+| Pronouns (gendered) | 6 columns — overflows, hidden | Sg/Pl toggle (Feature 1) |
+| Prepositions | Cards — fits fine | No change |
+| Accent rules | Text cards — fits fine | No change |
+
+---
+
+## Out of Scope
+
+- Redesigning the desktop layout (it works well as-is)
+- Adding new paradigm data or sections
+- Touch gestures (swipe between paradigms, pinch-to-zoom tables)
+
+---
+
+## Open Questions
+
+- Should the Sg/Pl toggle default to Singular, or remember the last selection in `localStorage`?
+- For the verb grid on the reference page, should cells show the 1sg form (`λύω`, `ἔλυον`) or just a tappable dot? The reference context might benefit from showing the form since students are looking things up, not drilling.

--- a/docs/prd/completed/grammar-reference.md
+++ b/docs/prd/completed/grammar-reference.md
@@ -1,0 +1,102 @@
+# PRD: Grammar Reference
+
+## Overview
+
+A set of clean, scannable reference tables covering the core grammatical paradigms students need when reading Koine Greek. Designed for quick lookup during reading and translation work, not for memorization drills (see Parsing & Drills PRD).
+
+---
+
+## Status
+
+**Complete.** All five sections implemented in `GrammarReference.tsx` and live at `/grammar`: noun/adjective declension tables, verb conjugation tables, pronoun reference, preposition quick reference, and accent rules summary. Includes sticky sidebar nav (desktop), horizontal scroll nav (mobile), hover tooltips, and endings-only toggle.
+
+---
+
+## Goals
+
+- Give students a fast, browser-accessible alternative to flipping through a textbook
+- Cover the paradigms that come up most often in GNT reading
+- Keep the UI scannable and printer-friendly
+
+---
+
+## Features
+
+### 1. Noun & Adjective Declension Tables
+
+Display the standard Greek noun paradigms organized by declension.
+
+**Tables to include:**
+- First declension: feminine (ἡμέρα, δόξα), masculine (νεανίας)
+- Second declension: masculine (λόγος), neuter (ἔργον)
+- Third declension: representative examples (σάρξ, πίστις, βασιλεύς, γένος)
+- Adjective: 2-1-2 pattern (ἀγαθός), third declension adjective (πᾶς)
+
+**Behavior:**
+- Each table shows case labels (Nom, Gen, Dat, Acc, Voc) × number (Sg, Pl)
+- Cells show the inflected form
+- Hover or tap a cell to see the case name + description (e.g., "Genitive Plural — of [noun]s")
+- Toggle to show endings only (stripped from the stem) vs. full forms
+
+### 2. Verb Conjugation Tables
+
+Display indicative and common non-indicative paradigms for λύω as the base model.
+
+**Tables to include:**
+- Present active/middle-passive indicative
+- Imperfect active/middle-passive indicative
+- Future active/middle indicative
+- Aorist active/middle indicative, aorist passive indicative
+- Perfect active indicative
+- Present active/passive subjunctive and imperative
+- Present and aorist infinitives and participles (summary table)
+
+**Behavior:**
+- Person × number grid (1sg, 2sg, 3sg, 1pl, 2pl, 3pl)
+- Label each form with its full parse on hover
+- Sidebar navigation to switch between tense/mood/voice combinations
+
+### 3. Pronoun Reference
+
+Quick-reference tables for the pronouns students encounter most.
+
+**Tables to include:**
+- Personal pronouns: ἐγώ, σύ, αὐτός
+- Demonstrative: οὗτος, ἐκεῖνος
+- Relative: ὅς, ἥ, ὅ
+- Interrogative/indefinite: τίς/τις
+
+### 4. Preposition Quick Reference
+
+A single-page reference card for all GNT prepositions, organized by the case(s) they govern.
+
+**Behavior:**
+- Group prepositions by case (genitive only, accusative only, dative only, multiple cases)
+- For each preposition: show the Greek form, the case(s) it takes, and primary glosses per case
+
+### 5. Accent Rules Summary
+
+A structured summary of Greek accent rules for students who need a reference while reading.
+
+**Content:**
+- Types of accents (acute, grave, circumflex) and where they can stand
+- Persistent vs. recessive accent rules
+- Rules for nouns (genitive plural always circumflex on ultima in 1st/2nd decl., etc.)
+- Proclitics and enclitics list
+- Common accent shifts to know (e.g., oxytone → grave before another word)
+
+---
+
+## Out of Scope
+
+- Paradigm-based quizzing (see Parsing & Drills PRD)
+- Syntax rules or clause-level grammar
+- Audio
+- Print/PDF export (see below)
+
+---
+
+## Decisions
+
+- **Layout:** One long scrollable page with sticky sidebar nav (desktop) / horizontal scroll nav (mobile). Sub-pages were considered but add navigation overhead for a reference tool; single-page with anchors is faster for lookup.
+- **Print export:** Not implemented. The browser's native print/PDF functionality (Cmd+P) is sufficient for the use case of printing paradigm tables. A dedicated export button would add complexity without meaningful gain.

--- a/docs/prd/completed/liquid-verbs.md
+++ b/docs/prd/completed/liquid-verbs.md
@@ -1,0 +1,133 @@
+# PRD: Liquid Verbs Reference & Drills
+
+## Overview
+
+A dedicated reference and practice module for Greek liquid verbs — verbs whose stems end in a liquid consonant (λ, μ, ν, or ρ). Liquid verbs are irregular in a predictable way: they lack the sigma (σ) of the standard future and instead use a contracted future form, and their aorists often show distinctive patterns. Because common GNT verbs like βάλλω, κρίνω, μένω, and αἴρω are liquids, students frequently encounter forms they cannot parse using the standard λύω paradigm.
+
+---
+
+## Status
+
+**Complete.** Implemented as a new section within the Grammar Reference page (`/grammar`).
+
+- σ-drop explainer callout card (amber, explains the phonological reason liquids are irregular)
+- Side-by-side future comparison table: Standard λύσω vs. Liquid βαλῶ, all 6 persons, liquid column highlighted in amber
+- Three numbered aorist pattern cards: (1) Sigmatic with stem change (μένω→ἔμεινα), (2) Asigmatic/2nd aorist (βάλλω→ἔβαλον), (3) Stem + augment irregularity (αἴρω→ἦρα)
+- Principal parts table for 8 high-frequency GNT liquid verbs (βάλλω, αἴρω, ἀποστέλλω, κρίνω, μένω, ἐγείρω, ἀγγέλλω, φαίνω)
+- Liquid future paradigm (βαλῶ) also exposed in the Paradigm Quiz Verbs tab via `buildLiquidVerbTables()`
+
+**Key files:**
+- Data: `src/data/grammar.ts` — `LiquidFutureRow`, `LiquidPrincipalParts` types + data arrays
+- Component: `src/components/GrammarReference.tsx` — `LiquidVerbsSection`
+- Quiz: `src/lib/paradigm-quiz.ts` — `buildLiquidVerbTables()`
+- Tests: `src/lib/paradigm-quiz.test.ts`
+
+---
+
+## Goals
+
+- Explain the underlying phonological reason liquids behave differently (sigma drops between a liquid and a vowel, triggering compensatory lengthening or contraction)
+- Provide paradigm tables for the tenses where liquid verbs deviate from the norm
+- List the most common GNT liquid verbs with their principal parts
+- Offer targeted drilling on the future and aorist forms that trip students up most
+
+---
+
+## Features
+
+### 1. Liquid Verb Explainer
+
+A brief, focused explanation of why liquid verbs are irregular — no more than a short summary card.
+
+**Content:**
+- Definition: liquid consonants are λ, μ, ν, ρ (so called because they "flow" — the voice is not completely blocked)
+- The problem: when the future-tense σ is added to a stem ending in a liquid, the σ is unstable between a liquid and a vowel and drops out
+- The result: the future uses ε-contract endings instead of the standard -σω/-σεις pattern (e.g., βαλ + σω → βαλῶ, not βαλσω)
+- The aorist: sigmatic aorist (ε + stem + σ + α) is also affected; many liquid verbs form a non-sigmatic (asigmatic) aorist with a distinctive stem vowel change (e.g., βάλλω → ἔβαλον)
+- Visual: a simple diagram showing σ-drop and compensatory contraction
+
+### 2. Liquid Future Paradigm Table
+
+A comparison table showing the liquid future alongside the standard future so students see exactly where the forms diverge.
+
+**Representative verb:** βάλλω (I throw) — stem βαλ-, future βαλῶ
+
+| Person | Standard Future (λύσω) | Liquid Future (βαλῶ) |
+|---|---|---|
+| 1sg | λύσω | βαλῶ |
+| 2sg | λύσεις | βαλεῖς |
+| 3sg | λύσει | βαλεῖ |
+| 1pl | λύσομεν | βαλοῦμεν |
+| 2pl | λύσετε | βαλεῖτε |
+| 3pl | λύσουσι(ν) | βαλοῦσι(ν) |
+
+**Behavior:**
+- Side-by-side layout (standard vs. liquid) with differences highlighted
+- Toggle to show middle/passive future forms as well
+- Hover any form for full parse confirmation
+- Additional verb selector: switch example verb among common GNT liquid futures (βαλῶ, μενῶ, κρινῶ, ἀρῶ, ἀποστελῶ)
+
+### 3. Liquid Aorist Patterns
+
+Reference section covering the aorist forms of common liquid verbs, which vary more than the future.
+
+**Content — three aorist patterns to document:**
+
+1. **Sigmatic aorist with stem change:** stem vowel lengthens to compensate for sigma loss
+   - μένω → ἔμεινα (stem: μεν- → μειν-)
+   - κρίνω → ἔκρινα (stem regular, sigma drops cleanly)
+
+2. **Asigmatic (second) aorist:** no sigma at all, with a distinct stem
+   - βάλλω → ἔβαλον
+   - ἔρχομαι → ἦλθον (suppletive, listed for cross-reference)
+
+3. **Verbs with multiple irregularities:** augment + liquid + stem change
+   - αἴρω → ἦρα (stem ἀρ-, augment + ε → η, no sigma)
+   - ἀποστέλλω → ἀπέστειλα
+
+**Behavior:**
+- Tabbed display: "Future" | "Aorist Active" | "Aorist Passive"
+- For each pattern, show the full 6-person paradigm of a representative verb
+- Brief note on which pattern a given verb follows
+
+### 4. Common GNT Liquid Verbs — Principal Parts List
+
+A reference table of the ~25 most frequent GNT liquid verbs with all six principal parts.
+
+**Columns:** Lexical Form | Meaning | Future | Aorist Act | Perfect Act | Perfect M/P | Aorist Pass
+
+**Verbs to include (by GNT frequency):**
+- βάλλω, αἴρω, ἀποστέλλω, κρίνω, μένω, ἀγγέλλω, ἐγείρω, αἰτέω (if treated as liquid context), σώζω (ζ-stem, for contrast), φαίνω, σπείρω, κλίνω, ὀφείλω, βουλεύομαι (deponent liquid), στέλλω, χαίρω, ἀποθνῄσκω (for contrast with true liquids)
+
+**Behavior:**
+- Sortable by verb or by frequency
+- Click a verb to jump to its paradigm in the table above
+- Cells with irregular or unexpected forms highlighted; hover for explanation
+
+### 5. Liquid Verb Parsing Drill
+
+Targeted drilling on the forms students are most likely to misparse: liquid futures (mistaken for present or epsilon-contract forms) and liquid aorists (mistaken for imperfects or second aorists).
+
+**Behavior:**
+- Present a form (e.g., βαλεῖτε or ἔμεινεν) and ask: Tense, Voice, Mood, Person, Number, Lexical Form
+- After submission: show correct parse, call out what makes this a liquid verb form, and identify which pattern it follows (σ-drop future, asigmatic aorist, etc.)
+- Drill set drawn from high-frequency GNT liquid verb forms
+- Filter option: Future only | Aorist only | Mixed
+- Track accuracy per tense to identify trouble spots
+
+---
+
+## Out of Scope
+
+- Liquid nouns or adjectives
+- Full treatment of second aorists generally (βάλλω/ἔβαλον is covered as a liquid example; second aorist as a system belongs in the Parsing Drills PRD or Grammar Reference)
+- Attic or non-Koine dialectal liquid patterns
+
+---
+
+## Decisions
+
+- **Location:** Section within Grammar Reference (`/grammar`), not a standalone route.
+- **σ-drop explainer:** Featured prominently as a callout card at the top of the section. The "why" is included because understanding the phonological rule (σ is unstable between liquid + vowel) helps students recognize other liquid futures they haven't memorized.
+- **Quiz integration:** Only the liquid future of βαλῶ is added to the Paradigm Quiz — the principal parts table is reference-only, not quiz-able in this version.
+- **Principal parts scope:** 8 highest-frequency GNT liquid verbs chosen. Curated separately from the Parsing & Drills principal parts drill; a shared data source can be established if that feature is built.

--- a/docs/prd/completed/noun-articles.md
+++ b/docs/prd/completed/noun-articles.md
@@ -1,0 +1,123 @@
+# PRD: Definite Article Display in Noun Paradigms
+
+## Overview
+
+Display the definite article alongside each form in noun paradigm tables — the standard Greek textbook convention (e.g., ὁ λόγος, τοῦ λόγου). Also adds the definite article as a standalone quizzable paradigm in the Paradigm Quiz, fulfilling the planned "Definite Article" category referenced in the Paradigm Quiz PRD.
+
+---
+
+## Status
+
+**Complete.** Implemented in PR #18. Article data and helper live in `src/data/grammar.ts`; noun table display updated in `src/components/GrammarReference.tsx`; article quiz paradigm added to `src/lib/paradigm-quiz.ts`.
+
+## LOE
+
+**Small** (half a day)
+
+---
+
+## Goals
+
+- Match the presentation convention used in Mounce, Wallace, and most Koine Greek textbooks
+- Help students correlate the article's form with the noun's case and gender at a glance
+- Add the article paradigm as a standalone memorization target in the quiz
+- Keep data DRY — derive article forms from a single lookup table, not per-paradigm repetition
+
+---
+
+## Features
+
+### 1. Article Data in `grammar.ts`
+
+Add the definite article paradigm as a new exported constant `articleForms` and a helper function `getArticle`.
+
+**Data shape:**
+
+```ts
+export const articleForms: Record<CaseKey, Record<NumKey, Record<GenderKey, string | null>>>
+```
+
+Article forms (null = no form exists for that slot):
+
+| Case | Masc Sg | Fem Sg | Neut Sg | Masc Pl | Fem Pl | Neut Pl |
+|------|---------|--------|---------|---------|--------|---------|
+| Nom  | ὁ       | ἡ      | τό      | οἱ      | αἱ     | τά      |
+| Gen  | τοῦ     | τῆς    | τοῦ     | τῶν     | τῶν    | τῶν     |
+| Dat  | τῷ      | τῇ     | τῷ      | τοῖς    | ταῖς   | τοῖς    |
+| Acc  | τόν     | τήν    | τό      | τούς    | τάς    | τά      |
+| Voc  | null    | null   | null    | null    | null   | null    |
+
+**Helper:**
+
+```ts
+export function getArticle(
+  caseKey: CaseKey,
+  numKey: NumKey,
+  gender: 'masculine' | 'feminine' | 'neuter'
+): string | null
+```
+
+Maps `'masculine' | 'feminine' | 'neuter'` → `GenderKey` (`'m' | 'f' | 'n'`) and returns `articleForms[caseKey][numKey][genderKey]`.
+
+---
+
+### 2. Article Display in Grammar Reference
+
+In `GrammarReference.tsx`, prepend the article to each noun cell's full form when not in endings-only mode.
+
+**Behavior:**
+- In full-form mode: cells display `[article] [noun form]` (e.g., `ὁ λόγος`, `τοῦ λόγου`)
+- In endings-only mode: article is hidden — the toggle shows only the noun ending, unchanged from current behavior
+- Vocative cells display the noun form alone (no article for vocative)
+- The article is rendered in a visually subordinate style (muted color or slightly smaller) so the noun form remains the visual focus
+
+---
+
+### 3. Definite Article as Standalone Quiz Paradigm
+
+Add the definite article as a quizzable `TableModel` in `paradigm-quiz.ts`, listed under a new `'article'` category.
+
+**Table layout:**
+- Rows = cases (Nom, Gen, Dat, Acc) — no Vocative row since the article has no vocative
+- Col groups = Singular | Plural
+- Leaf cols = Masc. | Fem. | Neut. (repeated per group)
+- 24 cells total (4 cases × 2 numbers × 3 genders)
+
+**Category updates:**
+- Add `'article'` to the `Category` type union
+- Add `'Article'` to `CATEGORY_LABELS`
+- Add `'article'` to `ALL_CATEGORIES`
+- Update `buildTableModels()` to include `buildArticleTable()`
+
+---
+
+## Data Sources
+
+| Feature | Source |
+|---------|--------|
+| Article forms | New `articleForms` constant in `src/data/grammar.ts` |
+| Noun paradigm gender | Existing `NounParadigm.gender` field |
+| Quiz table | Derived from `articleForms` in `paradigm-quiz.ts` |
+
+---
+
+## Technical Notes
+
+- **Files changed:** `src/data/grammar.ts`, `src/components/GrammarReference.tsx`, `src/lib/paradigm-quiz.ts`
+- **Tests:** Add unit tests for `getArticle()` in `src/data/grammar.test.ts` and for `buildArticleTable()` in `src/lib/paradigm-quiz.test.ts`
+- The `NounParadigm.gender` field already stores `'masculine' | 'feminine' | 'neuter'`, making the article lookup straightforward
+- No schema changes — `articleForms` and `getArticle` are additive exports
+
+---
+
+## Out of Scope
+
+- Showing articles in the Paradigm Quiz blank cells for noun paradigms (the quiz tests noun forms in isolation; mixing articles adds ambiguity about what is being tested)
+- Audio pronunciation of article forms
+- Indefinite article (Greek has none)
+
+---
+
+## Open Questions
+
+- **Article styling:** Should the article be visually differentiated from the noun (e.g., muted color), or rendered in the same style? Recommendation: muted/smaller to keep noun form as the primary visual focus.

--- a/docs/prd/completed/paradigm-quiz.md
+++ b/docs/prd/completed/paradigm-quiz.md
@@ -1,0 +1,144 @@
+# PRD: Paradigm Quiz
+
+## Overview
+
+A quiz mode that tests students on their ability to recall complete Greek paradigm tables from memory. Distinct from the Parsing & Drills tool (which presents individual GNT word forms) and the Grammar Reference (which is a lookup tool). The paradigm quiz is for students who need to internalize the declension and conjugation tables — the kind of rote memorization most Greek courses require.
+
+---
+
+## Status
+
+**Complete.**
+
+## LOE
+
+**Medium** (2–3 days)
+
+---
+
+## Goals
+
+- Test paradigm table recall, not just individual word recognition
+- Give immediate, cell-level feedback so students know exactly which forms they missed
+- Reuse the grammar data already in `src/data/grammar.ts` — no new data files required
+- Complement the Grammar Reference (reference) and Parsing & Drills (GNT form recognition)
+
+---
+
+## Features
+
+### 1. Paradigm Selection
+
+Student picks a paradigm to be quizzed on before a session begins.
+
+**Available paradigm categories:**
+
+- **Nouns** — all entries from `nounParadigms` (1st/2nd/3rd declension examples)
+- **Adjectives** — all entries from `adjParadigms` (2-1-2 and 3-1-3 patterns)
+- **Verbs** — all entries from `verbParadigms` (present/imperfect/future/aorist/perfect, active/middle-passive indicative; subjunctive; imperative; participle summary)
+- **Pronouns** — personal (ἐγώ, σύ), demonstrative (οὗτος, ἐκεῖνος), relative (ὅς), interrogative (τίς)
+- **Definite Article** — the article paradigm as a standalone quiz target
+
+**UI:** A selector screen organized by category. Each paradigm is listed by its display name (e.g., "1st Declension Feminine — ἡμέρα"). Includes a "Random" option per category.
+
+---
+
+### 2. Fill-in-the-Blank Mode
+
+The primary quiz mode. Present the full paradigm table with a subset of cells blanked out; student types the missing forms.
+
+**Behavior:**
+- The blanked cells are randomly selected each session (not the same cells every time)
+- **Density options:** Easy (25% of cells blank), Medium (50%), Hard (all cells blank)
+- Student types the Greek form into each blank using the existing Greek keyboard input or transliteration fallback
+- Submit button checks all blanks at once (or per-cell inline checking — see Open Questions)
+- After submission:
+  - Correct cells turn green
+  - Incorrect cells turn red and reveal the correct form alongside the student's input
+  - Score shown: "14 / 20 correct"
+- Student can retry the same paradigm with new blank placement, or switch paradigms
+- Accents are checked strictly — this is a memorization exercise, not a recognition one. Accent errors are marked wrong with a note distinguishing the accent from the consonant/vowel error.
+
+**Greek input:**
+- Each blank cell contains a small text input
+- The global Greek keyboard component attaches to whichever input has focus
+- Transliteration mode (Beta Code or simple romanization) available as an alternative
+
+---
+
+### 3. Full Recall Mode
+
+No cells are pre-filled. Student reconstructs the entire paradigm from scratch.
+
+**Behavior:**
+- The column/row headers are visible (e.g., case labels, number labels, person labels)
+- All form cells are blank inputs
+- Same checking and feedback behavior as Fill-in-the-Blank
+- Intended for advanced drill after the student is comfortable with the paradigm
+
+---
+
+### 4. Spot-the-Error Mode
+
+Show the complete paradigm table but with 3–5 cells intentionally wrong. Student identifies which cells contain errors.
+
+**Behavior:**
+- Student clicks to flag cells they believe are incorrect
+- On submit: correctly flagged cells highlight green, missed errors highlight red, false positives highlight orange
+- Shows the correct form for each flagged cell
+- Useful for students who are close to mastery and need a different angle
+
+---
+
+### 5. Session Progress & Scoring
+
+Lightweight per-session tracking (no persistence needed for V1).
+
+**Behavior:**
+- Score shown as correct/total at the end of each attempt
+- "Best this session" tracked if the student retries the same paradigm
+- No SRS or cross-session tracking in V1 (defer to Flashcard SRS system)
+
+---
+
+## Data Sources
+
+All quiz data derives from existing exports in `src/data/grammar.ts`:
+
+| Paradigm type | Source |
+|---|---|
+| Noun paradigms | `nounParadigms` |
+| Adjective paradigms | `adjParadigms` |
+| Verb paradigms | `verbParadigms`, `infinitiveForms`, `participleRows` |
+| Personal pronouns | `personalPronouns12` |
+| Gendered pronouns | `genderedPronouns` |
+
+No new data files or scripts are required.
+
+---
+
+## Technical Notes
+
+- **Route:** `/paradigms` (new page) — keeps separation from `/grammar` (reference) and `/drills` (GNT parsing)
+- **Component:** `ParadigmQuiz.tsx` — a React island on `src/pages/paradigms.astro`
+- **Shared components:** Reuse `GreekKeyboard.tsx` and the cell/table layout patterns from `GrammarReference.tsx`
+- **State:** All quiz state is local to the component (no `localStorage` needed for V1)
+- **Accent normalization:** The checking function should distinguish accent errors from root form errors in its feedback message. Normalize using Unicode normalization (NFC) before comparison, then separately check if the unaccented forms match to produce the right error label.
+
+---
+
+## Out of Scope
+
+- Cross-session progress tracking or SRS for paradigms (handled by Flashcards)
+- Audio pronunciation
+- Generating paradigm tables programmatically at runtime for arbitrary lemmas
+- Timed quiz modes
+- Leaderboards or sharing scores
+
+---
+
+## Open Questions
+
+- **Per-cell vs. submit-all checking:** Inline checking (as the student types) gives faster feedback but may feel like too much hand-holding in Hard mode. Recommendation: inline for Easy, submit-all for Medium and Hard.
+- **Should Spot-the-Error mode ship in V1?** It's the most novel quiz type but also the most implementation effort. Could defer to V2 if scope is tight.
+- **Route naming:** `/paradigms` vs. `/quiz` vs. adding a tab to `/grammar` — the standalone route makes the feature more discoverable and avoids cluttering the reference page.

--- a/docs/prd/completed/utilities.md
+++ b/docs/prd/completed/utilities.md
@@ -1,0 +1,58 @@
+# PRD: Utilities
+
+## Overview
+
+Small, self-contained tools that round out the site. These are lower priority than the core study features but add meaningful value for students who are typing, writing, or checking their work in Greek.
+
+---
+
+## Status
+
+**Complete.** Transliteration tool implemented in `src/lib/transliteration.ts` and `src/components/Transliteration.tsx`, live at `/transliteration`. Handles SBL scheme bidirectionally including breathing marks, accents, and iota subscripts. Sentence Diagramming Tool extracted to its own PRD (`sentence-diagramming.md`).
+
+---
+
+## Features
+
+### 1. Transliteration Tool
+
+Convert between Greek script and romanized transliteration in both directions.
+
+**Behavior:**
+- Two text areas side by side: Greek | Transliteration
+- Editing either side updates the other in real time
+- Transliteration scheme: Society of Biblical Literature (SBL) standard (most common in academic writing)
+- Handles all diacritics (breathing marks, accents, iota subscript)
+- Copy button on each side
+
+**Use cases:**
+- Student writing a paper who needs the SBL transliteration of a word
+- Student seeing a transliteration in a commentary and wanting the Greek script
+
+### 2. Sentence Diagramming Tool
+
+A lightweight visual tool for diagramming Greek sentences. This is the most complex utility and could be a later addition.
+
+**Behavior:**
+- Student inputs a Greek sentence (via paste or the Greek keyboard)
+- Words are displayed as draggable nodes
+- Student draws connecting lines between nodes and labels them (subject, verb, direct object, modifier, etc.)
+- Save/export as image
+
+**Scope note:** This is significantly more complex than the other utilities. A v1 could be much simpler — just a blank canvas with Greek text blocks the student can arrange manually, with no built-in syntax analysis.
+
+**Dependencies:** Would likely need a diagramming library (e.g., React Flow, Mermaid, or a canvas approach).
+
+---
+
+## Out of Scope for Utilities
+
+- Automated syntactic analysis (parsing sentences programmatically)
+- Morphological lookup (covered in GNT Reader and Parsing Drills)
+
+---
+
+## Priority Notes
+
+- Transliteration is a small, self-contained feature — good candidate for early implementation.
+- Sentence diagramming is a significant undertaking; defer until core study tools are stable. A simple v1 scope (free-form canvas only, no automated analysis) is feasible if the demand is clear.

--- a/docs/prd/flashcard-custom-deck-builder.md
+++ b/docs/prd/flashcard-custom-deck-builder.md
@@ -1,0 +1,77 @@
+# PRD: Flashcard Custom Deck Builder
+
+## Overview
+
+Let students create, name, and save their own vocabulary word lists. Custom decks are stored in `localStorage` and are studyable the same as any built-in deck.
+
+---
+
+## Status
+
+**Not started.**
+
+## LOE
+
+**Medium** (1.5–2 days)
+
+---
+
+## Goals
+
+- Give students full control over what they study
+- Support use cases like "words from this week's passage" or "terms I keep missing"
+- Persist decks across sessions without requiring an account
+
+---
+
+## Features
+
+### 1. Deck Management
+
+A dedicated UI for creating and managing custom decks.
+
+**Behavior:**
+- Student creates a new deck by giving it a name
+- Multiple decks can be saved simultaneously
+- Decks are listed in the deck selector alongside the built-in options
+- Student can rename or delete a deck
+- All deck data stored in `localStorage` under `greek-tools-custom-decks-v1`
+
+---
+
+### 2. Word Picker
+
+A searchable list of the master vocabulary for adding words to a deck.
+
+**Behavior:**
+- Student browses or searches the full vocabulary list (Greek word + gloss + frequency)
+- Checking a word adds it to the active deck
+- Words already in the deck are indicated
+- Bulk-add option: add all words currently visible (filtered by part-of-speech or frequency band) to the deck
+
+---
+
+### 3. Studying a Custom Deck
+
+Custom decks plug into the existing study session the same as any other deck.
+
+**Behavior:**
+- Custom deck is selectable from the deck picker before a session
+- Compatible with SRS, direction toggle, answer modes, and keyboard shortcuts
+- SRS progress for custom deck words is tracked separately from progress in built-in decks
+
+---
+
+## Technical Notes
+
+- **Component:** Extend `Flashcards.tsx` with a deck management view, or extract to a `DeckBuilder.tsx` modal/page
+- **Storage key:** `greek-tools-custom-decks-v1`
+- Words are stored by lemma ID — no duplication of vocabulary data in `localStorage`
+
+---
+
+## Out of Scope
+
+- Sharing decks between users or devices
+- Importing decks from external formats (Anki, CSV, etc.) — see Export to Anki PRD
+- Deck versioning or history

--- a/docs/prd/flashcard-enhancements.md
+++ b/docs/prd/flashcard-enhancements.md
@@ -11,10 +11,10 @@ Extend the existing flashcard tool with smarter study modes, filtering, and prog
 **Partially complete.** Six of eight features shipped:
 - ✅ Feature 1 — Spaced Repetition (SRS)
 - ✅ Feature 2 — Frequency & Part-of-Speech Filters
-- ❌ Feature 3 — Textbook Chapter Sets (not started)
+- ❌ Feature 3 — Frequency-Based Presets (not started) — see `flashcard-frequency-presets.md`
 - ✅ Feature 4 — Answer Modes (flip + type)
 - ✅ Feature 5 — Progress Tracking & Streaks
-- ❌ Feature 6 — Custom Deck Builder (not started)
+- ❌ Feature 6 — Custom Deck Builder (not started) — see `flashcard-custom-deck-builder.md`
 - ✅ Feature 7 — Direction Toggle (Greek → English / English → Greek)
 - ✅ Feature 8 — Keyboard Shortcuts
 
@@ -50,18 +50,20 @@ Let students narrow the deck before starting a session.
 - Active filter count shown on the Filters button
 - Filters reset on page load
 
-### 3. Textbook Chapter Sets
+### 3. Frequency-Based Presets
 
-Pre-built vocabulary lists mapped to common Koine Greek textbooks.
+Pre-built vocabulary sets based on GNT word frequency. All data derived from public domain frequency counts — no textbook licensing required.
 
-**Initial textbooks to support:**
-- Mounce, *Basics of Biblical Greek* (31 chapters)
-- Decker, *Reading Koine Greek* (if chapter word lists are available)
+**Preset ranges:**
+- Top 100 (500+ occurrences)
+- 101–300 (100–499 occurrences)
+- 301–500 (50–99 occurrences)
+- 500+ (<50 occurrences)
 
 **Behavior:**
-- Student selects a textbook and chapter range
-- Deck is scoped to that word list
-- Can be combined with SRS progress tracking
+- Student selects one or more preset ranges from a menu
+- Deck is scoped to words in those frequency bands
+- Can be combined with SRS progress tracking and part-of-speech filters
 
 ### 4. Answer Modes
 
@@ -126,4 +128,3 @@ Desktop keyboard navigation for faster review in Flip mode.
 ## Decisions
 
 - **Fuzzy matching threshold:** Levenshtein distance ≤ 1 for words longer than 3 characters, plus prefix matching (answer is prefix of correct gloss). Handles minor typos without being too lenient.
-- **Textbook chapter data:** Will be bundled in the codebase as a static JSON file.

--- a/docs/prd/flashcard-frequency-presets.md
+++ b/docs/prd/flashcard-frequency-presets.md
@@ -1,0 +1,60 @@
+# PRD: Flashcard Frequency-Based Presets
+
+## Overview
+
+Pre-built vocabulary sets scoped to GNT word frequency bands, selectable before a study session. All data derived from public domain frequency counts — no textbook licensing required.
+
+---
+
+## Status
+
+**Not started.**
+
+## LOE
+
+**Small** (0.5–1 day)
+
+---
+
+## Goals
+
+- Let students scope their deck to a meaningful frequency band without manually configuring filters
+- Complement the existing Frequency & Part-of-Speech Filters (Feature 2) with a one-tap starting point
+- Remain fully public domain — no dependency on any copyrighted textbook's chapter structure
+
+---
+
+## Features
+
+### 1. Preset Selector
+
+A menu or button group shown in the deck setup area before a session begins.
+
+**Preset ranges:**
+- Top 100 (500+ occurrences)
+- 101–300 (100–499 occurrences)
+- 301–500 (50–99 occurrences)
+- 500+ (<50 occurrences)
+
+**Behavior:**
+- Student selects one or more preset ranges
+- Deck is immediately scoped to words in those frequency bands
+- Selection is combinable with the existing part-of-speech filter toggles
+- Presets reset on page load (same behavior as other filters)
+- Active preset shown in the filter summary badge
+
+---
+
+## Technical Notes
+
+- Frequency data already exists in the vocabulary dataset — no new data files needed
+- Preset ranges map directly to the existing frequency filter ranges in Feature 2; this feature is essentially named shortcuts over the same filter logic
+- **Component:** Extend the existing filter panel in `Flashcards.tsx`
+
+---
+
+## Out of Scope
+
+- Custom frequency range input (handled by the existing filter sliders)
+- Textbook chapter mappings
+- Saving a preset as a named deck (covered by Custom Deck Builder PRD)

--- a/docs/prd/sentence-diagramming.md
+++ b/docs/prd/sentence-diagramming.md
@@ -1,0 +1,98 @@
+# PRD: Sentence Diagramming Tool
+
+## Overview
+
+A lightweight visual tool for diagramming Greek sentences. Students input a Greek sentence, arrange words as draggable nodes on a canvas, draw connecting lines between nodes, and label the relationships. Useful for students working through syntax and clause structure in exegesis.
+
+---
+
+## Status
+
+**Not started.**
+
+## LOE
+
+**Large** (3–5 days for a simple v1)
+
+---
+
+## Goals
+
+- Give students a visual workspace for analyzing Greek sentence structure
+- Keep v1 simple — free-form canvas with no automated syntax analysis
+- Support save/export so students can use diagrams in papers or study notes
+
+---
+
+## Features
+
+### 1. Sentence Input
+
+Student pastes or types a Greek sentence into an input area. The Greek keyboard component is available for input.
+
+**Behavior:**
+- On submit, each word becomes a draggable node on the canvas
+- Words retain their original Greek text including diacritics
+- Student can manually add or remove nodes after the initial parse
+
+---
+
+### 2. Draggable Word Nodes
+
+Each word is displayed as a labeled node that can be freely positioned on the canvas.
+
+**Behavior:**
+- Nodes are drag-and-drop repositionable
+- Node label shows the Greek word form
+- Optional: small secondary label below for gloss or parsing tag (student-entered)
+- Nodes snap to a loose grid to keep alignment manageable
+
+---
+
+### 3. Connecting Lines & Labels
+
+Student draws lines between nodes to represent syntactic relationships and labels them.
+
+**Behavior:**
+- Click a node then click another to draw a connecting line
+- Line label is editable: subject, verb, direct object, indirect object, modifier, prepositional phrase, relative clause, etc.
+- Lines can be deleted by clicking them
+- Visual style: straight lines with an arrowhead indicating direction (head → dependent)
+
+---
+
+### 4. Export
+
+Student can save the finished diagram.
+
+**Behavior:**
+- Export as PNG image (canvas screenshot)
+- No server-side storage — diagram data lives in the browser only
+- Optional: save/restore diagram state via `localStorage` for the current session
+
+---
+
+## Technical Notes
+
+- **Route:** `/diagram` (new page)
+- **Component:** `SentenceDiagram.tsx`
+- **Diagramming library options:** React Flow (most full-featured), or a lightweight canvas approach with `konva` / plain HTML canvas. React Flow is the recommendation given it handles drag, connections, and labels natively.
+- **Shared components:** Reuse `GreekKeyboard.tsx` for sentence input
+
+---
+
+## Out of Scope
+
+- Automated syntactic analysis or morphological parsing
+- Reed-Kellogg style traditional diagramming (complex to implement, less useful for Greek)
+- Cloud save or account-based storage
+- Collaborative/shared diagrams
+- Timed or graded modes
+
+---
+
+## Open Questions
+
+- Should nodes show a gloss automatically (pulled from the vocabulary data) or only what the student types?
+- React Flow vs. plain canvas: React Flow is faster to build but adds ~200kb to the bundle. Worth evaluating bundle impact before committing.
+- Should v1 support clause-level grouping (visually boxing subordinate clauses), or is free-form node placement sufficient?


### PR DESCRIPTION
## Summary

- Moves 9 completed PRDs into `docs/prd/completed/`
- Fixes `paradigm-quiz.md` status (was "Not started", feature is fully implemented)
- Splits `utilities.md` into completed (transliteration) + new `sentence-diagramming.md` PRD
- Replaces Textbook Chapter Sets with copyright-safe Frequency-Based Presets in flashcard PRD
- Extracts flashcard Features 3 and 6 into standalone PRDs (`flashcard-frequency-presets.md`, `flashcard-custom-deck-builder.md`)

## Test plan

- [ ] Verify `docs/prd/completed/` contains 9 PRDs all marked Complete
- [ ] Verify remaining PRDs in `docs/prd/` accurately reflect in-progress or not-started work

🤖 Generated with [Claude Code](https://claude.com/claude-code)