### PR TITLE
docs: add μι-verb PRD and Android keyboard bug; update CSP

### DIFF
--- a/docs/bugs/greek-keyboard-android.md
+++ b/docs/bugs/greek-keyboard-android.md
@@ -1,0 +1,77 @@
+# Bug: Greek Keyboard Non-Functional on Android
+
+## Summary
+
+The Greek keyboard input tool (`/keyboard`) does not produce Greek characters when used on an Android phone. Typing produces either nothing, the raw Latin characters, or garbled output.
+
+---
+
+## Affected Pages / Components
+
+- `/keyboard` — `GreekKeyboard.tsx`
+- `/paradigms` — `ParadigmQuiz` cell inputs (share the same `processGreekKey` from `src/lib/greek-input.ts`)
+
+---
+
+## Root Cause
+
+`GreekKeyboard` and the paradigm quiz inputs rely entirely on `onKeyDown` events to intercept keystrokes and map them to Greek characters via `processGreekKey`. On Android, the software keyboard does not fire standard `KeyboardEvent` values — instead, it fires:
+
+- `keydown` events where `event.key === "Unidentified"` (Chrome/WebView on Android)
+- Composition events (`compositionstart` / `compositionupdate` / `compositionend`) rather than discrete key events
+
+Because `GREEK_MAP` and `DIACRITIC_MAP` both look up by `event.key`, every keystroke on Android results in a no-op. The `onChange` handler on the textarea then writes the raw Latin character through to state, producing untranslated output.
+
+```typescript
+// greek-input.ts — processGreekKey is only called from onKeyDown
+// Android fires key: "Unidentified" → neither GREEK_MAP nor DIACRITIC_MAP match
+export function processGreekKey(key: string, ctrlOrMeta: boolean) {
+  const diacritic = DIACRITIC_MAP[key]; // miss
+  const greek = GREEK_MAP[key];         // miss
+  return { preventDefault: false, append: null }; // no-op → raw char leaks through
+}
+```
+
+---
+
+## Reproduction Steps
+
+1. Open `https://greek.tools/keyboard` (or `/paradigms`) on an Android phone in Chrome.
+2. Tap the textarea.
+3. Type any letter using the on-screen keyboard (e.g., "a").
+4. Observe: the letter "a" appears rather than "α".
+
+---
+
+## Expected Behavior
+
+Typing "a" should produce "α", consistent with the desktop experience.
+
+---
+
+## Proposed Fix
+
+Replace the `onKeyDown`-only approach with an `onInput` / `beforeinput` handler that intercepts the incoming characters from the `InputEvent` rather than the `KeyboardEvent`. The `InputEvent.data` property contains the actual character being inserted on all platforms, including Android.
+
+**High-level approach:**
+
+1. Replace the current `onKeyDown` + `onChange` pair with a single `onBeforeInput` handler (or `onInput` with manual cursor management).
+2. In the handler, read `event.data` (the character about to be inserted), look it up in `GREEK_MAP` / `DIACRITIC_MAP`, and replace it with the Greek equivalent before it reaches the DOM — or `preventDefault` and append to React state manually, same as the current approach.
+3. Update `processGreekKey` (or add a parallel `processGreekInput(data: string)`) to accept a raw character string rather than a `KeyboardEvent.key` value, so the lookup logic is shared between desktop and mobile paths.
+
+**Alternative (simpler, lower fidelity):** Add a visible on-screen Greek character grid below the textarea — a set of buttons, one per Greek letter — that appends characters to state on click. This sidesteps the keyboard event issue entirely and works on all platforms, but sacrifices the "type in English" ergonomics.
+
+---
+
+## Acceptance Criteria
+
+- Typing Latin characters on an Android soft keyboard produces the correct Greek output in the textarea at `/keyboard`
+- Typing in paradigm quiz cell inputs on Android produces Greek characters
+- Existing desktop behavior (including diacritics via `(`, `)`, `/`, `\`, `=`, `|`) is unchanged
+- Final sigma auto-conversion still applies
+
+---
+
+## Priority
+
+**Medium.** The tool is usable on desktop and iOS (which fires standard `KeyboardEvent.key` values). Android users are blocked entirely.

--- a/docs/prd/mi-verb-paradigms.md
+++ b/docs/prd/mi-verb-paradigms.md
@@ -2,32 +2,41 @@
 
 ## Overview
 
-Reference tables for the major μι-verbs in the GNT. These verbs follow a different conjugation pattern from the standard -ω verbs and are consistently difficult for intermediate students because they appear frequently in the text but aren't covered by the λύω paradigm.
+Reference tables for the major μι-verbs in the GNT. These verbs follow a different conjugation pattern from the standard ω-verbs and are consistently difficult for intermediate students because they appear frequently in the text but aren't covered by the λύω paradigm. μι-verbs use athematic (reduplicated) stems and a distinct set of personal endings that must be learned separately.
+
+---
+
+## Status
+
+**Planned.** Not yet implemented. The existing Grammar Reference covers ω-verbs (λύω), contract verbs, and liquid verbs, but has no μι-verb section.
 
 ---
 
 ## Goals
 
-- Give students a dedicated reference for μι-verb forms alongside the standard Grammar Reference
+- Give students a dedicated reference for μι-verb forms alongside the existing Grammar Reference
 - Cover the four highest-frequency μι-verbs in the GNT
-- Use the same table format and interaction model as the existing Grammar Reference
+- Surface the key structural differences between μι-verbs and ω-verbs so students can recognize forms in the text
+- Reuse the same card layout, interaction model, and data architecture as the existing Grammar Reference
 
 ---
 
 ## Priority
 
-Medium-High
+**Medium-High.** The four verbs covered appear a combined 812 times in the GNT. Students regularly encounter forms that look nothing like the λύω paradigm and have no reference for them.
 
 ---
 
 ## Verbs to Cover
 
-| Verb | Gloss | GNT Frequency |
-|------|-------|---------------|
-| δίδωμι | I give | 415× |
-| τίθημι | I place, put | 100× |
-| ἵστημι | I stand, set | 154× |
-| ἀφίημι | I forgive, release, permit | 143× |
+| Verb | Gloss | GNT Frequency | Notes |
+|------|-------|---------------|-------|
+| δίδωμι | I give | 415× | Most frequent; o/ω stem alternation |
+| ἵστημι | I stand / I set | 154× | Intransitive vs. transitive distinction by tense; 2nd aorist ἔστην |
+| ἀφίημι | I forgive, release, permit | 143× | Compound of ἀπό + ἵημι; shares ἵημι stem patterns |
+| τίθημι | I place, put | 100× | e/η stem alternation; 2nd aorist ἔθηκα (mixed) |
+
+**Deferred:** εἰμί — treated as a special case and will be added in a later phase.
 
 ---
 
@@ -35,44 +44,106 @@ Medium-High
 
 ### 1. Paradigm Tables
 
-For each verb, display the following tense/mood combinations:
+For each verb, display conjugation tables in the tense/mood combinations most critical for GNT reading. Coverage mirrors what the contract verbs section provides: indicative mood across key tenses, plus common non-indicative forms.
 
-- Present active/middle-passive indicative
-- Imperfect active/middle-passive indicative
-- Present active subjunctive
-- Present active imperative
-- Present active/passive infinitive
-- Present active participle (nominative singular M/F/N)
-- Aorist active/middle/passive indicative (including 2nd aorist forms where applicable)
-- Aorist active/middle/passive infinitive and participle
+**Tenses and moods per verb:**
 
-**Behavior:**
-- Same card layout, navy header, hover description bar as Grammar Reference paradigm tables
-- Each table labelled clearly with verb + tense/mood
-- Note where a μι-verb uses a 2nd aorist (e.g., ἵστημι aorist ἔστην)
+| Form | Notes |
+|------|-------|
+| Present active indicative | Athematic endings (-μι, -ς, -σι, -μεν, -τε, -ᾶσι) |
+| Present middle-passive indicative | |
+| Imperfect active indicative | Augmented; same athematic pattern |
+| Imperfect middle-passive indicative | |
+| Present active subjunctive | Lengthened vowel endings |
+| Present active imperative | |
+| Present active infinitive | |
+| Present active participle | Nominative singular M/F/N only |
+| Aorist active indicative | 1st aorist (δίδωμι, τίθημι) or 2nd aorist (ἵστημι, ἀφίημι) — note where applicable |
+| Aorist middle indicative | Where applicable |
+| Aorist passive indicative | |
+| Aorist active infinitive | |
+| Aorist active participle | Nominative singular M/F/N only |
 
-### 2. Pattern Notes
+**Display behavior:**
+- Same card layout as existing Grammar Reference paradigm tables: navy header bar, 6-row person × number grid (1sg–3pl), hover/tap description bar showing full parse
+- Label each card clearly: verb name + tense + voice + mood (e.g., "δίδωμι — Present Active Indicative")
+- Where a verb uses a 2nd aorist, call it out explicitly in the card header (e.g., "2nd Aorist Active Indicative — ἔστην")
+- Endings-only toggle: same behavior as noun and adjective tables — strips the stem to isolate the ending
 
-A brief callout per verb explaining the key pattern differences from -ω verbs:
+### 2. Verb Selector Grid
 
-- Reduplication in present stem (δι-δω-, τι-θη-, ἵ-στη-)
-- Athematic personal endings in present/imperfect (-μι, -ς, -σι vs. -ω, -εις, -ει)
-- Alternating long/short stem vowels (δίδωμι / δίδομεν)
+Reuse the `VerbParadigmGrid` pattern from the existing Verbs section. A tense × voice grid lets students navigate to the paradigm they need without scrolling through all cards at once.
 
-### 3. Integration with Grammar Reference
+- Rows: Present, Imperfect, Aorist
+- Columns: Active, Middle, Passive
+- Cells show the 1st singular form as a preview (or a dot if that combination doesn't exist for that verb)
+- Tabs above the grid switch between the four verbs
 
-Add a "μι-Verbs" section to the Grammar Reference sidebar navigation, or link from the Verbs section to a dedicated `/grammar/mi-verbs` sub-route.
+### 3. Pattern Notes
+
+A callout card per verb (or a shared introductory card for the section) explaining the key structural differences from ω-verbs. These are the things students need to internalize to recognize μι-verb forms in the wild.
+
+**Section-level note (shared):**
+- μι-verbs use reduplication in the present stem: δι-δω-, τι-θη-, ἵ-στη-, ἀφ-ι-η-
+- Present and imperfect use athematic personal endings (-μι, -ς, —, -μεν, -τε, -ᾶσι) rather than thematic (-ω, -εις, -ει, -ομεν, -ετε, -ουσι)
+- Stem vowel alternates between long (singular) and short (plural) forms in the present and imperfect
+
+**Per-verb notes:**
+
+| Verb | Key pattern note |
+|------|-----------------|
+| δίδωμι | Stem vowel: ω (singular) / ο (plural). 1st aorist ἔδωκα (κ-aorist). |
+| ἵστημι | Transitive in present/imperfect ("I set"), intransitive in 2nd aorist/perfect ("I stood/stand"). 2nd aorist ἔστην uses 2nd aorist passive endings. |
+| ἀφίημι | Compound (ἀπό + ἵημι). The simplex ἵημι rarely appears alone in the GNT; ἀφ- prefix is standard. η/ε stem alternation follows ἵημι. |
+| τίθημι | Stem vowel: η (singular) / ε (plural). Aorist is mixed: ἔθηκα looks like a 1st aorist but uses 2nd aorist forms in some persons. |
+
+### 4. Integration with Grammar Reference
+
+Add a "μι-Verbs" entry to the `NAV_SECTIONS` array in `GrammarReference.tsx`, inserting it after the existing "Liquid Verbs" section. The new section renders inline on the same `/grammar` page, consistent with all other Grammar Reference sections.
+
+No sub-route (`/grammar/mi-verbs`) needed — keeping everything on one page preserves the lookup-first UX.
+
+---
+
+## Data Architecture
+
+Follow the existing pattern in `src/data/grammar.ts`.
+
+**New type:**
+
+```typescript
+interface MiVerbParadigm {
+  id: string;
+  verb: 'didomi' | 'histemi' | 'aphiemi' | 'tithemi';
+  label: string;           // e.g., "Present Active Indicative"
+  tense: 'pres' | 'impf' | 'aor';
+  voice: 'act' | 'mid' | 'pass' | 'mid-pass';
+  group: 'indicative' | 'subjunctive' | 'imperative';
+  isSecondAorist?: boolean;
+  forms: Partial<Record<PersonNum, string>>;
+}
+```
+
+**New constant:**
+
+```typescript
+export const miVerbParadigms: MiVerbParadigm[] = [ ... ];
+```
+
+Reuse existing `PersonNum`, `PERSONS`, and `NUMBERS` label constants — no new label infrastructure needed.
 
 ---
 
 ## Out of Scope
 
-- Full declension of all μι-verb forms across all moods (comprehensive coverage deferred; focus on the most common forms)
-- εἰμί (handled separately as a special case; could be added as a 5th entry later)
+- Full coverage of all moods and tenses across all persons (this PRD focuses on the forms most frequently encountered in GNT reading)
+- εἰμί (deferred; may be added as a 5th entry later)
+- Compound forms beyond ἀφίημι (e.g., παραδίδωμι, ἀνίστημι) — the base paradigms cover these by analogy
+- Parsing drills for μι-verb forms (see Parsing & Drills PRD for integration point)
 
 ---
 
 ## Open Questions
 
-- Should μι-verbs be a sub-section within `/grammar` or a separate page?
-- Should εἰμί be included in this feature or treated separately?
+- Should εἰμί be included here or remain deferred? It has ~2,460 GNT occurrences and students need it urgently, but its paradigm is irregular enough that it may warrant its own treatment.
+- Should the Paradigm Quiz (`/paradigms`) expose μι-verb tables via a new `buildMiVerbTables()` function, similar to `buildContractVerbTables()`? Worth doing at the same time to avoid a second pass.


### PR DESCRIPTION
## Changes

- **docs/bugs/greek-keyboard-android.md** (new): Added comprehensive bug ticket for Greek keyboard input failing on Android due to `onKeyDown` event limitations. Includes root cause analysis, reproduction steps, and proposed fix using `onInput`/`beforeinput` handlers.

- **docs/prd/mi-verb-paradigms.md** (expanded): Completed μι-verb paradigm reference PRD with detailed coverage plan:
  - Added status section (Planned)
  - Expanded verb list with frequency counts and structural notes (δίδωμι, ἵστημι, ἀφίημι, τίθημι)
  - Detailed tense/mood coverage per verb
  - Specified card layout and interaction model
  - Added data architecture with new `MiVerbParadigm` interface
  - Deferred εἰμί to later phase

- **public/_headers**: Updated CSP to allow PostHog reverse proxy (`https://t.greek.tools`) and Cloudflare Insights origins for analytics.

- **src/data/morphgnt.ts**: Added mapping for `C-` POS code to "Conjunction" label.

- **src/layouts/Layout.astro**: Replaced ὁπλον easter egg with animated text morph—footer now transitions between English ("greek.tools") and Greek ("ἑλληνικά ὅπλα") on hover.
