### PR TITLE
feat(analytics): configure PostHog reverse proxy

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,6 +50,7 @@ function isActive(href: string) {
       if (import.meta.env.PROD && key) {
         posthog.init(key, {
           api_host: host,
+          ui_host: 'https://us.posthog.com',
           session_recording: { sample_rate: 0.2 },
           capture_pageview: true,
           capture_pageleave: false,


### PR DESCRIPTION
## Summary
- Adds `ui_host: 'https://us.posthog.com'` to the PostHog init so toolbar and UI links resolve correctly when using the managed reverse proxy
- `api_host` now routes through `t.greek.tools` (set via `PUBLIC_POSTHOG_HOST` in Cloudflare Pages env vars)

## Test plan
- [ ] Deploy to Cloudflare Pages and confirm PostHog events appear in the dashboard routing through `t.greek.tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)