### PR TITLE
fix(reader): map C- POS code to Conjunction label

### DIFF
--- a/src/data/morphgnt.ts
+++ b/src/data/morphgnt.ts
@@ -45,6 +45,7 @@ const POS_LABEL: Record<string, string> = {
   'V-': 'Verb',
   'P-': 'Preposition',
   'D-': 'Adverb',
+  'C-': 'Conjunction',
   'CC': 'Conjunction',
   'CS': 'Conjunction',
   'I-': 'Interjection',


### PR DESCRIPTION
- Add mapping for `C-` POS code to `Conjunction` label in morphological data
- Ensures consistent labeling alongside existing `CC` and `CS` conjunction codes