### PR TITLE
feat(grammar): sticky segmented section nav for mobile

### DIFF
--- a/docs/prd/alphabet-guide.md
+++ b/docs/prd/alphabet-guide.md
@@ -1,0 +1,81 @@
+# PRD: Greek Alphabet & Manuscript Guide
+
+## Overview
+
+An interactive guide to the Greek alphabet covering printed letter forms, stroke order for handwriting, the names and phonetic values of each letter, and a sampling of common manuscript letter forms. Useful for beginners learning to write Greek and for anyone curious about how letters look in actual manuscripts.
+
+---
+
+## Goals
+
+- Give beginners a clear, interactive reference for learning the alphabet
+- Show stroke order to help students develop legible Greek handwriting
+- Provide a brief introduction to manuscript letter forms for students moving into textual criticism or exegesis
+
+---
+
+## Priority
+
+Low
+
+---
+
+## Features
+
+### 1. Alphabet Table
+
+A clean table of all 24 Greek letters showing:
+- Uppercase and lowercase printed forms
+- Letter name (e.g., α = alpha)
+- Erasmian phonetic value
+- Rough English equivalent sound
+- Letter's numeric value (Greek numerals)
+
+### 2. Stroke Order Animations
+
+For each lowercase letter, a simple CSS/SVG animation showing stroke order.
+
+**Behavior:**
+- Click or tap a letter to trigger the stroke animation
+- Animation plays at readable speed; can be replayed
+- Particularly useful for letters students commonly write incorrectly (ξ, ψ, γ, χ)
+
+### 3. Diacritics Guide
+
+A sub-section explaining the diacritical marks used in polytonic Greek:
+- Breathing marks: smooth (᾿) and rough (῾)
+- Accent marks: acute (´), grave (`), circumflex (ˆ)
+- Iota subscript (ᾳ, ῃ, ῳ)
+- Dieresis (ϊ, ϋ)
+- Where each mark sits relative to the letter
+- How they combine (e.g., ᾶ = alpha + circumflex + smooth breathing)
+
+### 4. Manuscript Forms
+
+A brief gallery showing how each letter appears in major manuscript styles:
+- Uncial (all-caps, used in early manuscripts like Codex Sinaiticus)
+- Minuscule (cursive lowercase, used in later manuscripts)
+
+**Scope:** One representative image per letter for each style. Sourced from public domain manuscript images.
+
+---
+
+## Out of Scope
+
+- Full paleography course
+- Interactive manuscript reading exercises
+- Hebrew alphabet (separate tool if ever needed)
+
+---
+
+## Technical Notes
+
+- Stroke order animations can be implemented as SVG path animations with `stroke-dashoffset` technique — no external library needed
+- Manuscript images must be sourced from public domain collections (e.g., Codex Sinaiticus Project, British Library digitized manuscripts)
+
+---
+
+## Open Questions
+
+- Should Erasmian pronunciation be the only system shown, or should Restored Koine be included here? (See also: Pronunciation Guide PRD)
+- Is the manuscript forms section useful enough for the target audience (GNT students) to include in v1, or should it be deferred?

--- a/docs/prd/case-uses-reference.md
+++ b/docs/prd/case-uses-reference.md
@@ -1,0 +1,159 @@
+# PRD: Case Uses Reference
+
+## Overview
+
+A syntax reference covering the major uses of the Greek cases with definitions, GNT examples, and brief exegetical notes. Focuses on the Nominative and Accusative in v1, with Genitive, Dative, and Vocative to follow.
+
+Distinct from the Grammar Reference (which covers paradigm forms/morphology), this page covers function: what a case signals about a word's role in the sentence.
+
+---
+
+## Placement
+
+**Route:** `/syntax` — a new top-level page for syntactical reference material.
+
+This page is the first section of a planned Syntax Reference that will eventually include:
+1. Case uses (this PRD — Nominative + Accusative in v1)
+2. Genitive, Dative, and Vocative uses (future PRD)
+3. Syntax constructions: genitive absolute, indirect statement, conditionals, etc. (see `syntax-constructions.md`)
+
+The `/syntax` route gives this content room to grow without crowding the Grammar Reference.
+
+---
+
+## Priority
+
+Medium
+
+---
+
+## Features
+
+### 1. Navigation
+
+A sidebar (matching the Grammar Reference layout) with anchor links to each case section. On mobile, a horizontal scroll pill nav.
+
+Within each case, sub-links for each use category.
+
+---
+
+### 2. Nominative Uses
+
+#### Subject Nominative
+The standard use. The nominative identifies the subject of a finite verb.
+
+> **GNT example:** ὁ **θεός** ἀγαπᾷ τὸν κόσμον — "**God** loves the world" (John 3:16)
+
+#### Predicate Nominative
+A nominative that renames or describes the subject, linked by a copulative verb (εἰμί, γίνομαι, etc.). Both subject and predicate are nominative; the subject is typically the more definite noun.
+
+> **GNT example:** ὁ **λόγος** ἦν **θεός** — "the Word was **God**" (John 1:1)
+>
+> *Note:* The anarthrous predicate nominative (θεός without the article) is the basis of significant exegetical debate about John 1:1c.
+
+#### Nominative Absolute (Hanging Nominative / *Nominativus Pendens*)
+A nominative that stands outside the grammatical structure of the sentence, introducing a topic that is then resumed by a pronoun in a different case. Common in John and Revelation.
+
+> **GNT example:** ὁ νικῶν, δώσω αὐτῷ — "**The one who overcomes** — I will give to **him**..." (Rev 2:26)
+>
+> *Note:* ὁ νικῶν is nominative but has no grammatical role in the main clause; αὐτῷ (dative) resumes it. This is a Semitic construction reflecting Hebrew/Aramaic influence.
+
+#### Nominative of Address
+A nominative used as a form of direct address, functioning like the vocative. Especially common in John's Gospel.
+
+> **GNT example:** ναί, **κύριε** (vocative) vs. **κύριος** used in similar address contexts.
+>
+> *Note:* The line between nominative of address and true vocative is sometimes blurry; both signal direct address.
+
+#### Nominative of Appellation
+Proper names and titles used in nominative form regardless of syntactic function. Particularly common with indeclinable Hebrew names.
+
+> **GNT example:** The name Ἰσραήλ is often used as a nominative of appellation rather than following case requirements strictly.
+
+---
+
+### 3. Accusative Uses
+
+#### Direct Object
+The standard use. The accusative receives the action of a transitive verb.
+
+> **GNT example:** ἠγάπησεν ὁ θεὸς τὸν **κόσμον** — "God loved the **world**" (John 3:16)
+
+#### Double Accusative — Person and Thing
+Some verbs take two accusative objects: one for the person and one for the thing. Common with verbs of teaching, asking, and clothing.
+
+> **GNT example (διδάσκω):** ταῦτα ἐδίδασκεν... — teaching **them** **these things** (cf. John 14:26)
+>
+> *Key verbs:* διδάσκω (teach), αἰτέω (ask), ἐνδύω (clothe), ὑπομιμνῄσκω (remind)
+
+#### Double Accusative — Object and Complement
+A verb takes an accusative object and an accusative complement that predicates something of the object. The complement renames or describes the object.
+
+> **GNT example:** θήσω αὐτὸν **υἱόν** — "I will make him my **Son**" (Heb 1:5, allusion to Ps 2:7)
+>
+> *Key verbs:* καλέω (call), τίθημι (make, appoint), ποιέω (make)
+
+#### Cognate Accusative
+An accusative direct object formed from the same root as the verb (or closely related). Intensifies or specifies the verbal action. A Hebraism, common in the Septuagint and John.
+
+> **GNT example:** ἐφοβήθησαν **φόβον μέγαν** — "they feared **a great fear**" (Mark 4:41)
+>
+> *Note:* φόβον (accusative) is cognate with ἐφοβήθησαν (verb). This mirrors the Hebrew infinitive absolute construction.
+
+#### Accusative of Extent of Time
+The accusative answers the question "how long?" — the duration of an action.
+
+> **GNT example:** ἔμεινεν ἐκεῖ **δύο ἡμέρας** — "he stayed there **two days**" (John 4:40)
+
+#### Accusative of Extent of Space
+The accusative answers the question "how far?" — the distance covered by a movement.
+
+> **GNT example:** ἀπῆλθεν ὡς **λίθου βολήν** — "he withdrew about **a stone's throw**" (Luke 22:41)
+
+#### Accusative of Respect / Reference
+The accusative limits or specifies in what respect an adjective or verb applies. Sometimes called the "Greek accusative of specification."
+
+> **GNT example:** τυφλοὺς **τοὺς ὀφθαλμούς** — "blind **with respect to the eyes**"
+>
+> *Note:* Less common in the GNT than in classical Greek; appears most often in set phrases.
+
+#### Accusative as Subject of Infinitive
+In indirect discourse with an infinitive, the subject of the infinitive is put in the accusative case.
+
+> **GNT example:** νομίζουσιν... **αὐτοὺς** εἶναι σοφούς — "they think **them** to be wise" (Rom 1:22, loosely)
+>
+> *Note:* αὐτούς is the accusative subject of the infinitive εἶναι. This is one of the three constructions for indirect discourse in Greek (ὅτι clause, infinitive, participle).
+
+---
+
+### 4. Display Format
+
+Each use is presented as a card containing:
+- **Name** of the use (bold heading)
+- **One-sentence definition**
+- **GNT example** — Greek text with the relevant word(s) bolded, followed by a translation
+- **Reference** — displayed as a link that opens the GNT Reader at that passage (e.g., clicking "John 3:16" navigates to `/reader?ref=John.3.16`)
+- **Exegetical note** where the syntax has interpretive significance (optional, collapsible)
+
+Cards within each case section are linked from the sidebar for direct navigation.
+
+**Dependency:** GNT Reader links will be live once the GNT Reader is built. Until then, references are displayed as plain text.
+
+---
+
+## Out of Scope (v1)
+
+- Genitive, Dative, and Vocative uses (follow-on PRD)
+- Vocative of address beyond what is noted under Nominative of Address
+- Parsing exercises for case identification (covered by Parsing Drills PRD)
+
+---
+
+## Decisions
+
+- **GNT Reader links:** Each example reference links to the GNT Reader at that passage. Links are plain text until the GNT Reader is built.
+
+## Open Questions
+
+- Should exegetical notes be shown by default or hidden behind a "Show note" toggle to keep the cards scannable?
+- Should this page also cover the **article** as a separate section (its use as pronoun, with participles, etc.) since it is closely tied to case usage?

--- a/docs/prd/contract-verb-reference.md
+++ b/docs/prd/contract-verb-reference.md
@@ -1,0 +1,87 @@
+# PRD: Contract Verb Reference
+
+## Overview
+
+A reference page explaining the contraction rules for epsilon-, alpha-, and omicron-contract verbs, with the resulting paradigm forms for each contract class. Contract verbs are among the most confusing forms for intermediate students because the contracted endings often mask the underlying tense stem.
+
+---
+
+## Goals
+
+- Explain the three contraction rules clearly with a visual mapping
+- Show the resulting contracted forms for each class alongside the uncontracted forms
+- Let students see exactly which ending produced which contracted result
+
+---
+
+## Priority
+
+Medium
+
+---
+
+## Features
+
+### 1. Contraction Rules Tables
+
+Three tables, one per contract class, showing vowel + ending → contracted result.
+
+**Epsilon contracts (φιλέω):**
+- ε + ε → ει
+- ε + ο → ου
+- ε + any long vowel or diphthong → long vowel/diphthong absorbs ε
+
+**Alpha contracts (ἀγαπάω):**
+- α + ε → α (long)
+- α + ο → ω
+- α + ει → α (long)
+
+**Omicron contracts (πληρόω):**
+- ο + ε → ου
+- ο + ο → ου
+- ο + any vowel → ω
+
+Each table shows: stem vowel + ending → result, displayed in a clean two-column format.
+
+### 2. Full Contracted Paradigms
+
+For each contract class, show the full present active indicative in both uncontracted (intermediate) and contracted (actual) forms side by side, so students can see the transformation.
+
+**Example for φιλέω:**
+
+| Person | Uncontracted | Contracted |
+|--------|--------------|------------|
+| 1sg | φιλέ-ω | φιλῶ |
+| 2sg | φιλέ-εις | φιλεῖς |
+| 3sg | φιλέ-ει | φιλεῖ |
+| 1pl | φιλέ-ομεν | φιλοῦμεν |
+| 2pl | φιλέ-ετε | φιλεῖτε |
+| 3pl | φιλέ-ουσι | φιλοῦσι(ν) |
+
+Cover present active and middle/passive indicative for all three classes. Include present infinitive and participle.
+
+### 3. Key Principle Callout
+
+A highlighted note explaining: contract verbs are regular in all tenses except the present and imperfect — in all other tenses the stem vowel lengthens and the verb conjugates like a standard -ω verb (φιλέω → φιλήσω, etc.).
+
+### 4. Model Verbs
+
+| Class | Model Verb | Gloss | GNT Frequency |
+|-------|------------|-------|---------------|
+| ε-contract | φιλέω | I love | 25× |
+| α-contract | ἀγαπάω | I love | 143× |
+| ο-contract | πληρόω | I fill, fulfill | 86× |
+
+---
+
+## Out of Scope
+
+- Contract nouns
+- Liquid verbs (separate topic)
+
+---
+
+## Open Questions
+
+- Should this be a sub-section of the Grammar Reference or its own page?
+- Is the side-by-side uncontracted/contracted display the clearest way to present this, or would a step-by-step animated breakdown be more useful?

--- a/docs/prd/deponent-verb-list.md
+++ b/docs/prd/deponent-verb-list.md
@@ -1,0 +1,76 @@
+# PRD: Deponent Verb List
+
+## Overview
+
+A reference list of common deponent and middle-only verbs in the GNT, with explanations of their forms and meanings. Deponents confuse students because they appear middle or passive in form but translate as active — without a reference, students may think they've parsed incorrectly.
+
+---
+
+## Goals
+
+- Help students recognize deponent verbs on sight when reading
+- Explain why a verb is deponent and what that means practically
+- Cover all high-frequency deponents in the GNT
+
+---
+
+## Priority
+
+Low
+
+---
+
+## Background
+
+A "deponent" verb has no active voice forms (in some or all tenses) but carries an active meaning. Grammarians debate whether "deponent" is the right term (some prefer "middle-only" or "active-meaning middle"), but for practical reading purposes the key fact is: these verbs look middle/passive but translate as active.
+
+---
+
+## Features
+
+### 1. Deponent Verb Table
+
+A reference table of common GNT deponent verbs.
+
+**Columns:** Lexical form | Gloss | Deponent in | Notes | GNT Frequency
+
+**Sample entries:**
+
+| Verb | Gloss | Deponent in | Notes |
+|------|-------|-------------|-------|
+| ἔρχομαι | I come, go | All tenses | Future: ἐλεύσομαι; Aorist: ἦλθον |
+| γίνομαι | I become, am | All tenses | Very high frequency; aorist ἐγενόμην |
+| ἀποκρίνομαι | I answer | All tenses | Compound of κρίνω |
+| δέχομαι | I receive | All tenses | Aorist ἐδεξάμην |
+| ἐργάζομαι | I work | All tenses | |
+| εὐαγγελίζομαι | I preach the gospel | All tenses | |
+| πορεύομαι | I go, travel | All tenses | Very common in Luke-Acts |
+| προσεύχομαι | I pray | All tenses | |
+| ὄψομαι | see ὁράω | Future only | Future deponent of ὁράω |
+| λήμψομαι | see λαμβάνω | Future only | Future deponent of λαμβάνω |
+
+### 2. Explanatory Note
+
+A brief introductory section explaining:
+- What "deponent" means and why these verbs look the way they do
+- The difference between fully deponent (no active forms in any tense) and partially deponent (active in some tenses, middle/passive in others)
+- A note on the ongoing scholarly debate about the term "deponent" and what it may actually signal about the middle voice in Koine Greek
+
+### 3. Filtering
+
+Filter the table by:
+- Fully deponent vs. partially deponent
+- By part of speech or semantic category (movement verbs, speech verbs, etc.)
+
+---
+
+## Out of Scope
+
+- A full treatment of the Greek middle voice (a grammar reference topic, not a list)
+- Passive deponents (verbs with passive form but active meaning, e.g., some uses of ἀποκαλύπτομαι)
+
+---
+
+## Open Questions
+
+- Should this reference use the traditional term "deponent" or a more current term like "middle-only verb"? Consider mirroring the terminology used by the most common textbooks (Mounce uses "deponent").

--- a/docs/prd/gnt-book-statistics.md
+++ b/docs/prd/gnt-book-statistics.md
@@ -1,0 +1,84 @@
+# PRD: GNT Book Statistics
+
+## Overview
+
+A data dashboard showing vocabulary and frequency statistics for each of the 27 NT books. Helps students understand the scope of the GNT, identify which books are most accessible given their current vocabulary, and motivate continued study with concrete coverage metrics.
+
+---
+
+## Goals
+
+- Give students a bird's-eye view of the GNT's vocabulary profile
+- Surface which books are most accessible at different vocabulary levels
+- Make the data interesting and browsable, not just utilitarian
+
+---
+
+## Priority
+
+Low
+
+---
+
+## Features
+
+### 1. Book Statistics Table
+
+A sortable table with one row per NT book.
+
+**Columns:**
+- Book name
+- Total word count
+- Unique lemmas
+- % of words from the top 100 GNT lemmas
+- % of words from the top 500 GNT lemmas
+- Hapax legomena count (words appearing only once in the GNT)
+- Estimated difficulty (derived from vocabulary frequency profile)
+
+**Default sort:** NT canonical order (Matthew → Revelation)
+**Sort options:** Difficulty (easy → hard), word count, unique lemmas
+
+### 2. Difficulty Bar Chart
+
+A horizontal bar chart visualizing each book's vocabulary difficulty, colored by NT section (Gospels, Acts, Pauline letters, General letters, Revelation).
+
+**Behavior:**
+- Hover a bar to see the full stats for that book
+- Click to jump to the book detail view (see below)
+
+### 3. Book Detail View
+
+Clicking a book opens a detail panel or sub-page showing:
+- The 20 most frequent words unique to that book (not in the top 500 overall)
+- Distribution chart: how many words occur 1×, 2–5×, 6–10×, 10+× in this book
+- "Start reading this book" → opens GNT Reader at chapter 1
+
+### 4. Vocabulary Coverage Calculator
+
+An interactive slider: "If you know the top ___ GNT words, you can read ___% of [selected book]."
+
+**Behavior:**
+- Slider from 50 to 5,000 words
+- Per-book coverage updates in real time
+- Summary line: "You'd encounter an unknown word roughly every ___ words"
+
+---
+
+## Dependencies
+
+- MorphGNT dataset (for per-book word frequency data)
+- Vocabulary frequency data (already partially in `src/data/vocabulary.ts`)
+
+---
+
+## Out of Scope
+
+- Syntactic complexity metrics
+- Comparison with LXX or other Greek texts
+
+---
+
+## Open Questions
+
+- Should the book statistics be pre-computed at build time (from MorphGNT) and stored as a static JSON, or computed client-side from the MorphGNT data? Pre-computation is much faster at runtime.
+- Is "difficulty" best expressed as a single number, a letter grade, or left as raw coverage percentages?

--- a/docs/prd/mi-verb-paradigms.md
+++ b/docs/prd/mi-verb-paradigms.md
@@ -1,0 +1,78 @@
+# PRD: μι-Verb Paradigms
+
+## Overview
+
+Reference tables for the major μι-verbs in the GNT. These verbs follow a different conjugation pattern from the standard -ω verbs and are consistently difficult for intermediate students because they appear frequently in the text but aren't covered by the λύω paradigm.
+
+---
+
+## Goals
+
+- Give students a dedicated reference for μι-verb forms alongside the standard Grammar Reference
+- Cover the four highest-frequency μι-verbs in the GNT
+- Use the same table format and interaction model as the existing Grammar Reference
+
+---
+
+## Priority
+
+Medium-High
+
+---
+
+## Verbs to Cover
+
+| Verb | Gloss | GNT Frequency |
+|------|-------|---------------|
+| δίδωμι | I give | 415× |
+| τίθημι | I place, put | 100× |
+| ἵστημι | I stand, set | 154× |
+| ἀφίημι | I forgive, release, permit | 143× |
+
+---
+
+## Features
+
+### 1. Paradigm Tables
+
+For each verb, display the following tense/mood combinations:
+
+- Present active/middle-passive indicative
+- Imperfect active/middle-passive indicative
+- Present active subjunctive
+- Present active imperative
+- Present active/passive infinitive
+- Present active participle (nominative singular M/F/N)
+- Aorist active/middle/passive indicative (including 2nd aorist forms where applicable)
+- Aorist active/middle/passive infinitive and participle
+
+**Behavior:**
+- Same card layout, navy header, hover description bar as Grammar Reference paradigm tables
+- Each table labelled clearly with verb + tense/mood
+- Note where a μι-verb uses a 2nd aorist (e.g., ἵστημι aorist ἔστην)
+
+### 2. Pattern Notes
+
+A brief callout per verb explaining the key pattern differences from -ω verbs:
+
+- Reduplication in present stem (δι-δω-, τι-θη-, ἵ-στη-)
+- Athematic personal endings in present/imperfect (-μι, -ς, -σι vs. -ω, -εις, -ει)
+- Alternating long/short stem vowels (δίδωμι / δίδομεν)
+
+### 3. Integration with Grammar Reference
+
+Add a "μι-Verbs" section to the Grammar Reference sidebar navigation, or link from the Verbs section to a dedicated `/grammar/mi-verbs` sub-route.
+
+---
+
+## Out of Scope
+
+- Full declension of all μι-verb forms across all moods (comprehensive coverage deferred; focus on the most common forms)
+- εἰμί (handled separately as a special case; could be added as a 5th entry later)
+
+---
+
+## Open Questions
+
+- Should μι-verbs be a sub-section within `/grammar` or a separate page?
+- Should εἰμί be included in this feature or treated separately?

--- a/docs/prd/passage-difficulty-estimator.md
+++ b/docs/prd/passage-difficulty-estimator.md
@@ -1,0 +1,85 @@
+# PRD: Passage Difficulty Estimator
+
+## Overview
+
+Enter a GNT passage reference and get a difficulty score based on the vocabulary frequency profile of that passage. Helps students know which texts to tackle next as they build their vocabulary, and gives instructors a tool for sequencing reading assignments.
+
+---
+
+## Goals
+
+- Give students a data-driven answer to "am I ready to read this passage?"
+- Visualize vocabulary coverage at different knowledge thresholds
+- Recommend what vocabulary to study before tackling a passage
+
+---
+
+## Priority
+
+Medium
+
+---
+
+## Features
+
+### 1. Passage Input
+
+Student enters a passage reference (e.g., Romans 8:1–17) using a book/chapter/verse selector or typed reference.
+
+**Behavior:**
+- Pulls word list from MorphGNT dataset (shared with GNT Reader)
+- Deduplicates by lemma (counts unique vocabulary items, not raw word count)
+
+### 2. Difficulty Score
+
+Display a difficulty rating based on the vocabulary frequency profile.
+
+**Metrics shown:**
+- Total words in passage
+- Unique lemmas
+- % of words in the top 100 GNT lemmas
+- % of words in the top 200, 500, 1000
+- Estimated % readable if student knows top N words (shown as a bar chart)
+
+**Example output for John 3:16:**
+- 25 words, 20 unique lemmas
+- 80% covered by top 100 words
+- 95% covered by top 300 words
+- Unknown words at top-100 level: ἀγαπάω, μονογενής, ἀπόλλυμι, αἰώνιος
+
+### 3. Unknown Word List
+
+For any given vocabulary threshold (e.g., "top 200 words"), show the list of words in the passage that fall outside that threshold — these are the words to study before reading.
+
+**Behavior:**
+- Each unknown word links to its Flashcard entry
+- "Study these words" button loads them as a custom Flashcard deck
+
+### 4. Comparative Difficulty
+
+Show how the passage compares to other GNT books/sections:
+
+- "This passage is easier than 72% of GNT passages"
+- Small histogram showing where the passage falls in the overall GNT difficulty distribution
+
+---
+
+## Dependencies
+
+- MorphGNT dataset (for passage word lists and lemmas)
+- Vocabulary frequency data (already in `src/data/vocabulary.ts`, may need expansion)
+- Flashcards custom deck feature (for the "Study these words" action)
+
+---
+
+## Out of Scope
+
+- Syntactic difficulty (sentence length, subordinate clause density) — vocabulary only in v1
+- Non-GNT texts (LXX, patristics)
+
+---
+
+## Open Questions
+
+- What vocabulary threshold should be the default display? Top 200 (covers ~90% of GNT) seems reasonable as a starting point.
+- Should difficulty be presented as a letter grade (A–F), a numeric score, or purely as the raw coverage percentages?

--- a/docs/prd/principal-parts-reference.md
+++ b/docs/prd/principal-parts-reference.md
@@ -1,0 +1,92 @@
+# PRD: Principal Parts Reference Table
+
+## Overview
+
+A comprehensive lookup table of the six principal parts for the most common irregular verbs in the GNT. This is a reference companion to the Principal Parts Drill (see `parsing-drills.md`) — students use this to look up forms when reading, the drill to practice producing them from memory.
+
+---
+
+## Goals
+
+- Give students a single place to look up any common irregular verb's principal parts
+- Cover the ~100 highest-frequency irregular verbs in the GNT
+- Make the table filterable and searchable
+
+---
+
+## Priority
+
+Medium
+
+---
+
+## The Six Principal Parts
+
+| # | Tense/Voice/Mood | Example (λύω) |
+|---|-----------------|---------------|
+| 1 | Present Active Indicative 1sg | λύω |
+| 2 | Future Active Indicative 1sg | λύσω |
+| 3 | Aorist Active Indicative 1sg | ἔλυσα |
+| 4 | Perfect Active Indicative 1sg | λέλυκα |
+| 5 | Perfect Middle/Passive Indicative 1sg | λέλυμαι |
+| 6 | Aorist Passive Indicative 1sg | ἐλύθην |
+
+A dash (—) indicates the form does not occur in the GNT or does not exist for that verb.
+
+---
+
+## Features
+
+### 1. Full Principal Parts Table
+
+A sortable, searchable table with one row per verb.
+
+**Columns:** Lexical form | Gloss | PP1 | PP2 | PP3 | PP4 | PP5 | PP6
+
+**Sample rows:**
+
+| Lexical | Gloss | PP1 | PP2 | PP3 | PP4 | PP5 | PP6 |
+|---------|-------|-----|-----|-----|-----|-----|-----|
+| ἄγω | I lead | ἄγω | ἄξω | ἤγαγον | — | ἦγμαι | ἤχθην |
+| αἴρω | I take up | αἴρω | ἀρῶ | ἦρα | ἦρκα | ἦρμαι | ἤρθην |
+| βάλλω | I throw | βάλλω | βαλῶ | ἔβαλον | βέβληκα | βέβλημαι | ἐβλήθην |
+| γινώσκω | I know | γινώσκω | γνώσομαι | ἔγνων | ἔγνωκα | ἔγνωσμαι | ἐγνώσθην |
+| ἔρχομαι | I come | ἔρχομαι | ἐλεύσομαι | ἦλθον | ἐλήλυθα | — | — |
+| ὁράω | I see | ὁράω | ὄψομαι | εἶδον | ἑώρακα | — | ὤφθην |
+| λέγω | I say | λέγω | ἐρῶ | εἶπον | εἴρηκα | εἴρημαι | ἐρρέθην |
+
+### 2. Search and Filter
+
+**Behavior:**
+- Search by any form (type any of the six parts, get the full row)
+- Filter by: has 2nd aorist, deponent, missing forms
+- Sort by GNT frequency of the lexical form (default) or alphabetically
+
+### 3. Click-to-Study Link
+
+Each row links to the Principal Parts Drill pre-loaded with that verb, so students can go straight from lookup to practice.
+
+---
+
+## Data
+
+The ~100 verb list should prioritize:
+1. Verbs occurring 50+ times in the GNT
+2. Verbs with irregular (non-sigma) principal parts
+3. Verbs whose parts differ significantly from the lexical form (e.g., ὁράω → εἶδον)
+
+Regular verbs (predictable sigma aorist, kappa perfect) can be omitted as they add little reference value.
+
+---
+
+## Out of Scope
+
+- Full paradigm generation from principal parts (covered by Grammar Reference)
+- Deponent verb explanations (covered by Deponent Verb List PRD)
+
+---
+
+## Open Questions
+
+- Should the table be paginated or fully loaded at once? (~100 rows is manageable as a single table with client-side filtering.)
+- Should PP forms link to the GNT Reader to show occurrences in context?

--- a/docs/prd/pronunciation-guide.md
+++ b/docs/prd/pronunciation-guide.md
@@ -1,0 +1,87 @@
+# PRD: Pronunciation Guide
+
+## Overview
+
+A reference explaining the major Greek pronunciation systems used in academic and church settings, with phonetic breakdowns for each letter and diphthong. Students often encounter conflicting pronunciations from different professors and resources — this gives them a clear, side-by-side comparison.
+
+---
+
+## Goals
+
+- Clarify the differences between Erasmian and Restored Koine pronunciation
+- Give students the phonetic value of every letter and diphthong in each system
+- Be practical and opinionated rather than exhaustively academic
+
+---
+
+## Priority
+
+Low
+
+---
+
+## Pronunciation Systems Covered
+
+### Erasmian
+The most widely taught system in North American seminaries. Based on a reconstruction by Erasmus in the 16th century. Distinguishes sounds that had merged in later Koine (e.g., η ≠ ι). Practical for distinguishing forms when reading aloud.
+
+### Restored Koine (also called "Koine" or "Reconstructed")
+An attempt to reconstruct how Greek was actually pronounced in the 1st century CE, the time of the New Testament. Η and ι are both pronounced like "ee." Used by some professors and increasingly popular in newer curricula (e.g., Dobson, some Mounce supplements).
+
+### Modern Greek
+How Greek is pronounced today. Similar to Restored Koine in many ways. Occasionally referenced in academic contexts.
+
+---
+
+## Features
+
+### 1. Pronunciation Comparison Table
+
+A table with one row per letter/diphthong, three columns for the three systems.
+
+| Letter | Erasmian | Restored Koine | Modern Greek |
+|--------|----------|----------------|--------------|
+| α | "ah" (short/long distinction) | "ah" | "ah" |
+| η | "ay" (as in "they") | "ee" | "ee" |
+| ι | "ih" (short) / "ee" (long) | "ee" | "ee" |
+| υ | "oo" (like French "u") | "ee" | "ee" |
+| αι | "eye" | "eh" | "eh" |
+| ει | "ay" | "ee" | "ee" |
+| … | … | … | … |
+
+### 2. Letter-by-Letter Phonetic Guide
+
+For each letter, show:
+- The letter name (in Greek and English)
+- Its phonetic value in IPA notation for each system
+- A common English word that approximates the sound
+- Any special rules (e.g., γ before γ/κ/χ/ξ = "ng")
+
+### 3. Special Rules Section
+
+Rules that apply regardless of system:
+- Gamma nasal (γγ, γκ, γχ, γξ = "ng" sound)
+- Rough breathing = "h" sound before the vowel
+- Double consonants
+- Silent iota subscript (affects meaning/form but not pronunciation in most systems)
+
+### 4. Which System Should I Use?
+
+A brief, practical recommendation section:
+- If your professor uses Erasmian, use Erasmian — consistency with your class matters most
+- Restored Koine is increasingly considered more historically accurate
+- Both systems are intelligible in academic settings; neither is "wrong"
+
+---
+
+## Out of Scope
+
+- Audio recordings (would require hosting; deferred unless hosting is available)
+- Byzantine/Medieval Greek
+
+---
+
+## Open Questions
+
+- Without audio, how much of this is actually useful? Consider whether this PRD should be parked until audio support is feasible.
+- Should the site take a position on which system is preferred, or remain neutral?

--- a/docs/prd/textbook-companion.md
+++ b/docs/prd/textbook-companion.md
@@ -1,0 +1,84 @@
+# PRD: Textbook Companion
+
+## Overview
+
+Chapter-by-chapter companion pages for the most common Koine Greek textbooks. Each chapter page aggregates the vocabulary, grammar concepts, and paradigms introduced in that chapter and links directly to the relevant tools on greek.tools for practice.
+
+---
+
+## Goals
+
+- Make greek.tools a natural supplement to any Koine Greek course
+- Reduce the friction of finding the right study resources for a given chapter
+- Drive deeper tool usage by contextualizing vocabulary and grammar within a student's curriculum
+
+---
+
+## Priority
+
+Low
+
+---
+
+## Textbooks to Support (v1)
+
+1. **Mounce, *Basics of Biblical Greek*** — most widely used in seminaries; 31 chapters
+2. **Decker, *Reading Koine Greek*** — growing adoption; chapter structure TBD
+
+Additional textbooks can be added in future versions.
+
+---
+
+## Features
+
+### 1. Chapter Index Page
+
+A landing page at `/textbooks` listing supported textbooks. Each textbook links to its chapter list.
+
+### 2. Chapter Page
+
+For each chapter, a page showing:
+
+**Vocabulary introduced this chapter:**
+- List of Greek words with glosses
+- "Study this chapter's vocabulary" button → opens Flashcards pre-filtered to this chapter's word list
+
+**Grammar concepts introduced:**
+- List of grammar topics (e.g., "2nd Declension Masculine Nouns", "Present Active Indicative")
+- Links to the relevant section in the Grammar Reference (e.g., → Grammar Reference › Nouns › 2nd Declension)
+
+**Paradigms to know:**
+- Inline summary of any paradigm tables introduced this chapter
+- Link to the full paradigm in Grammar Reference
+
+**Related drills:**
+- Links to Parsing Drills filtered to the forms introduced in this chapter (once Parsing Drills is built)
+
+### 3. Progress Tracking
+
+Students can mark chapters as complete. Progress stored in `localStorage`.
+
+**Behavior:**
+- Checkmark on completed chapters in the index
+- "You've completed 8 of 31 chapters" summary on the textbook landing page
+
+---
+
+## Data Requirements
+
+- Mounce chapter vocabulary lists: available in published workbooks and several open-source datasets online; licensing must be verified before use
+- Grammar concept mapping: requires manual curation to link each chapter to the relevant Grammar Reference sections
+
+---
+
+## Out of Scope
+
+- Full textbook content reproduction (only vocabulary lists and grammar concept labels, not explanations)
+- Answer keys or exercise solutions
+
+---
+
+## Open Questions
+
+- Are Mounce's chapter vocabulary lists available under a license that permits use in a free web tool?
+- Should chapter pages be statically generated at build time (from a data file) or dynamically rendered?

--- a/docs/prd/word-formation-reference.md
+++ b/docs/prd/word-formation-reference.md
@@ -1,0 +1,82 @@
+# PRD: Word Formation Reference
+
+## Overview
+
+A reference for common Greek prefixes and suffixes that helps students decode unfamiliar vocabulary. Knowing that -ία forms abstract nouns or that κατα- intensifies a verb gives students a systematic tool for guessing meaning from word parts — a significant reading aid in the GNT where vocabulary is large.
+
+---
+
+## Goals
+
+- Teach students to recognize and use word-formation patterns
+- Reduce reliance on looking up every unfamiliar word
+- Cover the prefixes and suffixes with the highest payoff in GNT reading
+
+---
+
+## Priority
+
+Low
+
+---
+
+## Features
+
+### 1. Prepositional Prefixes
+
+A table of the eight prepositions most commonly used as verb prefixes, with their base meaning and how they modify the verb.
+
+| Prefix | Base Meaning | Effect on Verb | Example |
+|--------|-------------|----------------|---------|
+| ἀνα- | up, again | intensification or reversal | ἀνα + βαίνω = ἀναβαίνω (I go up) |
+| ἀπο- | away from | separation, completion | ἀπο + λύω = ἀπολύω (I release, dismiss) |
+| δια- | through | thoroughness | δια + κρίνω = διακρίνω (I distinguish) |
+| ἐκ/ἐξ- | out of | removal, completion | ἐκ + βάλλω = ἐκβάλλω (I cast out) |
+| ἐν- | in | location, entry | ἐν + τέλλω = ἐντέλλομαι (I command) |
+| κατα- | down, against | intensification, completion | κατα + λύω = καταλύω (I destroy) |
+| προ- | before, forward | priority, precedence | προ + άγω = προάγω (I lead forward) |
+| συν- | with, together | association | συν + ἄγω = συνάγω (I gather together) |
+
+### 2. Noun-Forming Suffixes
+
+Common suffixes that form nouns from verb or adjective stems.
+
+| Suffix | Meaning | Examples |
+|--------|---------|---------|
+| -ία (-εια) | abstract quality or state | πίστ + ία = πίστεια; ἀλήθ + εια = ἀλήθεια (truth) |
+| -τής, -τοῦ | agent (one who does) | βαπτ + ιστής = βαπτιστής (baptizer) |
+| -τήριον | place where action happens | προσ + ευχή → προσευχτήριον (place of prayer) |
+| -μα, -ματος | result of an action | βάπτ + ισμα = βάπτισμα (baptism) |
+| -σις, -σεως | act or process | πίστ + ις = πίστις (faith, act of trusting) |
+| -ος, -ους (neuter) | abstract result | γέν + ος = γένος (race, kind) |
+
+### 3. Adjective-Forming Suffixes
+
+| Suffix | Meaning | Examples |
+|--------|---------|---------|
+| -ικός, -ή, -όν | pertaining to, characterized by | πνευματ + ικός = πνευματικός (spiritual) |
+| -ινος | made of, belonging to | σαρκ + ινος = σάρκινος (fleshly, made of flesh) |
+| -ιος | of, belonging to | οὐράν + ιος = οὐράνιος (heavenly) |
+
+### 4. Interactive Decoder
+
+A simple tool: student types a Greek word, and the tool highlights any recognized prefixes or suffixes and suggests the likely base meaning.
+
+**Behavior:**
+- Pattern matches against the prefix/suffix lists
+- Shows the breakdown: prefix + root + suffix → likely meaning
+- Not a full morphological parser; works on string pattern matching
+- Suggests "Check lexicon" when no pattern is recognized
+
+---
+
+## Out of Scope
+
+- Full derivational morphology (a linguistics textbook topic)
+- Compound nouns from two noun stems
+
+---
+
+## Open Questions
+
+- Is the interactive decoder in scope for v1, or should we ship the static reference tables first and add the decoder later?

--- a/docs/screencast-script.md
+++ b/docs/screencast-script.md
@@ -1,0 +1,59 @@
+# greek.tools Screencast Script
+
+**Target length:** ~4 minutes (~600 words at speaking pace)
+
+**Notes for recording:** Timestamps are approximate guides to keep pacing on track. Transition between tools by clicking the navigation. Pause briefly on each screen so viewers can absorb what they're seeing.
+
+---
+
+## Script
+
+**[0:00 – Homepage]**
+
+greek.tools is a free set of browser-based utilities for students learning Koine Greek. No accounts, no sign-ups — you open the site and start using it. All your progress saves automatically in your browser.
+
+Let me walk you through each tool.
+
+**[0:15 – Greek Keyboard]**
+
+The Greek Keyboard lets you type polytonic Greek using your regular English keyboard. It uses Beta Code — so `a` gives you alpha, `b` gives you beta, `th` gives you theta. You type diacritical marks after the vowel: a forward slash for an acute accent, parentheses for breathing marks, equals for a circumflex. Final sigma is handled automatically — you just type `s` and it converts at word boundaries. There's a full reference chart right here if you need to look anything up. When you're done, hit Copy to grab your text.
+
+**[0:50 – Flashcards]**
+
+The Flashcards tool uses spaced repetition to help you learn GNT vocabulary. Words you struggle with come back sooner, words you know space out over time.
+
+You can study Greek-to-English or English-to-Greek, and choose between flipping to reveal or typing your answer. There are filters for word frequency — so you can focus on the most common words first, which is the fastest way to build reading fluency — and you can filter by part of speech if you want to drill just verbs or just nouns.
+
+In flip mode, you use the arrow keys: right for "Got It," left for "Still Learning." The app tracks your streak — consecutive days where you study at least ten cards — along with your overall accuracy.
+
+**[1:35 – Daily Verse]**
+
+The Daily Verse gives you one Greek verse each day, cycling through 66 curated passages from across the New Testament. It's designed to build a daily habit of reading Greek.
+
+You can toggle glosses on to see English definitions under each word, and clicking any word shows you its dictionary form, morphological parse, and how frequently it appears in the GNT. There's a link to open the full chapter in the Reader if you want to keep going. The page tracks your reading streak to help you stay consistent.
+
+**[2:10 – GNT Reader]**
+
+The Reader is where you read the Greek New Testament chapter by chapter. Pick a book and chapter from the dropdowns, or use the arrows to move forward and back.
+
+Clicking any word opens a popup with its lemma, English gloss, full morphological parse, and frequency. If you see a word you don't know, you can hit "Study in Flashcards" right from the popup to add it to your spaced repetition rotation. Words you've already studied show up with a dotted underline, so you can see your vocabulary coverage growing as you read.
+
+The Reader remembers your last position, and you can share or bookmark specific passages using URL parameters — so `reader?ref=JHN.3.16` takes you straight to John 3:16.
+
+**[2:50 – Transliteration]**
+
+The Transliteration tool converts between Greek text and SBL romanization. Type or paste Greek on one side and get the transliteration on the other, or go the other direction. It handles breathing marks, accents, iota subscripts — the full SBL scheme. Copy buttons on both sides.
+
+**[3:05 – Grammar Reference]**
+
+The Grammar Reference is an interactive paradigm reference. It covers noun declensions, adjective patterns, verb conjugations across every tense-voice-mood combination, contract verbs, liquid verbs, pronouns, prepositions, and accent rules.
+
+You can toggle between full forms and endings only, and click any cell for a grammatical description. The verb section has selectors for tense, voice, and mood so you can pull up exactly the paradigm you need.
+
+**[3:35 – Paradigm Quiz]**
+
+Finally, the Paradigm Quiz lets you test yourself. Pick a paradigm — a noun declension, adjective pattern, or verb conjugation — choose your difficulty, and fill in the blanks using Beta Code input. After you submit, the quiz color-codes your answers: green for correct, yellow for accent errors, red for wrong. You can toggle between strict and lenient accent grading depending on where you are in your studies.
+
+**[3:55 – Closing]**
+
+That's greek.tools — a free, focused toolkit for Greek students. Everything runs in your browser, your progress stays on your device, and there's nothing to install. Give it a try at greek.tools.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,111 @@
+# greek.tools User Guide
+
+greek.tools is a free, browser-based toolkit for students learning Koine Greek. Everything runs locally in your browser — no accounts, no sign-ups, and your progress is saved automatically on your device.
+
+---
+
+## Tools Overview
+
+### Greek Keyboard
+
+Type polytonic Greek using your standard English keyboard with Beta Code input. Letters map directly — type `a` for α, `b` for β, `g` for γ, and so on. Add diacritical marks after the vowel:
+
+| Key | Mark |
+|-----|------|
+| `)` | smooth breathing |
+| `(` | rough breathing |
+| `/` | acute accent |
+| `\` | grave accent |
+| `=` | circumflex |
+| `|` | iota subscript |
+
+Final sigma (ς) is applied automatically at word boundaries — just type `s` and the app handles the rest. A full mapping reference is available on the page. Use the **Copy** button to grab your Greek text for use anywhere.
+
+### Vocabulary Flashcards
+
+Study the most common Greek New Testament (GNT) vocabulary with built-in spaced repetition. Cards are scheduled using the SM-2 algorithm, so words you struggle with appear more often, and words you know well space out over time.
+
+**Settings you can adjust:**
+
+- **Direction** — Study Greek → English or English → Greek
+- **Answer mode** — Flip to reveal, or type your answer
+- **Frequency filter** — Focus on words that appear 500+ times, 100–499 times, 50–99 times, or fewer than 50
+- **Part of speech** — Filter by noun, verb, adjective, conjunction, and more
+
+In flip mode, use **Space** to reveal the answer, then **Right Arrow** for "Got It" or **Left Arrow** for "Still Learning." In type mode, answers are checked with fuzzy matching so minor typos won't count against you.
+
+Your study streak tracks consecutive days where you review at least 10 cards. Stats including accuracy and total reviews are tracked automatically.
+
+### Daily Verse
+
+A new Greek verse appears each day, cycling through 66 curated pedagogical passages from across the New Testament. Visit daily to build a reading streak.
+
+- Toggle **Show Glosses** to display English definitions beneath each word
+- Click any word to see its lemma, definition, morphological parse, and GNT frequency
+- Use the **Open Chapter** link to jump into the full Reader at that passage
+
+### GNT Reader
+
+Read the Greek New Testament chapter by chapter. Select a book and chapter from the toolbar, or navigate with the Previous/Next arrows.
+
+- Click any word for a popup showing its dictionary form, English gloss, full morphological parse, and how often it appears in the GNT
+- Toggle **Show Glosses** to display inline English definitions beneath each word
+- Words you've already studied in Flashcards are marked with a dotted underline
+- Use the **Study in Flashcards** button in any word popup to add it to your study rotation
+
+The Reader remembers where you left off. The homepage Reader card links directly to your last-read passage.
+
+**Direct links:** Share or bookmark specific passages using URL parameters like `greek.tools/reader?ref=JHN.3.16`.
+
+### Transliteration
+
+Convert between Greek text and the Society of Biblical Literature (SBL) romanization scheme. The tool works in both directions:
+
+- Type or paste Greek on the left to see the SBL transliteration on the right
+- Type SBL romanized text on the right to generate Greek on the left (unaccented)
+
+A reference table of the full SBL scheme is included on the page. Use the **Copy** buttons to grab either version.
+
+### Grammar Reference
+
+An interactive reference covering the major paradigms of Koine Greek, organized into eight sections:
+
+- **Nouns** — 1st, 2nd, and 3rd declension paradigms with articles
+- **Adjectives** — 2-1-2 and 3-1-3 patterns
+- **Verbs** — Present, Imperfect, Future, Aorist, Perfect, and Pluperfect across Active, Middle, and Passive voices in Indicative, Subjunctive, and Imperative moods
+- **Contract Verbs** — Contraction rules and paradigms for α, ε, and ο stems
+- **Liquid Verbs** — Future and Aorist patterns with comparison to standard forms
+- **Pronouns** — 1st, 2nd, and 3rd person with gendered forms
+- **Prepositions** — 60+ entries with case governance and English glosses
+- **Accent Rules** — Placement patterns and exceptions
+
+Use the **Endings** toggle to switch between full forms (with articles) and endings only. Click any cell in a paradigm table for a grammatical description. On mobile, use the **Sg/Pl** toggle to view one number at a time for wider tables.
+
+### Paradigm Quiz
+
+Test your paradigm knowledge with fill-in-the-blank drills. Choose from noun declensions, adjective patterns, or verb conjugations.
+
+**Settings:**
+
+- **Difficulty** — Easy (25% blank), Medium (50% blank), or Hard (100% blank for full recall)
+- **Accent grading** — Strict mode marks accent errors; lenient mode ignores them
+
+Type your answers using Beta Code (the same input system as the Greek Keyboard). After submitting, cells are color-coded: green for correct, yellow for accent-only errors, and red for incorrect. The correct forms are shown so you can compare.
+
+---
+
+## Tips
+
+- **Build a daily habit** — Visit the Daily Verse page each day to maintain your reading streak, then open the full chapter in the Reader to keep going.
+- **Use the Reader and Flashcards together** — When you encounter an unfamiliar word in the Reader, click it and hit "Study in Flashcards" to add it to your spaced repetition rotation. Words you've studied show a dotted underline in the Reader so you can track your progress.
+- **Start with high-frequency words** — Use the frequency filter in Flashcards to focus on words that appear 500+ times first, then work down. These words make up the vast majority of the GNT text.
+- **Quiz yourself on paradigms** — After reviewing a paradigm in the Grammar Reference, switch to the Paradigm Quiz and select the same pattern to test your recall.
+- **Bookmark passages** — Use direct URLs like `greek.tools/reader?ref=ROM.8` to bookmark chapters you're working through.
+
+---
+
+## Data and Privacy
+
+All your progress — flashcard history, reading position, streaks, and study stats — is stored locally in your browser using localStorage. Nothing is sent to a server. If you clear your browser data, your progress will be reset.
+
+greek.tools uses the MorphGNT dataset, which provides morphologically tagged text of the Greek New Testament based on the SBL Greek New Testament (SBLGNT).


### PR DESCRIPTION
## Summary

- Adds a sticky segmented section navigation bar for mobile on the Grammar Reference page
- Extracts grammar reference into smaller components for maintainability
- Adds 11 new PRDs covering features not yet implemented, plus a user guide and screencast script

## Test plan

- [ ] Open Grammar Reference on a mobile viewport
- [ ] Verify the section nav sticks to the top while scrolling
- [ ] Tap each segment and confirm the view scrolls to the correct section
- [ ] Verify layout on desktop is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)