### PR TITLE
feat(grammar): expand participle section with full declension tables

### DIFF
--- a/.claude/dev.sh
+++ b/.claude/dev.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export PATH="/opt/homebrew/bin:/opt/homebrew/Cellar/node/25.3.0/bin:$PATH"
+cd /Users/mitch/code/greek-tools
+npm run dev -- --port 4330

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,8 @@
   "configurations": [
     {
       "name": "greek-tools",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--", "--port", "4330"],
+      "runtimeExecutable": "/bin/sh",
+      "runtimeArgs": ["/Users/mitch/code/greek-tools/.claude/dev.sh"],
       "port": 4330,
       "autoPort": true
     }

--- a/docs/prd/participle-expansion.md
+++ b/docs/prd/participle-expansion.md
@@ -1,0 +1,155 @@
+# PRD: Participle Section Expansion
+
+## Overview
+
+The current participle reference shows only nominative singular forms for six tense-voice combinations, and the Paradigm Quiz tests only those six nominative singular cells. This is not enough to prepare a student to recognize or parse participles in the Greek New Testament (GNT), where participles decline across all cases, numbers, and genders — and where every voice (active, middle, passive) must be distinguished. This PRD expands the participle section to cover all voices, add missing tense-voice combinations, and expose full paradigm tables in both the Grammar Reference and the Paradigm Quiz.
+
+---
+
+## Status
+
+**Not started.**
+
+---
+
+## Goals
+
+- Cover all tense-voice combinations that appear in the GNT, including the currently missing Perfect Middle/Passive and all three Future participles
+- Give students a clear, scannable reference for participle forms organized by voice
+- Expose the full declension of each participle type (all cases × numbers × genders) so students can recognize oblique forms
+- Integrate expanded participle data into the Paradigm Quiz with the same cell-level grading already used for nouns and adjectives
+
+---
+
+## Background: Voices and Tenses
+
+Greek participles exist at the intersection of verbal aspect (tense-stem) and adjectival function (declining for case, number, gender). The current data covers six combinations; a complete reference covers ten:
+
+| Tense | Active | Middle | Passive |
+|-------|--------|--------|---------|
+| Present | λύων / λύουσα / λῦον ✓ | λυόμενος / -η / -ον ✓ (combined Mid/Pass) | — |
+| Future | — | — | — |
+| Aorist | λύσας / λύσασα / λῦσαν ✓ | λυσάμενος / -η / -ον ✓ | λυθείς / λυθεῖσα / λυθέν ✓ |
+| Perfect | λελυκώς / λελυκυῖα / λελυκός ✓ | — | — |
+
+**Additions needed:**
+1. **Perfect Middle/Passive** — λελυμένος / λελυμένη / λελυμένον
+2. **Future Active** — λύσων / λύσουσα / λῦσον
+3. **Future Middle** — λυσόμενος / λυσομένη / λυσόμενον
+4. **Future Passive** — λυθησόμενος / λυθησομένη / λυθησόμενον
+
+Future participles are relatively rare in the GNT but are needed for completeness and for students reading classical texts alongside GNT Greek. Perfect Mid/Pass is moderately common and fills an obvious gap.
+
+---
+
+## Features
+
+### 1. Expanded Data Layer
+
+Add the four missing tense-voice combinations to `participleRows` in `src/data/grammar.ts`.
+
+**New entries (nominative singular only, for parity with existing rows):**
+
+```ts
+{ label: 'Perfect Mid./Pass.',  m: 'λελυμένος',   f: 'λελυμένη',    n: 'λελυμένον'   },
+{ label: 'Future Active',       m: 'λύσων',        f: 'λύσουσα',     n: 'λῦσον'       },
+{ label: 'Future Middle',       m: 'λυσόμενος',    f: 'λυσομένη',    n: 'λυσόμενον'   },
+{ label: 'Future Passive',      m: 'λυθησόμενος',  f: 'λυθησομένη',  n: 'λυθησόμενον' },
+```
+
+This brings the total to ten tense-voice rows, covering active, middle, and passive across all four tense-stems that form participles.
+
+### 2. Grammar Reference Navigation
+
+Add a `participles` entry to `NAV_SECTIONS` in `GrammarReference.tsx`, positioned after `liquid-verbs` and before `pronouns`. Include it in `PARADIGM_NAV` so it appears under the "Paradigms" group in the mobile sticky nav (alongside Nouns, Adjectives, Verbs, Contract Verbs, and Liquid Verbs).
+
+```ts
+{ id: 'participles', label: 'Participles', shortLabel: 'Participles' },
+```
+
+Add a corresponding `<section id="participles">` in the page body.
+
+### 3. Tense-Organized Display in Grammar Reference
+
+Keep tense as the top-level organizing axis in `GrammarReference.tsx`, grouping rows by tense-stem and listing voices within each tense. Use a subtle section header or divider between tense groups.
+
+**Proposed grouping:**
+
+**Present**
+- Present Active
+- Present Middle/Passive
+
+**Future**
+- Future Active
+- Future Middle
+- Future Passive
+
+**Aorist**
+- Aorist Active
+- Aorist Middle
+- Aorist Passive
+
+**Perfect**
+- Perfect Active
+- Perfect Middle/Passive
+
+Add a brief callout explaining that Present and Perfect use the same forms for Middle and Passive, while Aorist and Future distinguish them.
+
+### 4. Declension Tables per Participle Type
+
+Each tense-voice combination declines differently, which is the core difficulty. Add a new `ParticipleParadigm` data structure to hold the full declension for each participle type, covering all cases (nominative, genitive, dative, accusative, vocative) in both singular and plural across all three genders.
+
+**Key paradigm patterns to cover:**
+
+| Participle | Masculine | Feminine | Neuter |
+|------------|-----------|----------|--------|
+| Present Active | 3rd decl (ων/οντος) | 1st decl (ουσα/ουσης) | 3rd decl (ον/οντος) |
+| Aorist Active | 3rd decl (ας/αντος) | 1st decl (ασα/ασης) | 3rd decl (αν/αντος) |
+| Aorist Passive | 3rd decl (εις/εντος) | 1st decl (εισα/εισης) | 3rd decl (εν/εντος) |
+| Perfect Active | 3rd decl (ως/οτος) | 1st decl (υια/υιας) | 3rd decl (ος/οτος) |
+| Mid/Pass forms | 2nd decl (ομενος) | 1st decl (ομενη) | 2nd decl (ομενον) |
+| Future Passive | 2nd decl (ησομενος) | 1st decl (ησομενη) | 2nd decl (ησομενον) |
+
+The Grammar Reference should show a declension card (similar to the adjective paradigm cards) for each participle type, switchable via tabs or a dropdown selector.
+
+**Display behavior:**
+- Gender tabs: Masculine | Feminine | Neuter, or a combined 3-column layout for compact viewing
+- Singular and plural sections within each gender column
+- An "Endings only" toggle (consistent with existing adjective and noun tables) that strips the stem and shows just the endings
+- A note beneath each table identifying which declension pattern(s) the participle follows (e.g., "Masculine/Neuter: 3rd declension (ντ-stem); Feminine: 1st declension")
+
+### 5. Paradigm Quiz Integration
+
+Expose the full declension data in the Paradigm Quiz, using the same table-based format already used for nouns and adjectives.
+
+- Add a "Participles" subsection within the Verbs tab (or as its own tab if the tab count allows)
+- Each tense-voice combination is a selectable table to quiz
+- The quiz blanks out cells in the full declension table, not just the nominative singular row
+- Scoring and cell-level feedback follow the existing paradigm quiz pattern
+
+---
+
+## Out of Scope
+
+- μι-verb participles (e.g., διδούς, τιθείς, ἱστάς) — covered by the μι-Verb Paradigms PRD
+- Contract verb participles in full declension — the contract verbs PRD covers present active/mid/pass nom sg only; full declension for contracts is deferred
+- Parsing drills on GNT participle forms — that belongs in the Parsing Drills PRD
+- Verbal aspect annotations or explanatory notes on the difference between aorist and present participle aspect — belongs in the Verbal Aspect PRD
+
+---
+
+## Decisions
+
+- **Tense grouping:** The current flat-list order (pres act, pres mid/pass, aor act, aor mid, aor pass, perf act) already follows tense order and that organization is preserved. Adding Future and Perfect Mid/Pass rows slots naturally into their tense groups. Tense is the primary axis because it drives the stem and accent pattern students need to recognize first.
+- **Combined Mid/Pass for Present and Perfect:** The forms are identical; showing them as a single row with a label note is cleaner than duplicating a table. Aorist and Future are distinguished because the forms differ.
+- **Full declension in Grammar Reference, not just nom sg:** The nom-sg-only table is useful as a quick lookup but insufficient for recognition. The Grammar Reference should model how participles actually behave as adjectives.
+- **Data structure:** `ParticipleParadigm` should parallel `AdjParadigm` — the same component used for adjective declension cards can likely be reused or lightly extended for participles.
+
+---
+
+## Key Files
+
+- Data: `src/data/grammar.ts` — `ParticipleRow`, `participleRows`, new `ParticipleParadigm` type and data
+- Grammar UI: `src/components/GrammarReference.tsx` — participle section, voice grouping, declension cards
+- Quiz: `src/lib/paradigm-quiz.ts` — participle table builder
+- Tests: `src/data/grammar.test.ts`, `src/lib/paradigm-quiz.test.ts`

--- a/src/components/GrammarReference.tsx
+++ b/src/components/GrammarReference.tsx
@@ -1,7 +1,7 @@
 /**
  * GrammarReference — interactive grammar paradigm reference for Koine Greek.
  *
- * Sections: Nouns · Adjectives · Verbs · Pronouns · Prepositions · Accent Rules
+ * Sections: Nouns · Adjectives · Verbs · Contract Verbs · Liquid Verbs · Participles · Pronouns · Prepositions · Accent Rules
  *
  * Features:
  * - Sticky sidebar navigation (desktop) / horizontal scroll nav (mobile)
@@ -25,7 +25,7 @@ import {
   adjParadigms,
   verbParadigms,
   infinitiveForms,
-  participleRows,
+  participleParadigms,
   personalPronouns12,
   genderedPronouns,
   prepositions,
@@ -44,6 +44,8 @@ import {
   type PersonNum,
   type ContractType,
   type ContractVerbParadigm,
+  type ParticipleParadigm,
+  type ParticipleTense,
 } from '../data/grammar';
 import {
   SectionHeading,
@@ -53,6 +55,7 @@ import {
   AdjParadigmCard,
   GenderedPronounCard,
   VerbParadigmGrid,
+  ParticipleParadigmCard,
 } from './grammar';
 import type { Mood } from './grammar/VerbParadigmGrid';
 
@@ -61,18 +64,19 @@ import type { Mood } from './grammar/VerbParadigmGrid';
 // ---------------------------------------------------------------------------
 
 const NAV_SECTIONS = [
-  { id: 'nouns',          label: 'Nouns',          shortLabel: 'Nouns'  },
-  { id: 'adjectives',     label: 'Adjectives',     shortLabel: 'Adj'   },
-  { id: 'verbs',          label: 'Verbs',          shortLabel: 'Verbs' },
-  { id: 'contract-verbs', label: 'Contract Verbs', shortLabel: 'Contract' },
-  { id: 'liquid-verbs',   label: 'Liquid Verbs',   shortLabel: 'Liquid'   },
-  { id: 'pronouns',       label: 'Pronouns',       shortLabel: 'Pronouns'     },
+  { id: 'nouns',          label: 'Nouns',          shortLabel: 'Nouns'        },
+  { id: 'adjectives',     label: 'Adjectives',     shortLabel: 'Adj'         },
+  { id: 'verbs',          label: 'Verbs',          shortLabel: 'Verbs'       },
+  { id: 'contract-verbs', label: 'Contract Verbs', shortLabel: 'Contract'    },
+  { id: 'liquid-verbs',   label: 'Liquid Verbs',   shortLabel: 'Liquid'      },
+  { id: 'participles',    label: 'Participles',    shortLabel: 'Participles' },
+  { id: 'pronouns',       label: 'Pronouns',       shortLabel: 'Pronouns'    },
   { id: 'prepositions',   label: 'Prepositions',   shortLabel: 'Prepositions' },
-  { id: 'accents',        label: 'Accents',        shortLabel: 'Accents'      },
+  { id: 'accents',        label: 'Accents',        shortLabel: 'Accents'     },
 ] as const;
 
 const PARADIGM_NAV = NAV_SECTIONS.filter(s =>
-  ['nouns', 'adjectives', 'verbs', 'contract-verbs', 'liquid-verbs'].includes(s.id)
+  ['nouns', 'adjectives', 'verbs', 'contract-verbs', 'liquid-verbs', 'participles'].includes(s.id)
 );
 const REFERENCE_NAV = NAV_SECTIONS.filter(s =>
   ['pronouns', 'prepositions', 'accents'].includes(s.id)
@@ -259,58 +263,23 @@ function VerbSection() {
         </div>
       </div>
 
-      {/* Infinitives & Participles */}
-      <div className="mt-8 grid md:grid-cols-2 gap-6">
-        <div>
-          <ParadigmHeading>Infinitives</ParadigmHeading>
-          <div className="rounded-xl overflow-hidden shadow-sm" style={{ border: '1px solid #e5e7eb' }}>
-            <div className="px-4 py-2.5" style={{ background: 'var(--color-primary)' }}>
-              <span className="text-sm font-semibold text-white">Infinitives</span>
-            </div>
-            <table className="w-full text-sm" style={{ background: 'var(--color-bg-card)' }}>
-              <tbody>
-                {infinitiveForms.map(({ label, form }, i) => (
-                  <tr key={label} style={{ background: i % 2 === 0 ? 'var(--color-bg-card)' : 'rgba(30,58,95,0.03)' }}>
-                    <td className="px-4 py-2 text-xs" style={{ color: 'var(--color-text-muted)' }}>{label}</td>
-                    <td className="px-4 py-2 font-greek text-base" style={{ color: 'var(--color-greek)' }}>{form}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      {/* Infinitives */}
+      <div className="mt-8 max-w-sm">
+        <ParadigmHeading>Infinitives</ParadigmHeading>
+        <div className="rounded-xl overflow-hidden shadow-sm" style={{ border: '1px solid #e5e7eb' }}>
+          <div className="px-4 py-2.5" style={{ background: 'var(--color-primary)' }}>
+            <span className="text-sm font-semibold text-white">Infinitives</span>
           </div>
-        </div>
-
-        <div>
-          <ParadigmHeading>Participles (Nominative Singular)</ParadigmHeading>
-          <div className="rounded-xl overflow-hidden shadow-sm" style={{ border: '1px solid #e5e7eb' }}>
-            <div className="px-4 py-2.5" style={{ background: 'var(--color-primary)' }}>
-              <span className="text-sm font-semibold text-white">Participles</span>
-            </div>
-            <table className="w-full text-sm" style={{ background: 'var(--color-bg-card)' }}>
-              <thead>
-                <tr style={{ background: 'rgba(30,58,95,0.06)' }}>
-                  <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }} />
-                  {(['m', 'f', 'n'] as GenderKey[]).map(g => (
-                    <th key={g} className="px-3 py-2 text-center text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>
-                      {GENDER_LABELS[g]}
-                    </th>
-                  ))}
+          <table className="w-full text-sm" style={{ background: 'var(--color-bg-card)' }}>
+            <tbody>
+              {infinitiveForms.map(({ label, form }, i) => (
+                <tr key={label} style={{ background: i % 2 === 0 ? 'var(--color-bg-card)' : 'rgba(30,58,95,0.03)' }}>
+                  <td className="px-4 py-2 text-xs" style={{ color: 'var(--color-text-muted)' }}>{label}</td>
+                  <td className="px-4 py-2 font-greek text-base" style={{ color: 'var(--color-greek)' }}>{form}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {participleRows.map((row, i) => (
-                  <tr key={row.label} style={{ background: i % 2 === 0 ? 'var(--color-bg-card)' : 'rgba(30,58,95,0.03)' }}>
-                    <td className="px-3 py-2 text-xs" style={{ color: 'var(--color-text-muted)' }}>{row.label}</td>
-                    {(['m', 'f', 'n'] as GenderKey[]).map(g => (
-                      <td key={g} className="px-3 py-2 text-center font-greek text-sm" style={{ color: 'var(--color-greek)' }}>
-                        {row[g]}
-                      </td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </section>
@@ -821,6 +790,83 @@ function LiquidVerbsSection() {
 }
 
 // ---------------------------------------------------------------------------
+// Participles section
+// ---------------------------------------------------------------------------
+
+const TENSE_LABELS: Record<ParticipleTense, string> = {
+  present: 'Present',
+  future: 'Future',
+  aorist: 'Aorist',
+  perfect: 'Perfect',
+};
+
+const TENSE_ORDER: ParticipleTense[] = ['present', 'future', 'aorist', 'perfect'];
+
+function ParticipleSection() {
+  const byTense = TENSE_ORDER.reduce(
+    (acc, t) => ({ ...acc, [t]: participleParadigms.filter(p => p.tense === t) }),
+    {} as Record<ParticipleTense, ParticipleParadigm[]>
+  );
+
+  const [activeTense, setActiveTense] = useState<ParticipleTense>('present');
+  const [activeId, setActiveId] = useState<string>(participleParadigms[0].id);
+
+  const activeParadigm = participleParadigms.find(p => p.id === activeId) ?? participleParadigms[0];
+
+  return (
+    <section id="participles" className="mb-16">
+      <SectionHeading id="participles">Participles — λύω</SectionHeading>
+      <p className="text-sm mb-6" style={{ color: 'var(--color-text-muted)' }}>
+        Participles are verbal adjectives: they carry tense and voice from the verb but decline for case, number,
+        and gender like adjectives. Present and Perfect use combined Middle/Passive forms; Aorist and Future
+        distinguish Middle from Passive.
+      </p>
+
+      {/* Tense tabs */}
+      <div className="flex flex-wrap gap-2 mb-3">
+        {TENSE_ORDER.map(tense => (
+          <button
+            key={tense}
+            onClick={() => {
+              setActiveTense(tense);
+              setActiveId(byTense[tense][0].id);
+            }}
+            className="px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors"
+            style={
+              activeTense === tense
+                ? { background: 'var(--color-primary)', color: '#fff' }
+                : { background: 'rgba(30,58,95,0.08)', color: 'var(--color-primary)' }
+            }
+          >
+            {TENSE_LABELS[tense]}
+          </button>
+        ))}
+      </div>
+
+      {/* Voice buttons for active tense */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        {byTense[activeTense].map(p => (
+          <button
+            key={p.id}
+            onClick={() => setActiveId(p.id)}
+            className="px-3 py-1 rounded-lg text-xs font-medium transition-colors"
+            style={
+              activeId === p.id
+                ? { background: 'var(--color-accent)', color: '#fff' }
+                : { background: 'rgba(30,58,95,0.05)', color: 'var(--color-text-muted)', border: '1px solid #e5e7eb' }
+            }
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      <ParticipleParadigmCard paradigm={activeParadigm} />
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
@@ -918,6 +964,9 @@ export default function GrammarReference() {
 
         {/* Liquid Verbs */}
         <LiquidVerbsSection />
+
+        {/* Participles */}
+        <ParticipleSection />
 
         {/* Pronouns */}
         <section id="pronouns" className="mb-16">

--- a/src/components/grammar/ParticipleParadigmCard.tsx
+++ b/src/components/grammar/ParticipleParadigmCard.tsx
@@ -1,0 +1,176 @@
+import { useState, useCallback } from 'react';
+import {
+  CASES,
+  NUMBERS,
+  GENDERS,
+  CASE_LABELS,
+  CASE_DESCRIPTIONS,
+  NUM_LABELS,
+  GENDER_LABELS,
+  type ParticipleParadigm,
+  type CaseKey,
+  type NumKey,
+  type GenderKey,
+} from '../../data/grammar';
+import NumberToggle from './NumberToggle';
+import DescriptionBar from './DescriptionBar';
+
+export default function ParticipleParadigmCard({ paradigm }: { paradigm: ParticipleParadigm }) {
+  const [description, setDescription] = useState<string | null>(null);
+  const [activeNumber, setActiveNumber] = useState<NumKey>('sg');
+
+  const handleCell = useCallback((caseKey: CaseKey, numKey: NumKey, genderKey: GenderKey) => {
+    setDescription(
+      `${CASE_DESCRIPTIONS[caseKey].split(' — ')[0]} ${NUM_LABELS[numKey]} ${GENDER_LABELS[genderKey]} — ${CASE_DESCRIPTIONS[caseKey].split(' — ')[1]}`
+    );
+  }, []);
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden shadow-sm"
+      style={{ border: '1px solid #e5e7eb' }}
+    >
+      <div
+        className="px-4 py-2.5 flex items-center justify-between"
+        style={{ background: 'var(--color-primary)' }}
+      >
+        <span className="text-sm font-semibold text-white">{paradigm.label} Participle — λύω</span>
+        <NumberToggle activeNumber={activeNumber} onToggle={setActiveNumber} />
+      </div>
+
+      {/* Desktop: full 6-column table (Sg M/F/N + Pl M/F/N) */}
+      <div className="hidden md:block overflow-x-auto" style={{ background: 'var(--color-bg-card)' }}>
+        <table className="w-full text-sm">
+          <thead>
+            <tr style={{ background: 'rgba(30,58,95,0.06)' }}>
+              <th
+                className="px-3 py-2 text-left font-semibold text-xs uppercase tracking-wider"
+                style={{ color: 'var(--color-text-muted)', width: '4rem' }}
+              />
+              {NUMBERS.map(num => (
+                <th
+                  key={num}
+                  colSpan={3}
+                  className="px-2 py-2 text-center font-semibold text-xs uppercase tracking-wider border-l"
+                  style={{ color: 'var(--color-text-muted)', borderColor: '#e5e7eb' }}
+                >
+                  {NUM_LABELS[num]}
+                </th>
+              ))}
+            </tr>
+            <tr style={{ background: 'rgba(30,58,95,0.03)' }}>
+              <th />
+              {NUMBERS.map(num =>
+                GENDERS.map(g => (
+                  <th
+                    key={`${num}-${g}`}
+                    className="px-3 py-1.5 text-center text-xs font-medium"
+                    style={{ color: 'var(--color-text-muted)' }}
+                  >
+                    {GENDER_LABELS[g]}
+                  </th>
+                ))
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {CASES.map((c, i) => (
+              <tr
+                key={c}
+                style={{ background: i % 2 === 0 ? 'var(--color-bg-card)' : 'rgba(30,58,95,0.03)' }}
+              >
+                <td
+                  className="px-3 py-2 font-semibold text-xs uppercase tracking-wider cursor-default"
+                  style={{ color: 'var(--color-text-muted)' }}
+                  onMouseEnter={() => setDescription(CASE_DESCRIPTIONS[c])}
+                  onMouseLeave={() => setDescription(null)}
+                >
+                  {CASE_LABELS[c]}
+                </td>
+                {NUMBERS.map(num =>
+                  GENDERS.map(g => (
+                    <td
+                      key={`${num}-${g}`}
+                      className="px-3 py-2 text-center font-greek text-sm cursor-default"
+                      style={{ color: 'var(--color-greek)' }}
+                      onMouseEnter={() => handleCell(c, num, g)}
+                      onMouseLeave={() => setDescription(null)}
+                      onClick={() => handleCell(c, num, g)}
+                    >
+                      {paradigm.forms[c][num][g]}
+                    </td>
+                  ))
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile: 3-column table with Sg/Pl toggle */}
+      <div className="md:hidden" style={{ background: 'var(--color-bg-card)' }}>
+        <table className="w-full text-sm">
+          <thead>
+            <tr style={{ background: 'rgba(30,58,95,0.06)' }}>
+              <th
+                className="px-3 py-2 text-left font-semibold text-xs uppercase tracking-wider"
+                style={{ color: 'var(--color-text-muted)', width: '4rem' }}
+              />
+              {GENDERS.map(g => (
+                <th
+                  key={g}
+                  className="px-3 py-2 text-center text-xs font-medium"
+                  style={{ color: 'var(--color-text-muted)' }}
+                >
+                  {GENDER_LABELS[g]}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {CASES.map((c, i) => (
+              <tr
+                key={c}
+                style={{ background: i % 2 === 0 ? 'var(--color-bg-card)' : 'rgba(30,58,95,0.03)' }}
+              >
+                <td
+                  className="px-3 py-2 font-semibold text-xs uppercase tracking-wider cursor-default"
+                  style={{ color: 'var(--color-text-muted)' }}
+                  onClick={() => setDescription(CASE_DESCRIPTIONS[c])}
+                >
+                  {CASE_LABELS[c]}
+                </td>
+                {GENDERS.map(g => (
+                  <td
+                    key={g}
+                    className="px-3 py-2 text-center font-greek text-sm cursor-default"
+                    style={{ color: 'var(--color-greek)' }}
+                    onClick={() => handleCell(c, activeNumber, g)}
+                  >
+                    {paradigm.forms[c][activeNumber][g]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="px-3 pt-1 pb-2" style={{ background: 'var(--color-bg-card)' }}>
+        <DescriptionBar text={description} />
+      </div>
+
+      {/* Declension note */}
+      <div
+        className="px-4 py-2 text-xs"
+        style={{
+          background: 'rgba(30,58,95,0.04)',
+          borderTop: '1px solid #e5e7eb',
+          color: 'var(--color-text-muted)',
+        }}
+      >
+        {paradigm.declensionNote}
+      </div>
+    </div>
+  );
+}

--- a/src/components/grammar/index.ts
+++ b/src/components/grammar/index.ts
@@ -6,3 +6,4 @@ export { default as NumberToggle } from './NumberToggle';
 export { default as AdjParadigmCard } from './AdjParadigmCard';
 export { default as GenderedPronounCard } from './GenderedPronounCard';
 export { default as VerbParadigmGrid } from './VerbParadigmGrid';
+export { default as ParticipleParadigmCard } from './ParticipleParadigmCard';

--- a/src/data/grammar.test.ts
+++ b/src/data/grammar.test.ts
@@ -8,6 +8,7 @@ import {
   verbParadigms,
   infinitiveForms,
   participleRows,
+  participleParadigms,
   personalPronouns12,
   genderedPronouns,
   prepositions,
@@ -177,13 +178,48 @@ describe('infinitiveForms', () => {
 });
 
 describe('participleRows', () => {
-  it('is a non-empty array with m/f/n fields', () => {
-    expect(participleRows.length).toBeGreaterThan(0);
+  it('has 10 entries covering all tense-voice combinations', () => {
+    expect(participleRows).toHaveLength(10);
+  });
+
+  it('every row has a label and non-empty m/f/n strings', () => {
     participleRows.forEach((row) => {
       expect(row.label).toBeTruthy();
       expect(typeof row.m).toBe('string');
       expect(typeof row.f).toBe('string');
       expect(typeof row.n).toBe('string');
+    });
+  });
+});
+
+describe('participleParadigms', () => {
+  it('has 10 paradigms covering all tense-voice combinations', () => {
+    expect(participleParadigms).toHaveLength(10);
+  });
+
+  it('every paradigm has all 5 cases × 2 numbers × 3 genders', () => {
+    const cases = ['nom', 'gen', 'dat', 'acc', 'voc'] as const;
+    const numbers = ['sg', 'pl'] as const;
+    const genders = ['m', 'f', 'n'] as const;
+    participleParadigms.forEach((p) => {
+      cases.forEach((c) => {
+        numbers.forEach((n) => {
+          genders.forEach((g) => {
+            expect(typeof p.forms[c][n][g]).toBe('string');
+            expect(p.forms[c][n][g].length).toBeGreaterThan(0);
+          });
+        });
+      });
+    });
+  });
+
+  it('nom sg forms match participleRows', () => {
+    participleParadigms.forEach((paradigm) => {
+      const row = participleRows.find(r => r.label === paradigm.label);
+      expect(row).toBeDefined();
+      expect(paradigm.forms.nom.sg.m).toBe(row!.m);
+      expect(paradigm.forms.nom.sg.f).toBe(row!.f);
+      expect(paradigm.forms.nom.sg.n).toBe(row!.n);
     });
   });
 });

--- a/src/data/grammar.ts
+++ b/src/data/grammar.ts
@@ -125,6 +125,21 @@ export interface ParticipleRow {
   n: string;
 }
 
+export type ParticipleTense = 'present' | 'future' | 'aorist' | 'perfect';
+export type ParticipleVoice = 'active' | 'middle' | 'passive' | 'mid-pass';
+
+export interface ParticipleParadigm {
+  id: string;
+  /** Display label, e.g. "Present Active" */
+  label: string;
+  tense: ParticipleTense;
+  voice: ParticipleVoice;
+  /** Short note on which declension patterns apply, shown below the table. */
+  declensionNote: string;
+  /** forms[case][number][gender] — full inflected form */
+  forms: Record<CaseKey, Record<NumKey, Record<GenderKey, string>>>;
+}
+
 // ---------------------------------------------------------------------------
 // Pronoun types
 // ---------------------------------------------------------------------------
@@ -542,12 +557,167 @@ export const infinitiveForms: InfinitivePair[] = [
 ];
 
 export const participleRows: ParticipleRow[] = [
-  { label: 'Present Active',     m: 'λύων',      f: 'λύουσα',   n: 'λῦον'    },
-  { label: 'Present Mid./Pass.', m: 'λυόμενος',  f: 'λυομένη',  n: 'λυόμενον' },
-  { label: 'Aorist Active',      m: 'λύσας',     f: 'λύσασα',   n: 'λῦσαν'   },
-  { label: 'Aorist Middle',      m: 'λυσάμενος', f: 'λυσαμένη', n: 'λυσάμενον' },
-  { label: 'Aorist Passive',     m: 'λυθείς',    f: 'λυθεῖσα',  n: 'λυθέν'   },
-  { label: 'Perfect Active',     m: 'λελυκώς',   f: 'λελυκυῖα', n: 'λελυκός' },
+  // Present
+  { label: 'Present Active',      m: 'λύων',        f: 'λύουσα',    n: 'λῦον'        },
+  { label: 'Present Mid./Pass.',  m: 'λυόμενος',    f: 'λυομένη',   n: 'λυόμενον'    },
+  // Future
+  { label: 'Future Active',       m: 'λύσων',       f: 'λύσουσα',   n: 'λῦσον'       },
+  { label: 'Future Middle',       m: 'λυσόμενος',   f: 'λυσομένη',  n: 'λυσόμενον'   },
+  { label: 'Future Passive',      m: 'λυθησόμενος', f: 'λυθησομένη', n: 'λυθησόμενον' },
+  // Aorist
+  { label: 'Aorist Active',       m: 'λύσας',       f: 'λύσασα',    n: 'λῦσαν'       },
+  { label: 'Aorist Middle',       m: 'λυσάμενος',   f: 'λυσαμένη',  n: 'λυσάμενον'   },
+  { label: 'Aorist Passive',      m: 'λυθείς',      f: 'λυθεῖσα',   n: 'λυθέν'       },
+  // Perfect
+  { label: 'Perfect Active',      m: 'λελυκώς',     f: 'λελυκυῖα',  n: 'λελυκός'     },
+  { label: 'Perfect Mid./Pass.',  m: 'λελυμένος',   f: 'λελυμένη',  n: 'λελυμένον'   },
+];
+
+export const participleParadigms: ParticipleParadigm[] = [
+  // ── Present ───────────────────────────────────────────────────────────────
+  {
+    id: 'pres-act-ptc',
+    label: 'Present Active',
+    tense: 'present',
+    voice: 'active',
+    declensionNote: 'Masc./Neut.: 3rd declension (ντ-stem); Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λύων',    f: 'λύουσα',    n: 'λῦον'      }, pl: { m: 'λύοντες',    f: 'λύουσαι',    n: 'λύοντα'      } },
+      gen: { sg: { m: 'λύοντος', f: 'λυούσης',   n: 'λύοντος'   }, pl: { m: 'λυόντων',   f: 'λυουσῶν',   n: 'λυόντων'    } },
+      dat: { sg: { m: 'λύοντι',  f: 'λυούσῃ',    n: 'λύοντι'    }, pl: { m: 'λύουσι(ν)', f: 'λυούσαις',  n: 'λύουσι(ν)'  } },
+      acc: { sg: { m: 'λύοντα',  f: 'λύουσαν',   n: 'λῦον'      }, pl: { m: 'λύοντας',   f: 'λυούσας',   n: 'λύοντα'      } },
+      voc: { sg: { m: 'λύων',    f: 'λύουσα',    n: 'λῦον'      }, pl: { m: 'λύοντες',   f: 'λύουσαι',   n: 'λύοντα'      } },
+    },
+  },
+  {
+    id: 'pres-mid-pass-ptc',
+    label: 'Present Mid./Pass.',
+    tense: 'present',
+    voice: 'mid-pass',
+    declensionNote: 'Masc./Neut.: 2nd declension; Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λυόμενος',  f: 'λυομένη',   n: 'λυόμενον'  }, pl: { m: 'λυόμενοι',  f: 'λυόμεναι',  n: 'λυόμενα'   } },
+      gen: { sg: { m: 'λυομένου',  f: 'λυομένης',  n: 'λυομένου'  }, pl: { m: 'λυομένων',  f: 'λυομένων',  n: 'λυομένων'  } },
+      dat: { sg: { m: 'λυομένῳ',   f: 'λυομένῃ',   n: 'λυομένῳ'   }, pl: { m: 'λυομένοις', f: 'λυομέναις', n: 'λυομένοις' } },
+      acc: { sg: { m: 'λυόμενον',  f: 'λυομένην',  n: 'λυόμενον'  }, pl: { m: 'λυομένους', f: 'λυομένας',  n: 'λυόμενα'   } },
+      voc: { sg: { m: 'λυόμενε',   f: 'λυομένη',   n: 'λυόμενον'  }, pl: { m: 'λυόμενοι',  f: 'λυόμεναι',  n: 'λυόμενα'   } },
+    },
+  },
+  // ── Future ────────────────────────────────────────────────────────────────
+  {
+    id: 'fut-act-ptc',
+    label: 'Future Active',
+    tense: 'future',
+    voice: 'active',
+    declensionNote: 'Masc./Neut.: 3rd declension (ντ-stem); Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λύσων',    f: 'λύσουσα',   n: 'λῦσον'     }, pl: { m: 'λύσοντες',    f: 'λύσουσαι',   n: 'λύσοντα'     } },
+      gen: { sg: { m: 'λύσοντος', f: 'λυσούσης',  n: 'λύσοντος'  }, pl: { m: 'λυσόντων',   f: 'λυσουσῶν',  n: 'λυσόντων'   } },
+      dat: { sg: { m: 'λύσοντι',  f: 'λυσούσῃ',   n: 'λύσοντι'   }, pl: { m: 'λύσουσι(ν)', f: 'λυσούσαις', n: 'λύσουσι(ν)' } },
+      acc: { sg: { m: 'λύσοντα',  f: 'λύσουσαν',  n: 'λῦσον'     }, pl: { m: 'λύσοντας',   f: 'λυσούσας',  n: 'λύσοντα'     } },
+      voc: { sg: { m: 'λύσων',    f: 'λύσουσα',   n: 'λῦσον'     }, pl: { m: 'λύσοντες',   f: 'λύσουσαι',  n: 'λύσοντα'     } },
+    },
+  },
+  {
+    id: 'fut-mid-ptc',
+    label: 'Future Middle',
+    tense: 'future',
+    voice: 'middle',
+    declensionNote: 'Masc./Neut.: 2nd declension; Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λυσόμενος',  f: 'λυσομένη',   n: 'λυσόμενον'  }, pl: { m: 'λυσόμενοι',  f: 'λυσόμεναι',  n: 'λυσόμενα'   } },
+      gen: { sg: { m: 'λυσομένου',  f: 'λυσομένης',  n: 'λυσομένου'  }, pl: { m: 'λυσομένων',  f: 'λυσομένων',  n: 'λυσομένων'  } },
+      dat: { sg: { m: 'λυσομένῳ',   f: 'λυσομένῃ',   n: 'λυσομένῳ'   }, pl: { m: 'λυσομένοις', f: 'λυσομέναις', n: 'λυσομένοις' } },
+      acc: { sg: { m: 'λυσόμενον',  f: 'λυσομένην',  n: 'λυσόμενον'  }, pl: { m: 'λυσομένους', f: 'λυσομένας',  n: 'λυσόμενα'   } },
+      voc: { sg: { m: 'λυσόμενε',   f: 'λυσομένη',   n: 'λυσόμενον'  }, pl: { m: 'λυσόμενοι',  f: 'λυσόμεναι',  n: 'λυσόμενα'   } },
+    },
+  },
+  {
+    id: 'fut-pass-ptc',
+    label: 'Future Passive',
+    tense: 'future',
+    voice: 'passive',
+    declensionNote: 'Masc./Neut.: 2nd declension; Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λυθησόμενος',  f: 'λυθησομένη',   n: 'λυθησόμενον'  }, pl: { m: 'λυθησόμενοι',  f: 'λυθησόμεναι',  n: 'λυθησόμενα'   } },
+      gen: { sg: { m: 'λυθησομένου',  f: 'λυθησομένης',  n: 'λυθησομένου'  }, pl: { m: 'λυθησομένων',  f: 'λυθησομένων',  n: 'λυθησομένων'  } },
+      dat: { sg: { m: 'λυθησομένῳ',   f: 'λυθησομένῃ',   n: 'λυθησομένῳ'   }, pl: { m: 'λυθησομένοις', f: 'λυθησομέναις', n: 'λυθησομένοις' } },
+      acc: { sg: { m: 'λυθησόμενον',  f: 'λυθησομένην',  n: 'λυθησόμενον'  }, pl: { m: 'λυθησομένους', f: 'λυθησομένας',  n: 'λυθησόμενα'   } },
+      voc: { sg: { m: 'λυθησόμενε',   f: 'λυθησομένη',   n: 'λυθησόμενον'  }, pl: { m: 'λυθησόμενοι',  f: 'λυθησόμεναι',  n: 'λυθησόμενα'   } },
+    },
+  },
+  // ── Aorist ────────────────────────────────────────────────────────────────
+  {
+    id: 'aor-act-ptc',
+    label: 'Aorist Active',
+    tense: 'aorist',
+    voice: 'active',
+    declensionNote: 'Masc./Neut.: 3rd declension (αντ-stem); Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λύσας',    f: 'λύσασα',    n: 'λῦσαν'     }, pl: { m: 'λύσαντες',    f: 'λύσασαι',    n: 'λύσαντα'     } },
+      gen: { sg: { m: 'λύσαντος', f: 'λυσάσης',   n: 'λύσαντος'  }, pl: { m: 'λυσάντων',   f: 'λυσασῶν',   n: 'λυσάντων'   } },
+      dat: { sg: { m: 'λύσαντι',  f: 'λυσάσῃ',    n: 'λύσαντι'   }, pl: { m: 'λύσασι(ν)',  f: 'λυσάσαις',  n: 'λύσασι(ν)'  } },
+      acc: { sg: { m: 'λύσαντα',  f: 'λύσασαν',   n: 'λῦσαν'     }, pl: { m: 'λύσαντας',   f: 'λυσάσας',   n: 'λύσαντα'     } },
+      voc: { sg: { m: 'λύσας',    f: 'λύσασα',    n: 'λῦσαν'     }, pl: { m: 'λύσαντες',   f: 'λύσασαι',   n: 'λύσαντα'     } },
+    },
+  },
+  {
+    id: 'aor-mid-ptc',
+    label: 'Aorist Middle',
+    tense: 'aorist',
+    voice: 'middle',
+    declensionNote: 'Masc./Neut.: 2nd declension; Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λυσάμενος',  f: 'λυσαμένη',   n: 'λυσάμενον'  }, pl: { m: 'λυσάμενοι',  f: 'λυσάμεναι',  n: 'λυσάμενα'   } },
+      gen: { sg: { m: 'λυσαμένου',  f: 'λυσαμένης',  n: 'λυσαμένου'  }, pl: { m: 'λυσαμένων',  f: 'λυσαμένων',  n: 'λυσαμένων'  } },
+      dat: { sg: { m: 'λυσαμένῳ',   f: 'λυσαμένῃ',   n: 'λυσαμένῳ'   }, pl: { m: 'λυσαμένοις', f: 'λυσαμέναις', n: 'λυσαμένοις' } },
+      acc: { sg: { m: 'λυσάμενον',  f: 'λυσαμένην',  n: 'λυσάμενον'  }, pl: { m: 'λυσαμένους', f: 'λυσαμένας',  n: 'λυσάμενα'   } },
+      voc: { sg: { m: 'λυσάμενε',   f: 'λυσαμένη',   n: 'λυσάμενον'  }, pl: { m: 'λυσάμενοι',  f: 'λυσάμεναι',  n: 'λυσάμενα'   } },
+    },
+  },
+  {
+    id: 'aor-pass-ptc',
+    label: 'Aorist Passive',
+    tense: 'aorist',
+    voice: 'passive',
+    declensionNote: 'Masc./Neut.: 3rd declension (εντ-stem); Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λυθείς',    f: 'λυθεῖσα',   n: 'λυθέν'     }, pl: { m: 'λυθέντες',    f: 'λυθεῖσαι',   n: 'λυθέντα'     } },
+      gen: { sg: { m: 'λυθέντος',  f: 'λυθείσης',  n: 'λυθέντος'  }, pl: { m: 'λυθέντων',   f: 'λυθεισῶν',  n: 'λυθέντων'   } },
+      dat: { sg: { m: 'λυθέντι',   f: 'λυθείσῃ',   n: 'λυθέντι'   }, pl: { m: 'λυθεῖσι(ν)', f: 'λυθείσαις', n: 'λυθεῖσι(ν)' } },
+      acc: { sg: { m: 'λυθέντα',   f: 'λυθεῖσαν',  n: 'λυθέν'     }, pl: { m: 'λυθέντας',   f: 'λυθείσας',  n: 'λυθέντα'     } },
+      voc: { sg: { m: 'λυθείς',    f: 'λυθεῖσα',   n: 'λυθέν'     }, pl: { m: 'λυθέντες',   f: 'λυθεῖσαι',  n: 'λυθέντα'     } },
+    },
+  },
+  // ── Perfect ───────────────────────────────────────────────────────────────
+  {
+    id: 'perf-act-ptc',
+    label: 'Perfect Active',
+    tense: 'perfect',
+    voice: 'active',
+    declensionNote: 'Masc./Neut.: 3rd declension (οτ-stem); Fem.: 1st declension (υι-stem)',
+    forms: {
+      nom: { sg: { m: 'λελυκώς',    f: 'λελυκυῖα',   n: 'λελυκός'    }, pl: { m: 'λελυκότες',    f: 'λελυκυῖαι',   n: 'λελυκότα'    } },
+      gen: { sg: { m: 'λελυκότος',  f: 'λελυκυίας',  n: 'λελυκότος'  }, pl: { m: 'λελυκότων',   f: 'λελυκυιῶν',  n: 'λελυκότων'  } },
+      dat: { sg: { m: 'λελυκότι',   f: 'λελυκυίᾳ',   n: 'λελυκότι'   }, pl: { m: 'λελυκόσι(ν)', f: 'λελυκυίαις', n: 'λελυκόσι(ν)' } },
+      acc: { sg: { m: 'λελυκότα',   f: 'λελυκυῖαν',  n: 'λελυκός'    }, pl: { m: 'λελυκότας',   f: 'λελυκυίας',  n: 'λελυκότα'    } },
+      voc: { sg: { m: 'λελυκώς',    f: 'λελυκυῖα',   n: 'λελυκός'    }, pl: { m: 'λελυκότες',   f: 'λελυκυῖαι',  n: 'λελυκότα'    } },
+    },
+  },
+  {
+    id: 'perf-mid-pass-ptc',
+    label: 'Perfect Mid./Pass.',
+    tense: 'perfect',
+    voice: 'mid-pass',
+    declensionNote: 'Masc./Neut.: 2nd declension; Fem.: 1st declension',
+    forms: {
+      nom: { sg: { m: 'λελυμένος',  f: 'λελυμένη',   n: 'λελυμένον'  }, pl: { m: 'λελυμένοι',  f: 'λελυμέναι',  n: 'λελυμένα'   } },
+      gen: { sg: { m: 'λελυμένου',  f: 'λελυμένης',  n: 'λελυμένου'  }, pl: { m: 'λελυμένων',  f: 'λελυμένων',  n: 'λελυμένων'  } },
+      dat: { sg: { m: 'λελυμένῳ',   f: 'λελυμένῃ',   n: 'λελυμένῳ'   }, pl: { m: 'λελυμένοις', f: 'λελυμέναις', n: 'λελυμένοις' } },
+      acc: { sg: { m: 'λελυμένον',  f: 'λελυμένην',  n: 'λελυμένον'  }, pl: { m: 'λελυμένους', f: 'λελυμένας',  n: 'λελυμένα'   } },
+      voc: { sg: { m: 'λελυμένε',   f: 'λελυμένη',   n: 'λελυμένον'  }, pl: { m: 'λελυμένοι',  f: 'λελυμέναι',  n: 'λελυμένα'   } },
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/lib/paradigm-quiz.test.ts
+++ b/src/lib/paradigm-quiz.test.ts
@@ -115,27 +115,38 @@ describe('buildTableModels', () => {
 
   // ── Verbs ────────────────────────────────────────────────────────────────
 
-  it('includes verb paradigms including infinitives and participles', () => {
+  it('includes verb paradigms including infinitives and participle declension tables', () => {
     const tables = buildTableModels();
     const verbs = tables.filter(t => t.category === 'verb');
     const ids = verbs.map(v => v.id);
     expect(ids).toContain('verb-infinitives');
-    expect(ids).toContain('verb-participles');
+    expect(ids).toContain('participle-pres-act-ptc');
+    expect(ids).toContain('participle-aor-pass-ptc');
+    expect(ids).toContain('participle-perf-mid-pass-ptc');
   });
 
   it('verb conjugation tables have 1 column (Form)', () => {
     const tables = buildTableModels();
-    const conj = tables.filter(t => t.category === 'verb' && !['verb-infinitives', 'verb-participles'].includes(t.id));
+    const particleIds = tables
+      .filter(t => t.id.startsWith('participle-'))
+      .map(t => t.id);
+    const conj = tables.filter(
+      t => t.category === 'verb' && t.id !== 'verb-infinitives' && !particleIds.includes(t.id)
+    );
     for (const v of conj) {
       expect(v.cols).toHaveLength(1);
       expect(v.cols[0]).toBe('Form');
     }
   });
 
-  it('participle table has 3 columns (M, F, N)', () => {
+  it('participle tables have 6 leaf columns (Sg M/F/N + Pl M/F/N)', () => {
     const tables = buildTableModels();
-    const participles = tables.find(t => t.id === 'verb-participles')!;
-    expect(participles.cols).toHaveLength(3);
+    const participles = tables.filter(t => t.id.startsWith('participle-'));
+    expect(participles).toHaveLength(10);
+    for (const p of participles) {
+      expect(p.cols).toHaveLength(6);
+      expect(p.rows).toHaveLength(5); // 5 cases
+    }
   });
 
   it('imperative paradigms have null answers for missing person-numbers', () => {

--- a/src/lib/paradigm-quiz.ts
+++ b/src/lib/paradigm-quiz.ts
@@ -19,7 +19,7 @@ import {
   adjParadigms,
   verbParadigms,
   infinitiveForms,
-  participleRows,
+  participleParadigms,
   personalPronouns12,
   genderedPronouns,
   articleForms,
@@ -145,18 +145,28 @@ function buildVerbTables(): TableModel[] {
     })),
   };
 
-  const participleTable: TableModel = {
-    id: 'verb-participles',
-    label: 'Participles (λύω)',
-    category: 'verb',
-    cols: ['Masc.', 'Fem.', 'Neut.'],
-    rows: participleRows.map(row => ({
-      label: row.label,
-      answers: [row.m, row.f, row.n],
-    })),
-  };
+  const participleTables = buildParticipleParadigmTables();
 
-  return [...conjugationTables, infinitiveTable, participleTable];
+  return [...conjugationTables, infinitiveTable, ...participleTables];
+}
+
+/**
+ * Participle paradigms: one table per tense-voice combination, rows = cases,
+ * col groups = [Singular, Plural], leaf cols = [Masc., Fem., Neut.].
+ * Mirrors the adjective table structure.
+ */
+function buildParticipleParadigmTables(): TableModel[] {
+  return participleParadigms.map(p => ({
+    id: `participle-${p.id}`,
+    label: `${p.label} Participle (λύω)`,
+    category: 'verb' as const,
+    colGroups: NUMBERS.map(n => NUM_LABELS[n]),
+    cols: NUMBERS.flatMap(() => GENDERS.map(g => GENDER_LABELS[g])),
+    rows: CASES.map(c => ({
+      label: CASE_LABELS[c],
+      answers: NUMBERS.flatMap(n => GENDERS.map(g => p.forms[c][n][g])),
+    })),
+  }));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds 4 missing tense-voice combinations: Future Active, Future Middle, Future Passive, and Perfect Middle/Passive
- Participles now have their own nav section in the Grammar Reference (between Liquid Verbs and Pronouns), with tense tabs (Present / Future / Aorist / Perfect) and voice buttons driving a full declension card
- Full `ParticipleParadigmCard` component shows all 5 cases × 2 numbers × 3 genders with mobile Sg/Pl toggle and a declension note footer
- Paradigm Quiz replaces the old nom-sg-only participle table with 10 full declension tables (6 leaf columns, 5 case rows), matching the adjective quiz structure
- PRD added at `docs/prd/participle-expansion.md`

## Test plan

- [ ] All 378 tests pass (`vitest run`)
- [ ] Zero TypeScript errors (`tsc --noEmit`)
- [ ] Grammar Reference `/grammar` → "Participles" nav link scrolls to section
- [ ] Tense tabs (Present / Future / Aorist / Perfect) switch paradigm group
- [ ] Voice buttons within each tense switch the declension card
- [ ] Mobile Sg/Pl toggle works on the declension card
- [ ] Hover on case label shows description bar
- [ ] Paradigm Quiz `/paradigms` → Verbs tab includes all 10 participle tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)