### PR TITLE
fix(csp): allow PostHog, Cloudflare Insights, and Daily Dose origins

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -19,4 +19,4 @@
   # To remove 'unsafe-inline', generate per-build hashes and inject them here — not worth the
   # complexity for a static site with no user-generated content.
   # style-src includes 'unsafe-inline' because React uses inline style attributes (e.g. style={{ color: ... }}).
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://dailydoseofgreek.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://us-assets.i.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://dailydoseofgreek.com https://us.i.posthog.com https://us-assets.i.posthog.com https://beacon.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';


### PR DESCRIPTION
## Summary

- PostHog scripts (`us-assets.i.posthog.com`) were blocked by `script-src`, preventing session recording from loading
- PostHog API calls (`us.i.posthog.com`, `us-assets.i.posthog.com`) were blocked by `connect-src`, silently dropping all analytics events (~10+ CSP violations per page load)
- Cloudflare Insights (`static.cloudflareinsights.com`, `beacon.cloudflareinsights.com`) was blocked entirely
- Added all required origins to `script-src` and `connect-src`

## Test plan

- [ ] Deploy to Cloudflare and open the site in Chrome DevTools — no CSP violations in the console
- [ ] Confirm PostHog events appear in the PostHog dashboard
- [ ] Confirm Daily Dose verse loads correctly on `/daily`

🤖 Generated with [Claude Code](https://claude.com/claude-code)