### PR TITLE
Add fix-issue slash command

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,0 +1,9 @@
+Implement GitHub issue #$ARGUMENTS in this repository.
+
+1. Run `gh issue view $ARGUMENTS` to read the full issue spec
+2. Understand the overview, goals, features, acceptance criteria, and technical notes thoroughly before writing any code
+3. If there are open questions in the issue that would materially affect the implementation, ask before starting
+4. Implement the feature according to the spec
+5. Write tests covering the acceptance criteria (aim for 90% coverage on new code)
+6. Ensure all existing tests still pass
+7. Use `closes #$ARGUMENTS` in your commit message to link the implementation to the issue


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/fix-issue.md` — a project-level slash command that reads a GitHub issue spec and implements it with tests, using `closes #N` in the commit to auto-close the issue on merge

## Usage

```
/fix-issue 40
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)