### PR TITLE
feat(parse): add verb parsing challenge

### DIFF
--- a/.claude/dev.sh
+++ b/.claude/dev.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 export PATH="/opt/homebrew/bin:/opt/homebrew/Cellar/node/25.3.0/bin:$PATH"
-cd /Users/mitch/code/greek-tools/.claude/worktrees/lucid-elion
+WORKTREE="/Users/mitch/code/greek-tools/.claude/worktrees/lucid-elion"
+MAIN="/Users/mitch/code/greek-tools"
+# Mirror public/data from main repo if not already present
+if [ ! -d "$WORKTREE/public/data" ]; then
+  mkdir -p "$WORKTREE/public"
+  cp -r "$MAIN/public/data" "$WORKTREE/public/data"
+fi
+cd "$WORKTREE"
 npm run dev -- --port 4330

--- a/.claude/dev.sh
+++ b/.claude/dev.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export PATH="/opt/homebrew/bin:/opt/homebrew/Cellar/node/25.3.0/bin:$PATH"
-cd /Users/mitch/code/greek-tools
+cd /Users/mitch/code/greek-tools/.claude/worktrees/lucid-elion
 npm run dev -- --port 4330

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,8 @@
     {
       "name": "greek-tools",
       "runtimeExecutable": "/bin/sh",
-      "runtimeArgs": ["-c", "export PATH=/opt/homebrew/bin:/opt/homebrew/Cellar/node/25.3.0/bin:$PATH && cd /Users/mitch/code/greek-tools/.claude/worktrees/thirsty-davinci && npm run dev -- --port 4331"],
-      "port": 4331,
+      "runtimeArgs": ["/Users/mitch/code/greek-tools/.claude/worktrees/lucid-elion/.claude/dev.sh"],
+      "port": 4330,
       "autoPort": true
     }
   ]

--- a/src/components/GNTParseChallenge.tsx
+++ b/src/components/GNTParseChallenge.tsx
@@ -1,0 +1,287 @@
+import React, { useState, useEffect } from 'react';
+import PassageSelector from './PassageSelector';
+import GNTParseQuestion from './GNTParseQuestion';
+import ParseResults from './ParseResults';
+import type { SessionResults } from './ParseResults';
+import { splitWordPunct } from '../data/morphgnt';
+import { fetchBook } from '../data/morphgnt';
+import type { MorphBook } from '../data/morphgnt';
+import {
+  extractVerbs, sampleVerbs, gradeGNTAnswer, emptyGNTAnswer,
+  loadGNTSettings, saveGNTSettings,
+  DEFAULT_GNT_SETTINGS,
+  GNT_TENSE_LABELS, GNT_VOICE_LABELS, GNT_MOOD_LABELS,
+  GNT_PERSON_LABELS, GNT_NUMBER_LABELS, GNT_CASE_LABELS, GNT_GENDER_LABELS,
+  FINITE_MOODS,
+} from '../lib/gnt-parse';
+import type { GNTParseItem, GNTParseAnswer, GNTParseResult, GNTPassageSettings } from '../lib/gnt-parse';
+import { fetchBooks } from '../data/morphgnt';
+
+type Phase = 'select' | 'question' | 'feedback' | 'results';
+
+export default function GNTParseChallenge() {
+  const [settings, setSettings] = useState<GNTPassageSettings>(DEFAULT_GNT_SETTINGS);
+  const [bookData, setBookData] = useState<MorphBook | null>(null);
+  const [bookName, setBookName] = useState('John');
+  const [verbCount, setVerbCount] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [phase, setPhase] = useState<Phase>('select');
+  const [session, setSession] = useState<GNTParseItem[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answer, setAnswer] = useState<GNTParseAnswer>(emptyGNTAnswer());
+  const [results, setResults] = useState<GNTParseResult[]>([]);
+  const [currentResult, setCurrentResult] = useState<GNTParseResult | null>(null);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+
+  // Load settings on mount
+  useEffect(() => {
+    setSettings(loadGNTSettings());
+    setSettingsLoaded(true);
+  }, []);
+
+  // Fetch book data whenever book or chapter changes
+  useEffect(() => {
+    if (!settingsLoaded) return;
+    setVerbCount(null);
+    setLoading(true);
+    Promise.all([
+      fetchBook(settings.book),
+      fetchBooks(),
+    ]).then(([data, books]) => {
+      setBookData(data);
+      const meta = books.find(b => b.code === settings.book);
+      if (meta) setBookName(meta.name);
+      const verbs = extractVerbs(data, String(settings.chapter), meta?.name ?? settings.book);
+      setVerbCount(verbs.length);
+    }).catch(console.error).finally(() => setLoading(false));
+  }, [settings.book, settings.chapter, settingsLoaded]);
+
+  function handleSettingsChange(s: GNTPassageSettings) {
+    setSettings(s);
+    saveGNTSettings(s);
+  }
+
+  function handleStart() {
+    if (!bookData) return;
+    const all = extractVerbs(bookData, String(settings.chapter), bookName);
+    const count = settings.sessionLength === 'all' ? all.length : settings.sessionLength;
+    const items = sampleVerbs(all, count);
+    if (items.length === 0) return;
+    setSession(items);
+    setCurrentIndex(0);
+    setResults([]);
+    setAnswer(emptyGNTAnswer());
+    setCurrentResult(null);
+    setPhase('question');
+  }
+
+  function handleSubmit() {
+    const result = gradeGNTAnswer(session[currentIndex], answer);
+    setCurrentResult(result);
+    setPhase('feedback');
+  }
+
+  function handleNext() {
+    const updated = [...results, currentResult!];
+    setResults(updated);
+    if (currentIndex + 1 >= session.length) {
+      setPhase('results');
+    } else {
+      setCurrentIndex(i => i + 1);
+      setAnswer(emptyGNTAnswer());
+      setCurrentResult(null);
+      setPhase('question');
+    }
+  }
+
+  // Adapt GNTParseResult[] → ParseResult[] for the shared ParseResults component
+  const sessionResults: SessionResults = {
+    results: results.map(r => ({
+      tense:  r.tense,
+      voice:  r.voice,
+      mood:   r.mood,
+      // For person/number/case/gender: count nulls as correct (not graded)
+      person: r.person ?? true,
+      number: r.number ?? true,
+      allCorrect: r.allCorrect,
+    })),
+    total: session.length,
+  };
+
+  if (!settingsLoaded) return null;
+
+  if (phase === 'select') {
+    return (
+      <PassageSelector
+        settings={settings}
+        verbCount={verbCount}
+        onChange={handleSettingsChange}
+        onStart={handleStart}
+        loading={loading}
+      />
+    );
+  }
+
+  if (phase === 'question' && session[currentIndex]) {
+    return (
+      <GNTParseQuestion
+        item={session[currentIndex]}
+        index={currentIndex}
+        total={session.length}
+        answer={answer}
+        onChange={setAnswer}
+        onSubmit={handleSubmit}
+      />
+    );
+  }
+
+  if (phase === 'feedback' && session[currentIndex] && currentResult) {
+    return (
+      <GNTFeedback
+        item={session[currentIndex]}
+        answer={answer}
+        result={currentResult}
+        onNext={handleNext}
+        isLast={currentIndex + 1 >= session.length}
+      />
+    );
+  }
+
+  if (phase === 'results') {
+    return (
+      <ParseResults
+        sessionResults={sessionResults}
+        onRetry={handleStart}
+        onChangeSettings={() => {
+          setPhase('select');
+          setSession([]);
+          setResults([]);
+          setCurrentIndex(0);
+        }}
+      />
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Inline feedback — similar to ParseFeedback but handles nullable properties
+// ---------------------------------------------------------------------------
+
+function GNTFeedback({
+  item,
+  answer,
+  result,
+  onNext,
+  isLast,
+}: {
+  item: GNTParseItem;
+  answer: GNTParseAnswer;
+  result: GNTParseResult;
+  onNext: () => void;
+  isLast: boolean;
+}) {
+  const isFinite   = item.type === 'finite';
+  const isParticiple = item.type === 'participle';
+
+  // Build the correct parse label
+  const correctLabel = (() => {
+    if (item.type === 'finite') {
+      return `${GNT_PERSON_LABELS[item.person]} ${GNT_TENSE_LABELS[item.tense]} ${GNT_VOICE_LABELS[item.voice]} ${GNT_MOOD_LABELS[item.mood]} ${GNT_NUMBER_LABELS[item.number]}`;
+    }
+    if (item.type === 'infinitive') {
+      return `${GNT_TENSE_LABELS[item.tense]} ${GNT_VOICE_LABELS[item.voice]} Infinitive`;
+    }
+    return `${GNT_TENSE_LABELS[item.tense]} ${GNT_VOICE_LABELS[item.voice]} Participle — ${GNT_CASE_LABELS[item.parseCase]} ${GNT_NUMBER_LABELS[item.number]} ${GNT_GENDER_LABELS[item.gender]}`;
+  })();
+
+  return (
+    <div className="max-w-lg mx-auto space-y-5">
+      {/* Form + ref */}
+      <div className="text-center py-5">
+        <p className="text-xs uppercase tracking-widest text-text-muted mb-1">{item.verseRef}</p>
+        <p className="text-4xl font-bold" style={{ fontFamily: 'var(--font-greek)', color: 'var(--color-accent)' }}>
+          {item.form}
+        </p>
+        <p className="mt-2 text-sm text-text-muted">{correctLabel}</p>
+      </div>
+
+      {/* Per-property rows */}
+      <div className="space-y-2">
+        <FeedbackRow property="Tense" correct={result.tense}
+          given={answer.tense ? GNT_TENSE_LABELS[answer.tense] : '—'}
+          expected={GNT_TENSE_LABELS[item.tense]} />
+        <FeedbackRow property="Voice" correct={result.voice}
+          given={answer.voice ? GNT_VOICE_LABELS[answer.voice] : '—'}
+          expected={GNT_VOICE_LABELS[item.voice]} />
+        <FeedbackRow property="Mood" correct={result.mood}
+          given={answer.mood ? GNT_MOOD_LABELS[answer.mood] : '—'}
+          expected={GNT_MOOD_LABELS[item.mood]} />
+
+        {/* Finite */}
+        {isFinite && item.type === 'finite' && (
+          <>
+            <FeedbackRow property="Person" correct={result.person!}
+              given={answer.person ? GNT_PERSON_LABELS[answer.person] : '—'}
+              expected={GNT_PERSON_LABELS[item.person]} />
+            <FeedbackRow property="Number" correct={result.number!}
+              given={answer.number ? GNT_NUMBER_LABELS[answer.number] : '—'}
+              expected={GNT_NUMBER_LABELS[item.number]} />
+          </>
+        )}
+
+        {/* Participle */}
+        {isParticiple && item.type === 'participle' && (
+          <>
+            <FeedbackRow property="Case" correct={result.parseCase!}
+              given={answer.parseCase ? GNT_CASE_LABELS[answer.parseCase] : '—'}
+              expected={GNT_CASE_LABELS[item.parseCase]} />
+            <FeedbackRow property="Number" correct={result.number!}
+              given={answer.number ? GNT_NUMBER_LABELS[answer.number] : '—'}
+              expected={GNT_NUMBER_LABELS[item.number]} />
+            <FeedbackRow property="Gender" correct={result.gender!}
+              given={answer.gender ? GNT_GENDER_LABELS[answer.gender] : '—'}
+              expected={GNT_GENDER_LABELS[item.gender]} />
+          </>
+        )}
+      </div>
+
+      {/* Verdict */}
+      <div className={[
+        'rounded-xl px-5 py-3 text-center font-semibold text-sm',
+        result.allCorrect ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700',
+      ].join(' ')}>
+        {result.allCorrect ? 'Correct!' : 'Not quite — review the corrections above.'}
+      </div>
+
+      <button
+        onClick={onNext}
+        className="w-full py-3 rounded-xl text-base font-bold bg-[var(--color-accent)] text-white hover:opacity-90 transition-opacity"
+      >
+        {isLast ? 'See Results' : 'Next Form'}
+      </button>
+    </div>
+  );
+}
+
+function FeedbackRow({ property, correct, given, expected }: {
+  property: string; correct: boolean; given: string; expected: string;
+}) {
+  return (
+    <div className={['flex items-center justify-between rounded-lg px-4 py-2.5 text-sm', correct ? 'bg-green-50' : 'bg-red-50'].join(' ')}>
+      <span className={['font-semibold', correct ? 'text-green-700' : 'text-red-700'].join(' ')}>{property}</span>
+      <div className="flex items-center gap-2">
+        {correct ? (
+          <span className="text-green-700 font-medium">{given}</span>
+        ) : (
+          <>
+            <span className="text-red-500 line-through">{given}</span>
+            <span className="text-red-700 font-semibold">{expected}</span>
+          </>
+        )}
+        <span className={correct ? 'text-green-600' : 'text-red-600'}>{correct ? '✓' : '✗'}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GNTParseQuestion.tsx
+++ b/src/components/GNTParseQuestion.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { splitWordPunct } from '../data/morphgnt';
+import type { MorphWord } from '../data/morphgnt';
+import type { GNTParseItem, GNTParseAnswer, GNTTense, GNTVoice, GNTMood, GNTPerson, GNTNumber, GNTCase, GNTGender } from '../lib/gnt-parse';
+import {
+  GNT_TENSES, GNT_VOICES, GNT_MOODS, GNT_PERSONS, GNT_NUMBERS, GNT_CASES, GNT_GENDERS,
+  GNT_TENSE_LABELS, GNT_VOICE_LABELS, GNT_MOOD_LABELS, GNT_PERSON_LABELS,
+  GNT_NUMBER_LABELS, GNT_CASE_LABELS, GNT_GENDER_LABELS,
+  FINITE_MOODS,
+} from '../lib/gnt-parse';
+
+interface Props {
+  item: GNTParseItem;
+  index: number;
+  total: number;
+  answer: GNTParseAnswer;
+  onChange: (a: GNTParseAnswer) => void;
+  onSubmit: () => void;
+}
+
+export default function GNTParseQuestion({ item, index, total, answer, onChange, onSubmit }: Props) {
+  const selectedMood = answer.mood as GNTMood | '';
+  const isFiniteMood = selectedMood && FINITE_MOODS.includes(selectedMood);
+  const isParticiple = selectedMood === 'participle';
+  const isInfinitive = selectedMood === 'infinitive';
+
+  // Clear conditional fields when mood changes
+  function handleMoodChange(mood: GNTMood) {
+    onChange({ ...answer, mood, person: '', number: '', parseCase: '', gender: '' });
+  }
+
+  const canSubmit = (() => {
+    if (!answer.tense || !answer.voice || !answer.mood) return false;
+    if (isFiniteMood) return !!(answer.person && answer.number);
+    if (isParticiple)  return !!(answer.parseCase && answer.number && answer.gender);
+    if (isInfinitive)  return true;
+    return false;
+  })();
+
+  return (
+    <div className="max-w-lg mx-auto space-y-6">
+      {/* ── Progress ────────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-1.5 bg-bg-card rounded-full overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all duration-300"
+            style={{ width: `${(index / total) * 100}%`, background: 'var(--color-accent)' }}
+          />
+        </div>
+        <span className="text-sm text-text-muted whitespace-nowrap">{index + 1} / {total}</span>
+      </div>
+
+      {/* ── Verse context ────────────────────────────────────────────────── */}
+      <div className="bg-bg-card rounded-xl p-4">
+        <p className="text-xs uppercase tracking-widest text-text-muted mb-3">
+          {item.verseRef}
+        </p>
+        <p
+          className="text-lg leading-relaxed"
+          style={{ fontFamily: 'var(--font-greek)' }}
+        >
+          {item.verseWords.map((word, i) => {
+            const [form, punct] = splitWordPunct(word.text);
+            const isTarget = i === item.wordIndex;
+            return (
+              <span key={i}>
+                <span
+                  style={isTarget ? {
+                    color: 'var(--color-accent)',
+                    fontWeight: 700,
+                    textDecoration: 'underline',
+                    textDecorationColor: 'var(--color-accent)',
+                  } : undefined}
+                >
+                  {form}
+                </span>
+                <span className="text-text-muted">{punct}</span>
+                {i < item.verseWords.length - 1 ? ' ' : ''}
+              </span>
+            );
+          })}
+        </p>
+      </div>
+
+      {/* ── Parse this form ──────────────────────────────────────────────── */}
+      <div>
+        <p className="text-xs uppercase tracking-widest text-text-muted mb-3">
+          Parse the highlighted form
+        </p>
+        <p
+          className="text-4xl font-bold mb-4"
+          style={{ fontFamily: 'var(--font-greek)', color: 'var(--color-accent)' }}
+        >
+          {item.form}
+        </p>
+
+        <div className="grid grid-cols-2 gap-3">
+          <GNTSelect<GNTTense>
+            label="Tense"
+            value={answer.tense}
+            options={GNT_TENSES}
+            labels={GNT_TENSE_LABELS}
+            onChange={v => onChange({ ...answer, tense: v })}
+          />
+          <GNTSelect<GNTVoice>
+            label="Voice"
+            value={answer.voice}
+            options={GNT_VOICES}
+            labels={GNT_VOICE_LABELS}
+            onChange={v => onChange({ ...answer, voice: v })}
+          />
+          <GNTSelect<GNTMood>
+            label="Mood"
+            value={answer.mood}
+            options={GNT_MOODS}
+            labels={GNT_MOOD_LABELS}
+            onChange={handleMoodChange}
+            className="col-span-2"
+          />
+
+          {/* Finite-only: person + number */}
+          {isFiniteMood && (
+            <>
+              <GNTSelect<GNTPerson>
+                label="Person"
+                value={answer.person}
+                options={GNT_PERSONS}
+                labels={GNT_PERSON_LABELS}
+                onChange={v => onChange({ ...answer, person: v })}
+              />
+              <GNTSelect<GNTNumber>
+                label="Number"
+                value={answer.number}
+                options={GNT_NUMBERS}
+                labels={GNT_NUMBER_LABELS}
+                onChange={v => onChange({ ...answer, number: v })}
+              />
+            </>
+          )}
+
+          {/* Participle-only: case + number + gender */}
+          {isParticiple && (
+            <>
+              <GNTSelect<GNTCase>
+                label="Case"
+                value={answer.parseCase}
+                options={GNT_CASES}
+                labels={GNT_CASE_LABELS}
+                onChange={v => onChange({ ...answer, parseCase: v })}
+              />
+              <GNTSelect<GNTNumber>
+                label="Number"
+                value={answer.number}
+                options={GNT_NUMBERS}
+                labels={GNT_NUMBER_LABELS}
+                onChange={v => onChange({ ...answer, number: v })}
+              />
+              <GNTSelect<GNTGender>
+                label="Gender"
+                value={answer.gender}
+                options={GNT_GENDERS}
+                labels={GNT_GENDER_LABELS}
+                onChange={v => onChange({ ...answer, gender: v })}
+                className="col-span-2"
+              />
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* ── Submit ──────────────────────────────────────────────────────── */}
+      <button
+        onClick={onSubmit}
+        disabled={!canSubmit}
+        className={[
+          'w-full py-3 rounded-xl text-base font-bold transition-colors',
+          canSubmit
+            ? 'bg-[var(--color-accent)] text-white hover:opacity-90'
+            : 'bg-bg-card text-text-muted cursor-not-allowed',
+        ].join(' ')}
+      >
+        Submit
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reusable select
+// ---------------------------------------------------------------------------
+
+interface SelectProps<T extends string> {
+  label: string;
+  value: T | '';
+  options: readonly T[];
+  labels: Record<T, string>;
+  onChange: (v: T) => void;
+  className?: string;
+}
+
+function GNTSelect<T extends string>({ label, value, options, labels, onChange, className = '' }: SelectProps<T>) {
+  return (
+    <div className={className}>
+      <label className="block text-xs font-semibold uppercase tracking-wide text-text-muted mb-1">
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value as T)}
+        className="w-full rounded-lg border border-bg-card bg-bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] appearance-none"
+      >
+        <option value="">— select —</option>
+        {options.map(opt => (
+          <option key={opt} value={opt}>{labels[opt]}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/ParseFeedback.tsx
+++ b/src/components/ParseFeedback.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import type { ParseItem, ParseAnswer, ParseResult } from '../lib/verb-parse';
+import {
+  TENSE_LABELS,
+  VOICE_LABELS,
+  MOOD_LABELS,
+  PERSON_LABELS,
+  NUMBER_LABELS,
+} from '../lib/verb-parse';
+
+interface Props {
+  item: ParseItem;
+  answer: ParseAnswer;
+  result: ParseResult;
+  onNext: () => void;
+  isLast: boolean;
+}
+
+export default function ParseFeedback({ item, answer, result, onNext, isLast }: Props) {
+  return (
+    <div className="max-w-lg mx-auto space-y-6">
+      {/* ── Form display ────────────────────────────────────────────────── */}
+      <div className="text-center py-6">
+        <p
+          className="text-5xl font-bold"
+          style={{ fontFamily: 'var(--font-greek)', color: 'var(--color-primary)' }}
+        >
+          {item.form}
+        </p>
+        <p className="mt-3 text-sm text-text-muted">{item.paradigmLabel}</p>
+        {item.ambiguous && item.ambiguous.length > 0 && (
+          <p className="mt-1 text-xs text-text-muted">
+            Also valid: {item.ambiguous.join('; ')}
+          </p>
+        )}
+      </div>
+
+      {/* ── Property results ────────────────────────────────────────────── */}
+      <div className="space-y-2">
+        <FeedbackRow
+          property="Tense"
+          correct={result.tense}
+          given={answer.tense ? TENSE_LABELS[answer.tense] : '—'}
+          expected={TENSE_LABELS[item.tense]}
+        />
+        <FeedbackRow
+          property="Voice"
+          correct={result.voice}
+          given={answer.voice ? VOICE_LABELS[answer.voice] : '—'}
+          expected={VOICE_LABELS[item.voice]}
+        />
+        <FeedbackRow
+          property="Mood"
+          correct={result.mood}
+          given={answer.mood ? MOOD_LABELS[answer.mood] : '—'}
+          expected={MOOD_LABELS[item.mood]}
+        />
+        <FeedbackRow
+          property="Person"
+          correct={result.person}
+          given={answer.person ? PERSON_LABELS[answer.person] : '—'}
+          expected={PERSON_LABELS[item.person]}
+        />
+        <FeedbackRow
+          property="Number"
+          correct={result.number}
+          given={answer.number ? NUMBER_LABELS[answer.number] : '—'}
+          expected={NUMBER_LABELS[item.number]}
+        />
+      </div>
+
+      {/* ── Overall verdict ─────────────────────────────────────────────── */}
+      <div
+        className={[
+          'rounded-xl px-5 py-3 text-center font-semibold text-sm',
+          result.allCorrect
+            ? 'bg-green-50 text-green-700'
+            : 'bg-red-50 text-red-700',
+        ].join(' ')}
+      >
+        {result.allCorrect ? 'Correct!' : 'Not quite — review the corrections above.'}
+      </div>
+
+      {/* ── Next button ─────────────────────────────────────────────────── */}
+      <button
+        onClick={onNext}
+        className="w-full py-3 rounded-xl text-base font-bold bg-[var(--color-accent)] text-white hover:opacity-90 transition-opacity"
+      >
+        {isLast ? 'See Results' : 'Next Form'}
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single property row
+// ---------------------------------------------------------------------------
+
+function FeedbackRow({
+  property,
+  correct,
+  given,
+  expected,
+}: {
+  property: string;
+  correct: boolean;
+  given: string;
+  expected: string;
+}) {
+  return (
+    <div
+      className={[
+        'flex items-center justify-between rounded-lg px-4 py-2.5 text-sm',
+        correct ? 'bg-green-50' : 'bg-red-50',
+      ].join(' ')}
+    >
+      <span className={['font-semibold', correct ? 'text-green-700' : 'text-red-700'].join(' ')}>
+        {property}
+      </span>
+      <div className="flex items-center gap-2 text-right">
+        {correct ? (
+          <span className="text-green-700 font-medium">{given}</span>
+        ) : (
+          <>
+            <span className="text-red-500 line-through">{given}</span>
+            <span className="text-red-700 font-semibold">{expected}</span>
+          </>
+        )}
+        <span className={correct ? 'text-green-600' : 'text-red-600'}>
+          {correct ? '✓' : '✗'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ParseQuestion.tsx
+++ b/src/components/ParseQuestion.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import type { ParseItem, ParseAnswer, ParseTense, ParseVoice, ParseMood, ParsePerson, ParseNumber } from '../lib/verb-parse';
+import {
+  PARSE_TENSES,
+  PARSE_VOICES,
+  PARSE_MOODS,
+  PARSE_PERSONS,
+  PARSE_NUMBERS,
+  TENSE_LABELS,
+  VOICE_LABELS,
+  MOOD_LABELS,
+  PERSON_LABELS,
+  NUMBER_LABELS,
+} from '../lib/verb-parse';
+
+interface Props {
+  item: ParseItem;
+  index: number;
+  total: number;
+  answer: ParseAnswer;
+  onChange: (answer: ParseAnswer) => void;
+  onSubmit: () => void;
+}
+
+export default function ParseQuestion({ item, index, total, answer, onChange, onSubmit }: Props) {
+  const canSubmit =
+    answer.tense !== '' &&
+    answer.voice !== '' &&
+    answer.mood !== '' &&
+    answer.person !== '' &&
+    answer.number !== '';
+
+  return (
+    <div className="max-w-lg mx-auto space-y-8">
+      {/* ── Progress ────────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-1.5 bg-bg-card rounded-full overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all duration-300"
+            style={{
+              width: `${(index / total) * 100}%`,
+              background: 'var(--color-accent)',
+            }}
+          />
+        </div>
+        <span className="text-sm text-text-muted whitespace-nowrap">
+          {index + 1} / {total}
+        </span>
+      </div>
+
+      {/* ── Verb form ───────────────────────────────────────────────────── */}
+      <div className="text-center py-8">
+        <p className="text-xs uppercase tracking-widest text-text-muted mb-3">
+          Parse this form
+        </p>
+        <p
+          className="text-6xl font-bold leading-none"
+          style={{ fontFamily: 'var(--font-greek)', color: 'var(--color-primary)' }}
+        >
+          {item.form}
+        </p>
+      </div>
+
+      {/* ── Dropdowns ───────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 gap-4">
+        <ParseSelect<ParseTense>
+          label="Tense"
+          value={answer.tense}
+          options={PARSE_TENSES}
+          labels={TENSE_LABELS}
+          onChange={v => onChange({ ...answer, tense: v })}
+        />
+        <ParseSelect<ParseVoice>
+          label="Voice"
+          value={answer.voice}
+          options={PARSE_VOICES}
+          labels={VOICE_LABELS}
+          onChange={v => onChange({ ...answer, voice: v })}
+        />
+        <ParseSelect<ParseMood>
+          label="Mood"
+          value={answer.mood}
+          options={PARSE_MOODS}
+          labels={MOOD_LABELS}
+          onChange={v => onChange({ ...answer, mood: v })}
+        />
+        <ParseSelect<ParsePerson>
+          label="Person"
+          value={answer.person}
+          options={PARSE_PERSONS}
+          labels={PERSON_LABELS}
+          onChange={v => onChange({ ...answer, person: v })}
+        />
+        <ParseSelect<ParseNumber>
+          label="Number"
+          value={answer.number}
+          options={PARSE_NUMBERS}
+          labels={NUMBER_LABELS}
+          onChange={v => onChange({ ...answer, number: v })}
+          className="col-span-2"
+        />
+      </div>
+
+      {/* ── Submit ──────────────────────────────────────────────────────── */}
+      <button
+        onClick={onSubmit}
+        disabled={!canSubmit}
+        className={[
+          'w-full py-3 rounded-xl text-base font-bold transition-colors',
+          canSubmit
+            ? 'bg-[var(--color-accent)] text-white hover:opacity-90'
+            : 'bg-bg-card text-text-muted cursor-not-allowed',
+        ].join(' ')}
+      >
+        Submit
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reusable dropdown
+// ---------------------------------------------------------------------------
+
+interface SelectProps<T extends string> {
+  label: string;
+  value: T | '';
+  options: readonly T[];
+  labels: Record<T, string>;
+  onChange: (val: T) => void;
+  className?: string;
+}
+
+function ParseSelect<T extends string>({
+  label,
+  value,
+  options,
+  labels,
+  onChange,
+  className = '',
+}: SelectProps<T>) {
+  return (
+    <div className={className}>
+      <label className="block text-xs font-semibold uppercase tracking-wide text-text-muted mb-1">
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value as T)}
+        className="w-full rounded-lg border border-bg-card bg-bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] appearance-none"
+      >
+        <option value="">— select —</option>
+        {options.map(opt => (
+          <option key={opt} value={opt}>
+            {labels[opt]}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/ParseResults.tsx
+++ b/src/components/ParseResults.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import type { ParseResult } from '../lib/verb-parse';
+
+export interface SessionResults {
+  results: ParseResult[];
+  total: number;
+}
+
+interface Props {
+  sessionResults: SessionResults;
+  onRetry: () => void;
+  onChangeSettings: () => void;
+}
+
+type PropertyKey = 'tense' | 'voice' | 'mood' | 'person' | 'number';
+
+const PROPERTIES: { key: PropertyKey; label: string }[] = [
+  { key: 'tense',  label: 'Tense'  },
+  { key: 'voice',  label: 'Voice'  },
+  { key: 'mood',   label: 'Mood'   },
+  { key: 'person', label: 'Person' },
+  { key: 'number', label: 'Number' },
+];
+
+export default function ParseResults({ sessionResults, onRetry, onChangeSettings }: Props) {
+  const { results, total } = sessionResults;
+  const correct = results.filter(r => r.allCorrect).length;
+  const pct = total > 0 ? Math.round((correct / total) * 100) : 0;
+
+  return (
+    <div className="max-w-lg mx-auto space-y-8">
+      {/* ── Score hero ──────────────────────────────────────────────────── */}
+      <div className="text-center py-8 bg-bg-card rounded-2xl">
+        <p className="text-xs uppercase tracking-widest text-text-muted mb-2">Session Score</p>
+        <p
+          className="text-6xl font-extrabold mb-1"
+          style={{ color: scoreColor(pct) }}
+        >
+          {correct}/{total}
+        </p>
+        <p className="text-lg text-text-muted">{pct}% correct</p>
+      </div>
+
+      {/* ── Property breakdown ──────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">
+          Accuracy by Property
+        </h2>
+        <div className="space-y-2">
+          {PROPERTIES.map(({ key, label }) => {
+            const propertyCorrect = results.filter(r => r[key]).length;
+            const propertyPct = total > 0 ? Math.round((propertyCorrect / total) * 100) : 0;
+            return (
+              <div key={key} className="flex items-center gap-3">
+                <span className="text-sm w-16 text-text-muted">{label}</span>
+                <div className="flex-1 h-2 bg-bg-card rounded-full overflow-hidden">
+                  <div
+                    className="h-full rounded-full transition-all duration-500"
+                    style={{
+                      width: `${propertyPct}%`,
+                      background: scoreColor(propertyPct),
+                    }}
+                  />
+                </div>
+                <span className="text-sm font-semibold w-16 text-right">
+                  {propertyCorrect}/{total}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* ── Actions ─────────────────────────────────────────────────────── */}
+      <div className="flex gap-3">
+        <button
+          onClick={onRetry}
+          className="flex-1 py-3 rounded-xl text-base font-bold bg-[var(--color-accent)] text-white hover:opacity-90 transition-opacity"
+        >
+          Try Again
+        </button>
+        <button
+          onClick={onChangeSettings}
+          className="flex-1 py-3 rounded-xl text-base font-bold bg-bg-card text-text hover:opacity-80 transition-opacity"
+        >
+          Change Settings
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function scoreColor(pct: number): string {
+  if (pct >= 80) return '#16a34a'; // green-600
+  if (pct >= 60) return '#d97706'; // amber-600
+  return '#dc2626';                 // red-600
+}

--- a/src/components/ParseSettings.tsx
+++ b/src/components/ParseSettings.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import type {
+  ParseSettings,
+  ParseTense,
+  ParseVoice,
+  ParseMood,
+} from '../lib/verb-parse';
+import {
+  PARSE_TENSES,
+  PARSE_VOICES,
+  PARSE_MOODS,
+  TENSE_LABELS,
+  VOICE_LABELS,
+  MOOD_LABELS,
+} from '../lib/verb-parse';
+
+interface Props {
+  settings: ParseSettings;
+  onChange: (s: ParseSettings) => void;
+  onStart: () => void;
+}
+
+function toggle<T>(arr: T[], val: T): T[] {
+  return arr.includes(val) ? arr.filter(x => x !== val) : [...arr, val];
+}
+
+const SESSION_LENGTHS = [10, 20, 30] as const;
+
+// Group tenses by indicative-only vs. cross-mood availability
+const TENSE_GROUPS: { label: string; tenses: ParseTense[] }[] = [
+  { label: 'All Moods', tenses: ['present', 'aorist'] },
+  { label: 'Indicative Only', tenses: ['imperfect', 'future', 'perfect'] },
+];
+
+export default function ParseSettings({ settings, onChange, onStart }: Props) {
+  const canStart =
+    settings.tenses.length > 0 &&
+    settings.voices.length > 0 &&
+    settings.moods.length > 0;
+
+  function setTenses(tenses: ParseTense[]) {
+    onChange({ ...settings, tenses });
+  }
+  function setVoices(voices: ParseVoice[]) {
+    onChange({ ...settings, voices });
+  }
+  function setMoods(moods: ParseMood[]) {
+    onChange({ ...settings, moods });
+  }
+
+  return (
+    <div className="max-w-lg mx-auto space-y-8">
+      {/* ── Tenses ──────────────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">
+          Tenses
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {PARSE_TENSES.map(t => (
+            <ToggleChip
+              key={t}
+              label={TENSE_LABELS[t]}
+              active={settings.tenses.includes(t)}
+              onClick={() => setTenses(toggle(settings.tenses, t))}
+            />
+          ))}
+        </div>
+        <div className="mt-2 flex gap-2">
+          <button
+            onClick={() => setTenses([...PARSE_TENSES])}
+            className="text-xs text-text-muted underline underline-offset-2 hover:text-text"
+          >
+            All
+          </button>
+          <button
+            onClick={() => setTenses([])}
+            className="text-xs text-text-muted underline underline-offset-2 hover:text-text"
+          >
+            None
+          </button>
+        </div>
+      </section>
+
+      {/* ── Voices ──────────────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">
+          Voices
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {PARSE_VOICES.map(v => (
+            <ToggleChip
+              key={v}
+              label={VOICE_LABELS[v]}
+              active={settings.voices.includes(v)}
+              onClick={() => setVoices(toggle(settings.voices, v))}
+            />
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-text-muted">
+          Middle/Passive paradigms accept either "Middle" or "Passive" as correct.
+        </p>
+      </section>
+
+      {/* ── Moods ───────────────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">
+          Moods
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {PARSE_MOODS.map(m => (
+            <ToggleChip
+              key={m}
+              label={MOOD_LABELS[m]}
+              active={settings.moods.includes(m)}
+              onClick={() => setMoods(toggle(settings.moods, m))}
+            />
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-text-muted">
+          Not all tense/voice/mood combinations exist — unavailable combos are skipped automatically.
+        </p>
+      </section>
+
+      {/* ── Session length ──────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">
+          Forms per session
+        </h2>
+        <div className="flex gap-2">
+          {SESSION_LENGTHS.map(n => (
+            <button
+              key={n}
+              onClick={() => onChange({ ...settings, sessionLength: n })}
+              className={[
+                'px-4 py-2 rounded-lg text-sm font-semibold border-2 transition-colors',
+                settings.sessionLength === n
+                  ? 'border-[var(--color-accent)] bg-[var(--color-accent)] text-white'
+                  : 'border-bg-card bg-bg-card text-text-muted hover:border-[var(--color-accent)]',
+              ].join(' ')}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Start button ────────────────────────────────────────────────── */}
+      <button
+        onClick={onStart}
+        disabled={!canStart}
+        className={[
+          'w-full py-3 rounded-xl text-base font-bold transition-colors',
+          canStart
+            ? 'bg-[var(--color-accent)] text-white hover:opacity-90'
+            : 'bg-bg-card text-text-muted cursor-not-allowed',
+        ].join(' ')}
+      >
+        Start Parsing
+      </button>
+
+      {!canStart && (
+        <p className="text-center text-xs text-red-500">
+          Select at least one tense, voice, and mood to continue.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ToggleChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        'px-3 py-1.5 rounded-full text-sm font-medium border-2 transition-colors',
+        active
+          ? 'border-[var(--color-accent)] bg-[var(--color-accent)] text-white'
+          : 'border-bg-card bg-bg-card text-text-muted hover:border-[var(--color-accent)]',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/PassageSelector.tsx
+++ b/src/components/PassageSelector.tsx
@@ -1,0 +1,137 @@
+import React, { useState, useEffect } from 'react';
+import { fetchBooks, type BookMeta } from '../data/morphgnt';
+import type { GNTPassageSettings } from '../lib/gnt-parse';
+
+interface Props {
+  settings: GNTPassageSettings;
+  verbCount: number | null;  // null while unknown
+  onChange: (s: GNTPassageSettings) => void;
+  onStart: () => void;
+  loading: boolean;
+}
+
+const SESSION_LENGTHS = [10, 20, 30, 'all'] as const;
+const SESSION_LABELS: Record<string, string> = {
+  10: '10', 20: '20', 30: '30', all: 'All',
+};
+
+export default function PassageSelector({
+  settings,
+  verbCount,
+  onChange,
+  onStart,
+  loading,
+}: Props) {
+  const [books, setBooks] = useState<BookMeta[]>([]);
+
+  useEffect(() => {
+    fetchBooks().then(setBooks).catch(console.error);
+  }, []);
+
+  const currentBook = books.find(b => b.code === settings.book);
+  const chapterCount = currentBook?.chapters ?? 1;
+
+  function handleBookChange(code: string) {
+    onChange({ ...settings, book: code, chapter: 1 });
+  }
+
+  function handleChapterChange(ch: number) {
+    onChange({ ...settings, chapter: ch });
+  }
+
+  const canStart = !loading && verbCount !== null && verbCount > 0;
+
+  return (
+    <div className="max-w-lg mx-auto space-y-8">
+      {/* ── Passage ──────────────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">
+          Passage
+        </h2>
+        <div className="flex gap-3">
+          {/* Book */}
+          <div className="flex-1">
+            <label className="block text-xs font-semibold uppercase tracking-wide text-text-muted mb-1">
+              Book
+            </label>
+            <select
+              value={settings.book}
+              onChange={e => handleBookChange(e.target.value)}
+              className="w-full rounded-lg border border-bg-card bg-bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] appearance-none"
+            >
+              {books.map(b => (
+                <option key={b.code} value={b.code}>{b.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Chapter */}
+          <div className="w-28">
+            <label className="block text-xs font-semibold uppercase tracking-wide text-text-muted mb-1">
+              Chapter
+            </label>
+            <select
+              value={settings.chapter}
+              onChange={e => handleChapterChange(Number(e.target.value))}
+              className="w-full rounded-lg border border-bg-card bg-bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] appearance-none"
+            >
+              {Array.from({ length: chapterCount }, (_, i) => i + 1).map(n => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Verb count feedback */}
+        <p className="mt-2 text-xs text-text-muted h-4">
+          {loading && 'Loading…'}
+          {!loading && verbCount === null && ''}
+          {!loading && verbCount === 0 && 'No verbs found in this chapter.'}
+          {!loading && verbCount !== null && verbCount > 0 &&
+            `${verbCount} verb form${verbCount !== 1 ? 's' : ''} in this chapter`}
+        </p>
+      </section>
+
+      {/* ── Session length ──────────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">
+          Forms per session
+        </h2>
+        <div className="flex gap-2">
+          {SESSION_LENGTHS.map(n => (
+            <button
+              key={n}
+              onClick={() => onChange({ ...settings, sessionLength: n })}
+              disabled={n !== 'all' && verbCount !== null && verbCount < Number(n)}
+              className={[
+                'px-4 py-2 rounded-lg text-sm font-semibold border-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed',
+                settings.sessionLength === n
+                  ? 'border-[var(--color-accent)] bg-[var(--color-accent)] text-white'
+                  : 'border-bg-card bg-bg-card text-text-muted hover:border-[var(--color-accent)]',
+              ].join(' ')}
+            >
+              {SESSION_LABELS[n]}
+            </button>
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-text-muted">
+          "All" parses every verb in the chapter in order.
+        </p>
+      </section>
+
+      {/* ── Start ────────────────────────────────────────────────────────── */}
+      <button
+        onClick={onStart}
+        disabled={!canStart}
+        className={[
+          'w-full py-3 rounded-xl text-base font-bold transition-colors',
+          canStart
+            ? 'bg-[var(--color-accent)] text-white hover:opacity-90'
+            : 'bg-bg-card text-text-muted cursor-not-allowed',
+        ].join(' ')}
+      >
+        {loading ? 'Loading…' : 'Start Parsing'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/VerbParseChallenge.tsx
+++ b/src/components/VerbParseChallenge.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useEffect } from 'react';
+import ParseSettings from './ParseSettings';
+import ParseQuestion from './ParseQuestion';
+import ParseFeedback from './ParseFeedback';
+import ParseResults from './ParseResults';
+import type { SessionResults } from './ParseResults';
+import {
+  buildSession,
+  gradeAnswer,
+  emptyAnswer,
+  loadParseSettings,
+  saveParseSettings,
+  DEFAULT_PARSE_SETTINGS,
+} from '../lib/verb-parse';
+import type { ParseItem, ParseAnswer, ParseResult, ParseSettings as ParseSettingsType } from '../lib/verb-parse';
+
+type Phase = 'settings' | 'question' | 'feedback' | 'results';
+
+export default function VerbParseChallenge() {
+  const [settings, setSettings] = useState<ParseSettingsType>(DEFAULT_PARSE_SETTINGS);
+  const [phase, setPhase] = useState<Phase>('settings');
+  const [session, setSession] = useState<ParseItem[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answer, setAnswer] = useState<ParseAnswer>(emptyAnswer());
+  const [results, setResults] = useState<ParseResult[]>([]);
+  const [currentResult, setCurrentResult] = useState<ParseResult | null>(null);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+
+  // Load persisted settings on mount (client-only)
+  useEffect(() => {
+    setSettings(loadParseSettings());
+    setSettingsLoaded(true);
+  }, []);
+
+  function handleSettingsChange(s: ParseSettingsType) {
+    setSettings(s);
+    saveParseSettings(s);
+  }
+
+  function handleStart() {
+    const items = buildSession(settings, settings.sessionLength);
+    if (items.length === 0) return; // No matching forms — settings too narrow
+    setSession(items);
+    setCurrentIndex(0);
+    setResults([]);
+    setAnswer(emptyAnswer());
+    setCurrentResult(null);
+    setPhase('question');
+  }
+
+  function handleSubmit() {
+    const item = session[currentIndex];
+    const result = gradeAnswer(item, answer);
+    setCurrentResult(result);
+    setPhase('feedback');
+  }
+
+  function handleNext() {
+    const updatedResults = [...results, currentResult!];
+    setResults(updatedResults);
+
+    if (currentIndex + 1 >= session.length) {
+      setPhase('results');
+    } else {
+      setCurrentIndex(i => i + 1);
+      setAnswer(emptyAnswer());
+      setCurrentResult(null);
+      setPhase('question');
+    }
+  }
+
+  function handleRetry() {
+    handleStart();
+  }
+
+  function handleChangeSettings() {
+    setPhase('settings');
+    setSession([]);
+    setResults([]);
+    setCurrentIndex(0);
+    setAnswer(emptyAnswer());
+    setCurrentResult(null);
+  }
+
+  if (!settingsLoaded) return null;
+
+  const sessionResults: SessionResults = {
+    results,
+    total: session.length,
+  };
+
+  return (
+    <div>
+      {phase === 'settings' && (
+        <ParseSettings
+          settings={settings}
+          onChange={handleSettingsChange}
+          onStart={handleStart}
+        />
+      )}
+
+      {phase === 'question' && session[currentIndex] && (
+        <ParseQuestion
+          item={session[currentIndex]}
+          index={currentIndex}
+          total={session.length}
+          answer={answer}
+          onChange={setAnswer}
+          onSubmit={handleSubmit}
+        />
+      )}
+
+      {phase === 'feedback' && session[currentIndex] && currentResult && (
+        <ParseFeedback
+          item={session[currentIndex]}
+          answer={answer}
+          result={currentResult}
+          onNext={handleNext}
+          isLast={currentIndex + 1 >= session.length}
+        />
+      )}
+
+      {phase === 'results' && (
+        <ParseResults
+          sessionResults={sessionResults}
+          onRetry={handleRetry}
+          onChangeSettings={handleChangeSettings}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,17 +9,21 @@ interface Props {
 const { title, description = "Free tools for Koine Greek students — keyboard, flashcards, and more." } = Astro.props;
 
 const navLinks = [
-  { href: '/keyboard',   label: 'Type', tabLabel: 'Type'   },
-  { href: '/flashcards', label: 'Flashcards',  tabLabel: 'Cards'  },
-  { href: '/daily',      label: 'Daily',       tabLabel: 'Daily'  },
-  { href: '/reader',     label: 'Reader',      tabLabel: 'Reader' },
-  { href: '/grammar',    label: 'Grammar',     tabLabel: 'Grammar'},
-  { href: '/paradigms',  label: 'Quiz',        tabLabel: 'Quiz'   },
+  { href: '/keyboard',   label: 'Type',       tabLabel: 'Type'   },
+  { href: '/flashcards', label: 'Flashcards', tabLabel: 'Cards'  },
+  { href: '/daily',      label: 'Daily',      tabLabel: 'Daily'  },
+  { href: '/reader',     label: 'Reader',     tabLabel: 'Reader' },
+  { href: '/grammar',    label: 'Grammar',    tabLabel: 'Grammar'},
+  { href: '/quiz',       label: 'Quiz',       tabLabel: 'Quiz'   },
 ];
 
 const currentPath = Astro.url.pathname;
 
+// Quiz section covers the picker and both quiz modes
+const QUIZ_PATHS = ['/quiz', '/paradigms', '/parse'];
+
 function isActive(href: string) {
+  if (href === '/quiz') return QUIZ_PATHS.some(p => currentPath.startsWith(p));
   return currentPath.startsWith(href);
 }
 ---
@@ -246,14 +250,14 @@ function isActive(href: string) {
           </span>
         </a>
 
-        <!-- Paradigm Quiz -->
+        <!-- Quiz -->
         <a
-          href="/paradigms"
-          class:list={["tab-item", isActive('/paradigms') ? "tab-active" : "tab-inactive"]}
-          aria-label="Paradigm Quiz"
-          aria-current={isActive('/paradigms') ? 'page' : undefined}
+          href="/quiz"
+          class:list={["tab-item", isActive('/quiz') ? "tab-active" : "tab-inactive"]}
+          aria-label="Quiz"
+          aria-current={isActive('/quiz') ? 'page' : undefined}
         >
-          <span class:list={["tab-pill", { "tab-pill-active": isActive('/paradigms') }]}>
+          <span class:list={["tab-pill", { "tab-pill-active": isActive('/quiz') }]}>
             <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <circle cx="12" cy="12" r="10"/>
               <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>

--- a/src/lib/gnt-parse.test.ts
+++ b/src/lib/gnt-parse.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for src/lib/gnt-parse.ts
+ *
+ * Covers: extractVerbs, sampleVerbs, gradeGNTAnswer.
+ * Uses synthetic MorphBook fixtures — no network calls.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extractVerbs,
+  sampleVerbs,
+  gradeGNTAnswer,
+  emptyGNTAnswer,
+  type GNTParseItem,
+  type GNTParseAnswer,
+} from './gnt-parse';
+import type { MorphBook } from '../data/morphgnt';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Build a minimal MorphBook with a single chapter/verse of provided words. */
+function makeBook(words: Array<{ text: string; lemma: string; pos: string; parsing: string }>): MorphBook {
+  return { '1': { '1': words.map(w => ({ ...w })) } };
+}
+
+const FINITE_VERB = { text: 'λύει', lemma: 'λύω', pos: 'V-', parsing: '3PAI-S--' };
+// 3=3rd, P=Present, A=Active, I=Indicative, -=no case, S=Singular, -=no gender
+const INFINITIVE   = { text: 'λύειν', lemma: 'λύω', pos: 'V-', parsing: '-PAN----' };
+// -=no person, P=Present, A=Active, N=Infinitive
+const PARTICIPLE   = { text: 'βοώντος', lemma: 'βοάω', pos: 'V-', parsing: '-PAPGSMX' };
+// -=no person, P=Present, A=Active, P=Participle, G=Genitive, S=Singular, M=Masculine
+const NOUN         = { text: 'ἀρχῇ', lemma: 'ἀρχή', pos: 'N-', parsing: '---DSF--' };
+
+// ---------------------------------------------------------------------------
+// extractVerbs
+// ---------------------------------------------------------------------------
+
+describe('extractVerbs', () => {
+  it('ignores non-verb parts of speech', () => {
+    const book = makeBook([NOUN]);
+    expect(extractVerbs(book, '1', 'John')).toHaveLength(0);
+  });
+
+  it('extracts a finite verb', () => {
+    const book = makeBook([FINITE_VERB]);
+    const items = extractVerbs(book, '1', 'John');
+    expect(items).toHaveLength(1);
+    const item = items[0];
+    expect(item.type).toBe('finite');
+    expect(item.tense).toBe('present');
+    expect(item.voice).toBe('active');
+    expect(item.mood).toBe('indicative');
+    if (item.type === 'finite') {
+      expect(item.person).toBe('3rd');
+      expect(item.number).toBe('singular');
+    }
+    expect(item.form).toBe('λύει');
+    expect(item.lemma).toBe('λύω');
+    expect(item.verseRef).toBe('John 1:1');
+  });
+
+  it('extracts an infinitive', () => {
+    const book = makeBook([INFINITIVE]);
+    const items = extractVerbs(book, '1', 'John');
+    expect(items).toHaveLength(1);
+    const item = items[0];
+    expect(item.type).toBe('infinitive');
+    expect(item.tense).toBe('present');
+    expect(item.voice).toBe('active');
+    expect(item.mood).toBe('infinitive');
+  });
+
+  it('extracts a participle', () => {
+    const book = makeBook([PARTICIPLE]);
+    const items = extractVerbs(book, '1', 'John');
+    expect(items).toHaveLength(1);
+    const item = items[0];
+    expect(item.type).toBe('participle');
+    expect(item.tense).toBe('present');
+    expect(item.voice).toBe('active');
+    expect(item.mood).toBe('participle');
+    if (item.type === 'participle') {
+      expect(item.parseCase).toBe('genitive');
+      expect(item.number).toBe('singular');
+      expect(item.gender).toBe('masculine');
+    }
+  });
+
+  it('extracts mixed verbs from the same verse', () => {
+    const book = makeBook([NOUN, FINITE_VERB, INFINITIVE, PARTICIPLE]);
+    const items = extractVerbs(book, '1', 'John');
+    expect(items).toHaveLength(3);
+    expect(items.map(i => i.type).sort()).toEqual(['finite', 'infinitive', 'participle'].sort());
+  });
+
+  it('returns empty array for missing chapter', () => {
+    const book = makeBook([FINITE_VERB]);
+    expect(extractVerbs(book, '99', 'John')).toHaveLength(0);
+  });
+
+  it('strips trailing punctuation from form', () => {
+    const book = makeBook([{ ...FINITE_VERB, text: 'λύει·' }]);
+    const items = extractVerbs(book, '1', 'John');
+    expect(items[0].form).toBe('λύει');
+  });
+
+  it('records correct wordIndex for highlighting', () => {
+    const book = makeBook([NOUN, FINITE_VERB]);
+    const items = extractVerbs(book, '1', 'John');
+    expect(items[0].wordIndex).toBe(1); // FINITE_VERB is at index 1
+  });
+
+  it('skips verbs with unrecognised parse codes', () => {
+    const bad = { text: 'foo', lemma: 'foo', pos: 'V-', parsing: '---' }; // too short
+    const book = makeBook([bad]);
+    expect(extractVerbs(book, '1', 'John')).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sampleVerbs
+// ---------------------------------------------------------------------------
+
+describe('sampleVerbs', () => {
+  const book = makeBook([FINITE_VERB, INFINITIVE, PARTICIPLE]);
+  const all = extractVerbs(book, '1', 'John');
+
+  it('returns at most count items', () => {
+    expect(sampleVerbs(all, 2)).toHaveLength(2);
+  });
+
+  it('returns all items when count >= length', () => {
+    expect(sampleVerbs(all, 10)).toHaveLength(3);
+  });
+
+  it('does not mutate the original array', () => {
+    const copy = [...all];
+    sampleVerbs(all, 2);
+    expect(all).toHaveLength(copy.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gradeGNTAnswer — finite verb
+// ---------------------------------------------------------------------------
+
+describe('gradeGNTAnswer — finite verb', () => {
+  const book = makeBook([FINITE_VERB]);
+  const item = extractVerbs(book, '1', 'John')[0] as GNTParseItem;
+
+  it('all correct', () => {
+    const answer: GNTParseAnswer = {
+      tense: 'present', voice: 'active', mood: 'indicative',
+      person: '3rd', number: 'singular', parseCase: '', gender: '',
+    };
+    const result = gradeGNTAnswer(item, answer);
+    expect(result.allCorrect).toBe(true);
+    expect(result.tense).toBe(true);
+    expect(result.voice).toBe(true);
+    expect(result.mood).toBe(true);
+    expect(result.person).toBe(true);
+    expect(result.number).toBe(true);
+    expect(result.parseCase).toBeNull();
+    expect(result.gender).toBeNull();
+  });
+
+  it('wrong tense', () => {
+    const answer: GNTParseAnswer = {
+      tense: 'aorist', voice: 'active', mood: 'indicative',
+      person: '3rd', number: 'singular', parseCase: '', gender: '',
+    };
+    const result = gradeGNTAnswer(item, answer);
+    expect(result.allCorrect).toBe(false);
+    expect(result.tense).toBe(false);
+  });
+
+  it('empty answer — all false', () => {
+    const result = gradeGNTAnswer(item, emptyGNTAnswer());
+    expect(result.allCorrect).toBe(false);
+    expect(result.tense).toBe(false);
+    expect(result.voice).toBe(false);
+    expect(result.mood).toBe(false);
+    expect(result.person).toBe(false);
+    expect(result.number).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gradeGNTAnswer — infinitive
+// ---------------------------------------------------------------------------
+
+describe('gradeGNTAnswer — infinitive', () => {
+  const book = makeBook([INFINITIVE]);
+  const item = extractVerbs(book, '1', 'John')[0];
+
+  it('all correct — no person/number/case/gender', () => {
+    const answer: GNTParseAnswer = {
+      tense: 'present', voice: 'active', mood: 'infinitive',
+      person: '', number: '', parseCase: '', gender: '',
+    };
+    const result = gradeGNTAnswer(item, answer);
+    expect(result.allCorrect).toBe(true);
+    expect(result.person).toBeNull();
+    expect(result.number).toBeNull();
+    expect(result.parseCase).toBeNull();
+    expect(result.gender).toBeNull();
+  });
+
+  it('wrong voice', () => {
+    const answer: GNTParseAnswer = {
+      tense: 'present', voice: 'passive', mood: 'infinitive',
+      person: '', number: '', parseCase: '', gender: '',
+    };
+    expect(gradeGNTAnswer(item, answer).allCorrect).toBe(false);
+    expect(gradeGNTAnswer(item, answer).voice).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gradeGNTAnswer — participle
+// ---------------------------------------------------------------------------
+
+describe('gradeGNTAnswer — participle', () => {
+  const book = makeBook([PARTICIPLE]);
+  const item = extractVerbs(book, '1', 'John')[0];
+
+  it('all correct', () => {
+    const answer: GNTParseAnswer = {
+      tense: 'present', voice: 'active', mood: 'participle',
+      person: '', number: 'singular', parseCase: 'genitive', gender: 'masculine',
+    };
+    const result = gradeGNTAnswer(item, answer);
+    expect(result.allCorrect).toBe(true);
+    expect(result.person).toBeNull();
+    expect(result.parseCase).toBe(true);
+    expect(result.number).toBe(true);
+    expect(result.gender).toBe(true);
+  });
+
+  it('wrong case', () => {
+    const answer: GNTParseAnswer = {
+      tense: 'present', voice: 'active', mood: 'participle',
+      person: '', number: 'singular', parseCase: 'nominative', gender: 'masculine',
+    };
+    const result = gradeGNTAnswer(item, answer);
+    expect(result.allCorrect).toBe(false);
+    expect(result.parseCase).toBe(false);
+  });
+
+  it('wrong gender', () => {
+    const answer: GNTParseAnswer = {
+      tense: 'present', voice: 'active', mood: 'participle',
+      person: '', number: 'singular', parseCase: 'genitive', gender: 'feminine',
+    };
+    expect(gradeGNTAnswer(item, answer).gender).toBe(false);
+  });
+});

--- a/src/lib/gnt-parse.ts
+++ b/src/lib/gnt-parse.ts
@@ -1,0 +1,294 @@
+/**
+ * GNT Passage Parsing — types, verb extraction, and grading logic.
+ *
+ * Draws from /data/morphgnt/{CODE}.json via fetchBook() and fetchBooks()
+ * from src/data/morphgnt.ts.
+ *
+ * Parse code positions (8 chars):
+ *   [0] person  — 1/2/3/-
+ *   [1] tense   — P/I/F/A/X/Y
+ *   [2] voice   — A/M/P
+ *   [3] mood    — I/D/S/O/N/P  (N=Infinitive, P=Participle)
+ *   [4] case    — N/G/D/A/V
+ *   [5] number  — S/P
+ *   [6] gender  — M/F/N
+ */
+
+import type { MorphWord, MorphBook } from '../data/morphgnt';
+import { splitWordPunct } from '../data/morphgnt';
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type GNTTense = 'present' | 'imperfect' | 'future' | 'aorist' | 'perfect' | 'pluperfect';
+export type GNTVoice = 'active' | 'middle' | 'passive';
+export type GNTMood  = 'indicative' | 'imperative' | 'subjunctive' | 'optative' | 'infinitive' | 'participle';
+export type GNTPerson = '1st' | '2nd' | '3rd';
+export type GNTNumber = 'singular' | 'plural';
+export type GNTCase   = 'nominative' | 'genitive' | 'dative' | 'accusative' | 'vocative';
+export type GNTGender = 'masculine' | 'feminine' | 'neuter';
+
+export const GNT_TENSES:  GNTTense[]  = ['present', 'imperfect', 'future', 'aorist', 'perfect', 'pluperfect'];
+export const GNT_VOICES:  GNTVoice[]  = ['active', 'middle', 'passive'];
+export const GNT_MOODS:   GNTMood[]   = ['indicative', 'imperative', 'subjunctive', 'optative', 'infinitive', 'participle'];
+export const GNT_PERSONS: GNTPerson[] = ['1st', '2nd', '3rd'];
+export const GNT_NUMBERS: GNTNumber[] = ['singular', 'plural'];
+export const GNT_CASES:   GNTCase[]   = ['nominative', 'genitive', 'dative', 'accusative', 'vocative'];
+export const GNT_GENDERS: GNTGender[] = ['masculine', 'feminine', 'neuter'];
+
+export const GNT_TENSE_LABELS:  Record<GNTTense,  string> = { present: 'Present', imperfect: 'Imperfect', future: 'Future', aorist: 'Aorist', perfect: 'Perfect', pluperfect: 'Pluperfect' };
+export const GNT_VOICE_LABELS:  Record<GNTVoice,  string> = { active: 'Active', middle: 'Middle', passive: 'Passive' };
+export const GNT_MOOD_LABELS:   Record<GNTMood,   string> = { indicative: 'Indicative', imperative: 'Imperative', subjunctive: 'Subjunctive', optative: 'Optative', infinitive: 'Infinitive', participle: 'Participle' };
+export const GNT_PERSON_LABELS: Record<GNTPerson, string> = { '1st': '1st', '2nd': '2nd', '3rd': '3rd' };
+export const GNT_NUMBER_LABELS: Record<GNTNumber, string> = { singular: 'Singular', plural: 'Plural' };
+export const GNT_CASE_LABELS:   Record<GNTCase,   string> = { nominative: 'Nominative', genitive: 'Genitive', dative: 'Dative', accusative: 'Accusative', vocative: 'Vocative' };
+export const GNT_GENDER_LABELS: Record<GNTGender, string> = { masculine: 'Masculine', feminine: 'Feminine', neuter: 'Neuter' };
+
+// Finite moods (have person + number)
+export const FINITE_MOODS: GNTMood[] = ['indicative', 'imperative', 'subjunctive', 'optative'];
+
+// ---------------------------------------------------------------------------
+// Parse item — discriminated union by verb type
+// ---------------------------------------------------------------------------
+
+interface BaseItem {
+  form: string;         // word as shown (punctuation stripped)
+  lemma: string;
+  verseRef: string;     // e.g. "John 3:16"
+  verseWords: MorphWord[];
+  wordIndex: number;    // index of target verb within verseWords
+  tense: GNTTense;
+  voice: GNTVoice;
+  mood: GNTMood;
+}
+
+export interface GNTFiniteItem extends BaseItem {
+  type: 'finite';
+  person: GNTPerson;
+  number: GNTNumber;
+}
+
+export interface GNTInfinitiveItem extends BaseItem {
+  type: 'infinitive';
+}
+
+export interface GNTParticipleItem extends BaseItem {
+  type: 'participle';
+  parseCase: GNTCase;
+  number: GNTNumber;
+  gender: GNTGender;
+}
+
+export type GNTParseItem = GNTFiniteItem | GNTInfinitiveItem | GNTParticipleItem;
+
+// ---------------------------------------------------------------------------
+// Answer — covers all possible properties
+// ---------------------------------------------------------------------------
+
+export interface GNTParseAnswer {
+  tense:     GNTTense  | '';
+  voice:     GNTVoice  | '';
+  mood:      GNTMood   | '';
+  // finite-specific
+  person:    GNTPerson | '';
+  number:    GNTNumber | '';
+  // participle-specific
+  parseCase: GNTCase   | '';
+  gender:    GNTGender | '';
+}
+
+export function emptyGNTAnswer(): GNTParseAnswer {
+  return { tense: '', voice: '', mood: '', person: '', number: '', parseCase: '', gender: '' };
+}
+
+// ---------------------------------------------------------------------------
+// Grading result
+// ---------------------------------------------------------------------------
+
+export interface GNTParseResult {
+  tense:     boolean;
+  voice:     boolean;
+  mood:      boolean;
+  person:    boolean | null;    // null = not applicable for this verb type
+  number:    boolean | null;
+  parseCase: boolean | null;
+  gender:    boolean | null;
+  allCorrect: boolean;
+}
+
+export function gradeGNTAnswer(item: GNTParseItem, answer: GNTParseAnswer): GNTParseResult {
+  const tense = answer.tense === item.tense;
+  const voice = answer.voice === item.voice;
+  const mood  = answer.mood  === item.mood;
+
+  if (item.type === 'finite') {
+    const person = answer.person === item.person;
+    const number = answer.number === item.number;
+    return {
+      tense, voice, mood, person, number,
+      parseCase: null, gender: null,
+      allCorrect: tense && voice && mood && person && number,
+    };
+  }
+
+  if (item.type === 'infinitive') {
+    return {
+      tense, voice, mood,
+      person: null, number: null, parseCase: null, gender: null,
+      allCorrect: tense && voice && mood,
+    };
+  }
+
+  // participle
+  const parseCase = answer.parseCase === item.parseCase;
+  const number    = answer.number    === item.number;
+  const gender    = answer.gender    === item.gender;
+  return {
+    tense, voice, mood,
+    person: null, number, parseCase, gender,
+    allCorrect: tense && voice && mood && parseCase && number && gender,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Parse code → typed values
+// ---------------------------------------------------------------------------
+
+const TENSE_MAP: Record<string, GNTTense> = {
+  P: 'present', I: 'imperfect', F: 'future',
+  A: 'aorist',  X: 'perfect',  Y: 'pluperfect',
+};
+const VOICE_MAP: Record<string, GNTVoice> = {
+  A: 'active', M: 'middle', P: 'passive',
+};
+const MOOD_MAP: Record<string, GNTMood> = {
+  I: 'indicative', D: 'imperative', S: 'subjunctive',
+  O: 'optative',   N: 'infinitive', P: 'participle',
+};
+const PERSON_MAP: Record<string, GNTPerson> = {
+  '1': '1st', '2': '2nd', '3': '3rd',
+};
+const NUMBER_MAP: Record<string, GNTNumber> = {
+  S: 'singular', P: 'plural',
+};
+const CASE_MAP: Record<string, GNTCase> = {
+  N: 'nominative', G: 'genitive', D: 'dative', A: 'accusative', V: 'vocative',
+};
+const GENDER_MAP: Record<string, GNTGender> = {
+  M: 'masculine', F: 'feminine', N: 'neuter',
+};
+
+// ---------------------------------------------------------------------------
+// Verb extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all verb parse items from a chapter of MorphGNT data.
+ * Returns them in canonical (text order) sequence, then shuffled.
+ */
+export function extractVerbs(
+  bookData: MorphBook,
+  chapter: string,
+  bookName: string,
+): GNTParseItem[] {
+  const verses = bookData[chapter];
+  if (!verses) return [];
+
+  const items: GNTParseItem[] = [];
+
+  for (const [verseNum, words] of Object.entries(verses)) {
+    for (let i = 0; i < words.length; i++) {
+      const word = words[i];
+      if (word.pos !== 'V-') continue;
+      if (word.parsing.length < 7) continue;
+
+      const [p1, p2, p3, p4, p5, p6, p7] = word.parsing;
+
+      const tense = TENSE_MAP[p2];
+      const voice = VOICE_MAP[p3];
+      const mood  = MOOD_MAP[p4];
+      if (!tense || !voice || !mood) continue;
+
+      const [form] = splitWordPunct(word.text);
+
+      const base: BaseItem = {
+        form: form || word.text,
+        lemma: word.lemma,
+        verseRef: `${bookName} ${chapter}:${verseNum}`,
+        verseWords: words,
+        wordIndex: i,
+        tense, voice, mood,
+      };
+
+      if (p4 === 'N') {
+        // Infinitive — no person, number, case, gender
+        items.push({ ...base, type: 'infinitive' });
+      } else if (p4 === 'P') {
+        // Participle
+        const parseCase = CASE_MAP[p5];
+        const number    = NUMBER_MAP[p6];
+        const gender    = GENDER_MAP[p7];
+        if (!parseCase || !number || !gender) continue;
+        items.push({ ...base, type: 'participle', parseCase, number, gender });
+      } else {
+        // Finite verb
+        const person = PERSON_MAP[p1];
+        const number = NUMBER_MAP[p6];
+        if (!person || !number) continue;
+        items.push({ ...base, type: 'finite', person, number });
+      }
+    }
+  }
+
+  return items;
+}
+
+/** Shuffle and take the first `count` items. */
+export function sampleVerbs(items: GNTParseItem[], count: number): GNTParseItem[] {
+  const out = [...items];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out.slice(0, count);
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+export interface GNTPassageSettings {
+  book: string;
+  chapter: number;
+  sessionLength: 10 | 20 | 30 | 'all';
+}
+
+const GNT_SETTINGS_KEY = 'greek-tools-gnt-parse-settings-v1';
+
+export const DEFAULT_GNT_SETTINGS: GNTPassageSettings = {
+  book: 'JHN',
+  chapter: 1,
+  sessionLength: 20,
+};
+
+export function loadGNTSettings(): GNTPassageSettings {
+  try {
+    const raw = localStorage.getItem(GNT_SETTINGS_KEY);
+    if (!raw) return { ...DEFAULT_GNT_SETTINGS };
+    const p = JSON.parse(raw) as Partial<GNTPassageSettings>;
+    return {
+      book:          typeof p.book    === 'string' ? p.book    : 'JHN',
+      chapter:       typeof p.chapter === 'number' ? p.chapter : 1,
+      sessionLength: ([10, 20, 30, 'all'] as const).includes(p.sessionLength as 10 | 20 | 30 | 'all')
+        ? (p.sessionLength as GNTPassageSettings['sessionLength'])
+        : 20,
+    };
+  } catch {
+    return { ...DEFAULT_GNT_SETTINGS };
+  }
+}
+
+export function saveGNTSettings(s: GNTPassageSettings): void {
+  localStorage.setItem(GNT_SETTINGS_KEY, JSON.stringify(s));
+}

--- a/src/lib/verb-parse.test.ts
+++ b/src/lib/verb-parse.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for src/lib/verb-parse.ts
+ *
+ * Covers: buildSession, gradeAnswer, normalizeForm, and type helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildSession,
+  gradeAnswer,
+  normalizeForm,
+  emptyAnswer,
+  DEFAULT_PARSE_SETTINGS,
+  PARSE_TENSES,
+  PARSE_VOICES,
+  PARSE_MOODS,
+  type ParseSettings,
+  type ParseAnswer,
+} from './verb-parse';
+
+// ---------------------------------------------------------------------------
+// normalizeForm
+// ---------------------------------------------------------------------------
+
+describe('normalizeForm', () => {
+  it('strips parenthesized movable-nu', () => {
+    expect(normalizeForm('λύουσι(ν)')).toBe('λύουσι');
+  });
+
+  it('leaves plain forms unchanged', () => {
+    expect(normalizeForm('λύω')).toBe('λύω');
+    expect(normalizeForm('ἔλυσαν')).toBe('ἔλυσαν');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSession
+// ---------------------------------------------------------------------------
+
+describe('buildSession', () => {
+  it('returns at most the requested count', () => {
+    const items = buildSession(DEFAULT_PARSE_SETTINGS, 10);
+    expect(items.length).toBeLessThanOrEqual(10);
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it('all items have the required fields', () => {
+    const items = buildSession(DEFAULT_PARSE_SETTINGS, 20);
+    for (const item of items) {
+      expect(item.form).toBeTruthy();
+      expect(PARSE_TENSES).toContain(item.tense);
+      expect([...PARSE_VOICES, 'mid-pass']).toContain(item.voice);
+      expect(PARSE_MOODS).toContain(item.mood);
+      expect(['1st', '2nd', '3rd']).toContain(item.person);
+      expect(['singular', 'plural']).toContain(item.number);
+      expect(item.paradigmLabel).toContain('λύω');
+    }
+  });
+
+  it('respects tense filter — present only', () => {
+    const settings: ParseSettings = {
+      ...DEFAULT_PARSE_SETTINGS,
+      tenses: ['present'],
+    };
+    const items = buildSession(settings, 30);
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.tense).toBe('present');
+    }
+  });
+
+  it('respects mood filter — indicative only', () => {
+    const settings: ParseSettings = {
+      ...DEFAULT_PARSE_SETTINGS,
+      moods: ['indicative'],
+    };
+    const items = buildSession(settings, 30);
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.mood).toBe('indicative');
+    }
+  });
+
+  it('respects voice filter — active only', () => {
+    const settings: ParseSettings = {
+      ...DEFAULT_PARSE_SETTINGS,
+      voices: ['active'],
+    };
+    const items = buildSession(settings, 30);
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      // mid-pass paradigms are excluded when only 'active' is selected
+      expect(item.voice).toBe('active');
+    }
+  });
+
+  it('returns empty array when no paradigms match', () => {
+    const settings: ParseSettings = {
+      ...DEFAULT_PARSE_SETTINGS,
+      // imperfect subjunctive does not exist
+      tenses: ['imperfect'],
+      moods: ['subjunctive'],
+    };
+    const items = buildSession(settings, 10);
+    expect(items).toHaveLength(0);
+  });
+
+  it('present active indicative filter returns only pres-act-ind forms', () => {
+    const settings: ParseSettings = {
+      tenses: ['present'],
+      voices: ['active'],
+      moods: ['indicative'],
+      sessionLength: 10,
+    };
+    const items = buildSession(settings, 30);
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.tense).toBe('present');
+      expect(item.voice).toBe('active');
+      expect(item.mood).toBe('indicative');
+    }
+  });
+
+  it('de-duplicates forms that appear in multiple paradigms', () => {
+    const items = buildSession(DEFAULT_PARSE_SETTINGS, 200);
+    const forms = items.map(i => normalizeForm(i.form));
+    const unique = new Set(forms);
+    expect(forms.length).toBe(unique.size);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gradeAnswer
+// ---------------------------------------------------------------------------
+
+describe('gradeAnswer', () => {
+  const presActIndItem = {
+    form: 'λύω',
+    tense: 'present' as const,
+    voice: 'active' as const,
+    mood: 'indicative' as const,
+    person: '1st' as const,
+    number: 'singular' as const,
+    paradigmLabel: 'Present Active Indicative — λύω',
+  };
+
+  it('returns allCorrect=true for a fully correct answer', () => {
+    const answer: ParseAnswer = {
+      tense: 'present',
+      voice: 'active',
+      mood: 'indicative',
+      person: '1st',
+      number: 'singular',
+    };
+    const result = gradeAnswer(presActIndItem, answer);
+    expect(result.allCorrect).toBe(true);
+    expect(result.tense).toBe(true);
+    expect(result.voice).toBe(true);
+    expect(result.mood).toBe(true);
+    expect(result.person).toBe(true);
+    expect(result.number).toBe(true);
+  });
+
+  it('returns allCorrect=false when any property is wrong', () => {
+    const answer: ParseAnswer = {
+      tense: 'aorist', // wrong
+      voice: 'active',
+      mood: 'indicative',
+      person: '1st',
+      number: 'singular',
+    };
+    const result = gradeAnswer(presActIndItem, answer);
+    expect(result.allCorrect).toBe(false);
+    expect(result.tense).toBe(false);
+    expect(result.voice).toBe(true);
+  });
+
+  it('accepts "middle" or "passive" for a mid-pass paradigm', () => {
+    const midPassItem = {
+      ...presActIndItem,
+      voice: 'mid-pass' as const,
+      paradigmLabel: 'Present Middle/Passive Indicative — λύω',
+    };
+    const withMiddle: ParseAnswer = { ...emptyAnswer(), voice: 'middle', tense: 'present', mood: 'indicative', person: '1st', number: 'singular' };
+    const withPassive: ParseAnswer = { ...emptyAnswer(), voice: 'passive', tense: 'present', mood: 'indicative', person: '1st', number: 'singular' };
+    expect(gradeAnswer(midPassItem, withMiddle).voice).toBe(true);
+    expect(gradeAnswer(midPassItem, withPassive).voice).toBe(true);
+  });
+
+  it('rejects wrong voice for mid-pass paradigm', () => {
+    const midPassItem = {
+      ...presActIndItem,
+      voice: 'mid-pass' as const,
+    };
+    const withActive: ParseAnswer = { ...emptyAnswer(), voice: 'active', tense: 'present', mood: 'indicative', person: '1st', number: 'singular' };
+    expect(gradeAnswer(midPassItem, withActive).voice).toBe(false);
+  });
+
+  it('handles empty answers — all false', () => {
+    const result = gradeAnswer(presActIndItem, emptyAnswer());
+    expect(result.allCorrect).toBe(false);
+    expect(result.tense).toBe(false);
+    expect(result.voice).toBe(false);
+    expect(result.mood).toBe(false);
+    expect(result.person).toBe(false);
+    expect(result.number).toBe(false);
+  });
+});

--- a/src/lib/verb-parse.ts
+++ b/src/lib/verb-parse.ts
@@ -1,0 +1,307 @@
+/**
+ * Verb parsing challenge — form pool generation, types, and grading logic.
+ *
+ * Draws entirely from verbParadigms[] in src/data/grammar.ts.
+ * No Greek text input needed; all answers are dropdown selections.
+ */
+
+import { verbParadigms, type PersonNum } from '../data/grammar';
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type ParseTense = 'present' | 'imperfect' | 'future' | 'aorist' | 'perfect';
+export type ParseVoice = 'active' | 'middle' | 'passive' | 'mid-pass';
+export type ParseMood = 'indicative' | 'subjunctive' | 'imperative';
+export type ParsePerson = '1st' | '2nd' | '3rd';
+export type ParseNumber = 'singular' | 'plural';
+
+export const PARSE_TENSES: ParseTense[] = ['present', 'imperfect', 'future', 'aorist', 'perfect'];
+export const PARSE_VOICES: ParseVoice[] = ['active', 'middle', 'passive'];
+export const PARSE_MOODS: ParseMood[] = ['indicative', 'subjunctive', 'imperative'];
+export const PARSE_PERSONS: ParsePerson[] = ['1st', '2nd', '3rd'];
+export const PARSE_NUMBERS: ParseNumber[] = ['singular', 'plural'];
+
+export const TENSE_LABELS: Record<ParseTense, string> = {
+  present: 'Present',
+  imperfect: 'Imperfect',
+  future: 'Future',
+  aorist: 'Aorist',
+  perfect: 'Perfect',
+};
+
+export const VOICE_LABELS: Record<ParseVoice, string> = {
+  active: 'Active',
+  middle: 'Middle',
+  passive: 'Passive',
+  'mid-pass': 'Middle/Passive',
+};
+
+export const MOOD_LABELS: Record<ParseMood, string> = {
+  indicative: 'Indicative',
+  subjunctive: 'Subjunctive',
+  imperative: 'Imperative',
+};
+
+export const PERSON_LABELS: Record<ParsePerson, string> = {
+  '1st': '1st',
+  '2nd': '2nd',
+  '3rd': '3rd',
+};
+
+export const NUMBER_LABELS: Record<ParseNumber, string> = {
+  singular: 'Singular',
+  plural: 'Plural',
+};
+
+/** A single verb form together with its full parse. */
+export interface ParseItem {
+  form: string;
+  tense: ParseTense;
+  voice: ParseVoice;
+  mood: ParseMood;
+  person: ParsePerson;
+  number: ParseNumber;
+  /** Display label for the source paradigm, e.g. "Present Active Indicative — λύω" */
+  paradigmLabel: string;
+  /** Other valid parses when the same form appears in multiple paradigms. */
+  ambiguous?: string[];
+}
+
+/** The student's answer for one ParseItem. */
+export interface ParseAnswer {
+  tense: ParseTense | '';
+  voice: ParseVoice | '';
+  mood: ParseMood | '';
+  person: ParsePerson | '';
+  number: ParseNumber | '';
+}
+
+/** Per-property grading for a single form. */
+export interface ParseResult {
+  tense: boolean;
+  voice: boolean;
+  mood: boolean;
+  person: boolean;
+  number: boolean;
+  /** true iff all five properties are correct */
+  allCorrect: boolean;
+}
+
+export function emptyAnswer(): ParseAnswer {
+  return { tense: '', voice: '', mood: '', person: '', number: '' };
+}
+
+// ---------------------------------------------------------------------------
+// Parse code extraction from paradigm ID
+// ---------------------------------------------------------------------------
+
+/** Map paradigm id segment → ParseTense */
+const ID_TENSE: Record<string, ParseTense> = {
+  pres: 'present',
+  impf: 'imperfect',
+  fut:  'future',
+  aor:  'aorist',
+  perf: 'perfect',
+};
+
+/** Map paradigm id segment → ParseVoice */
+const ID_VOICE: Record<string, ParseVoice> = {
+  act:  'active',
+  mid:  'middle',
+  pass: 'passive',
+  'mid-pass': 'mid-pass',
+};
+
+/** Map paradigm id segment → ParseMood */
+const ID_MOOD: Record<string, ParseMood> = {
+  ind:  'indicative',
+  subj: 'subjunctive',
+  imp:  'imperative',
+};
+
+/** Map PersonNum key → ParsePerson + ParseNumber */
+const PERSON_MAP: Record<PersonNum, { person: ParsePerson; number: ParseNumber }> = {
+  '1sg': { person: '1st', number: 'singular' },
+  '2sg': { person: '2nd', number: 'singular' },
+  '3sg': { person: '3rd', number: 'singular' },
+  '1pl': { person: '1st', number: 'plural' },
+  '2pl': { person: '2nd', number: 'plural' },
+  '3pl': { person: '3rd', number: 'plural' },
+};
+
+function parseTenseFromId(id: string): ParseTense | null {
+  for (const [seg, tense] of Object.entries(ID_TENSE)) {
+    if (id.startsWith(seg + '-')) return tense;
+  }
+  return null;
+}
+
+function parseVoiceFromId(id: string): ParseVoice | null {
+  // Order matters: check mid-pass before mid and pass
+  for (const seg of ['mid-pass', 'act', 'mid', 'pass']) {
+    if (id.includes('-' + seg + '-')) return ID_VOICE[seg];
+  }
+  return null;
+}
+
+function parseMoodFromId(id: string): ParseMood | null {
+  for (const [seg, mood] of Object.entries(ID_MOOD)) {
+    if (id.endsWith('-' + seg)) return mood;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Settings types
+// ---------------------------------------------------------------------------
+
+export interface ParseSettings {
+  tenses: ParseTense[];
+  voices: ParseVoice[];
+  moods: ParseMood[];
+  sessionLength: 10 | 20 | 30;
+}
+
+export const DEFAULT_PARSE_SETTINGS: ParseSettings = {
+  tenses: [...PARSE_TENSES],
+  voices: ['active', 'middle', 'passive'],
+  moods: [...PARSE_MOODS],
+  sessionLength: 20,
+};
+
+// ---------------------------------------------------------------------------
+// Form pool generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the full pool of ParseItems from verbParadigms, then filter,
+ * de-duplicate visible forms, and return a shuffled session of `count` items.
+ */
+export function buildSession(settings: ParseSettings, count: number): ParseItem[] {
+  // 1. Expand all paradigms into individual ParseItems
+  const allItems: ParseItem[] = [];
+
+  for (const paradigm of verbParadigms) {
+    const tense = parseTenseFromId(paradigm.id);
+    const voice = parseVoiceFromId(paradigm.id);
+    const mood  = parseMoodFromId(paradigm.id);
+    if (!tense || !voice || !mood) continue;
+
+    // Filter by settings — mid-pass paradigms can count for either middle or passive
+    const voiceMatch =
+      settings.voices.includes(voice) ||
+      (voice === 'mid-pass' &&
+        (settings.voices.includes('middle') || settings.voices.includes('passive')));
+
+    if (
+      !settings.tenses.includes(tense) ||
+      !voiceMatch ||
+      !settings.moods.includes(mood)
+    ) continue;
+
+    for (const [personNum, form] of Object.entries(paradigm.forms) as [PersonNum, string][]) {
+      const { person, number } = PERSON_MAP[personNum];
+      allItems.push({
+        form,
+        tense,
+        voice,
+        mood,
+        person,
+        number,
+        paradigmLabel: `${paradigm.label} — λύω`,
+      });
+    }
+  }
+
+  // 2. Group by normalized form to detect ambiguous forms
+  const byForm = new Map<string, ParseItem[]>();
+  for (const item of allItems) {
+    const key = normalizeForm(item.form);
+    const existing = byForm.get(key) ?? [];
+    existing.push(item);
+    byForm.set(key, existing);
+  }
+
+  // 3. De-duplicate: for forms shared across paradigms, keep first occurrence
+  //    but annotate with ambiguous[] listing the other parses.
+  const deduped: ParseItem[] = [];
+  for (const [, items] of byForm) {
+    const primary = items[0];
+    if (items.length > 1) {
+      primary.ambiguous = items.slice(1).map(
+        i => `${TENSE_LABELS[i.tense]} ${VOICE_LABELS[i.voice]} ${MOOD_LABELS[i.mood]} ${i.person} ${NUMBER_LABELS[i.number]}`
+      );
+    }
+    deduped.push(primary);
+  }
+
+  // 4. Shuffle and take `count`
+  const shuffled = shuffle(deduped);
+  return shuffled.slice(0, count);
+}
+
+/** Grade a student's answer against the correct parse. */
+export function gradeAnswer(item: ParseItem, answer: ParseAnswer): ParseResult {
+  const tense  = answer.tense  === item.tense;
+  const voice  = gradeVoice(item.voice, answer.voice);
+  const mood   = answer.mood   === item.mood;
+  const person = answer.person === item.person;
+  const number = answer.number === item.number;
+  return { tense, voice, mood, person, number, allCorrect: tense && voice && mood && person && number };
+}
+
+/** mid-pass paradigms accept either 'middle' or 'passive' as correct. */
+function gradeVoice(correct: ParseVoice, given: ParseVoice | ''): boolean {
+  if (!given) return false;
+  if (given === correct) return true;
+  if (correct === 'mid-pass' && (given === 'middle' || given === 'passive')) return true;
+  return false;
+}
+
+/** Strip parenthesized movable-nu variants, e.g. "λύουσι(ν)" → "λύουσι" */
+export function normalizeForm(form: string): string {
+  return form.replace(/\([^)]+\)$/, '').trim();
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+const PARSE_SETTINGS_KEY = 'greek-tools-parse-settings-v1';
+
+export function loadParseSettings(): ParseSettings {
+  try {
+    const raw = localStorage.getItem(PARSE_SETTINGS_KEY);
+    if (!raw) return { ...DEFAULT_PARSE_SETTINGS };
+    const parsed = JSON.parse(raw) as Partial<ParseSettings>;
+    return {
+      tenses: Array.isArray(parsed.tenses) ? parsed.tenses : [...PARSE_TENSES],
+      voices: Array.isArray(parsed.voices) ? parsed.voices : ['active', 'middle', 'passive'],
+      moods:  Array.isArray(parsed.moods)  ? parsed.moods  : [...PARSE_MOODS],
+      sessionLength: ([10, 20, 30] as const).includes(parsed.sessionLength as 10 | 20 | 30)
+        ? (parsed.sessionLength as 10 | 20 | 30)
+        : 20,
+    };
+  } catch {
+    return { ...DEFAULT_PARSE_SETTINGS };
+  }
+}
+
+export function saveParseSettings(settings: ParseSettings): void {
+  localStorage.setItem(PARSE_SETTINGS_KEY, JSON.stringify(settings));
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+function shuffle<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,6 +42,14 @@ const tools = [
     accentColor: '#F43F5E',   // coral rose
     bgColor: '#FFF1F2',
   },
+  {
+    href: '/parse',
+    icon: 'λύ',
+    title: 'Verb Parsing',
+    description: 'Practice parsing Greek verb forms. Given a single form, identify its tense, voice, mood, person, and number.',
+    accentColor: '#059669',   // emerald green
+    bgColor: '#ECFDF5',
+  },
 ] as const;
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,12 +43,12 @@ const tools = [
     bgColor: '#FFF1F2',
   },
   {
-    href: '/parse',
-    icon: 'λύ',
-    title: 'Verb Parsing',
-    description: 'Practice parsing Greek verb forms. Given a single form, identify its tense, voice, mood, person, and number.',
-    accentColor: '#059669',   // emerald green
-    bgColor: '#ECFDF5',
+    href: '/quiz',
+    icon: '?',
+    title: 'Quiz',
+    description: 'Drill paradigm tables or practice parsing individual verb forms — two modes for building fluency.',
+    accentColor: '#7C3AED',   // grape violet (reused from flashcards family)
+    bgColor: '#F5F3FF',
   },
 ] as const;
 ---

--- a/src/pages/paradigms.astro
+++ b/src/pages/paradigms.astro
@@ -8,7 +8,7 @@ import ParadigmQuiz from '../components/ParadigmQuiz';
   description="Quiz yourself on Greek paradigm tables — noun declensions, verb conjugations, pronouns, and more."
 >
   <a href="/quiz" class="inline-flex items-center gap-1 text-sm text-text-muted hover:text-text transition-colors mb-4">
-    ← Quiz
+    ← Back
   </a>
   <div class="mb-8">
     <h1

--- a/src/pages/paradigms.astro
+++ b/src/pages/paradigms.astro
@@ -7,6 +7,9 @@ import ParadigmQuiz from '../components/ParadigmQuiz';
   title="Paradigm Quiz"
   description="Quiz yourself on Greek paradigm tables — noun declensions, verb conjugations, pronouns, and more."
 >
+  <a href="/quiz" class="inline-flex items-center gap-1 text-sm text-text-muted hover:text-text transition-colors mb-4">
+    ← Quiz
+  </a>
   <div class="mb-8">
     <h1
       class="text-3xl font-bold mb-1"

--- a/src/pages/parse.astro
+++ b/src/pages/parse.astro
@@ -8,7 +8,7 @@ import VerbParseChallenge from '../components/VerbParseChallenge';
   description="Practice parsing Greek verb forms — identify tense, voice, mood, person, and number for λύω paradigm forms."
 >
   <a href="/quiz" class="inline-flex items-center gap-1 text-sm text-text-muted hover:text-text transition-colors mb-4">
-    ← Quiz
+    ← Back
   </a>
   <div class="mb-8">
     <h1

--- a/src/pages/parse.astro
+++ b/src/pages/parse.astro
@@ -1,0 +1,23 @@
+---
+import Layout from '../layouts/Layout.astro';
+import VerbParseChallenge from '../components/VerbParseChallenge';
+---
+
+<Layout
+  title="Verb Parsing"
+  description="Practice parsing Greek verb forms — identify tense, voice, mood, person, and number for λύω paradigm forms."
+>
+  <div class="mb-8">
+    <h1
+      class="text-3xl font-bold mb-1"
+      style="color: var(--color-accent);"
+    >
+      Verb Parsing
+    </h1>
+    <p class="text-text-muted">
+      Given a single verb form, identify its tense, voice, mood, person, and number.
+      All forms are drawn from the standard λύω paradigms.
+    </p>
+  </div>
+  <VerbParseChallenge client:load />
+</Layout>

--- a/src/pages/parse.astro
+++ b/src/pages/parse.astro
@@ -7,6 +7,9 @@ import VerbParseChallenge from '../components/VerbParseChallenge';
   title="Verb Parsing"
   description="Practice parsing Greek verb forms — identify tense, voice, mood, person, and number for λύω paradigm forms."
 >
+  <a href="/quiz" class="inline-flex items-center gap-1 text-sm text-text-muted hover:text-text transition-colors mb-4">
+    ← Quiz
+  </a>
   <div class="mb-8">
     <h1
       class="text-3xl font-bold mb-1"

--- a/src/pages/parse/gnt.astro
+++ b/src/pages/parse/gnt.astro
@@ -1,0 +1,25 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import GNTParseChallenge from '../../components/GNTParseChallenge';
+---
+
+<Layout
+  title="GNT Passage Parsing"
+  description="Parse verb forms from a chapter of the Greek New Testament — finite verbs, infinitives, and participles in context."
+>
+  <a href="/quiz" class="inline-flex items-center gap-1 text-sm text-text-muted hover:text-text transition-colors mb-4">
+    ← Back
+  </a>
+  <div class="mb-8">
+    <h1
+      class="text-3xl font-bold mb-1"
+      style="color: var(--color-primary);"
+    >
+      GNT Passage Parsing
+    </h1>
+    <p class="text-text-muted">
+      Select a book and chapter. Parse every verb — finite, infinitive, and participle — as it appears in the text.
+    </p>
+  </div>
+  <GNTParseChallenge client:load />
+</Layout>

--- a/src/pages/quiz.astro
+++ b/src/pages/quiz.astro
@@ -1,0 +1,80 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+  title="Quiz"
+  description="Practice Koine Greek with paradigm table drills or verb parsing challenges."
+>
+  <div class="mb-8">
+    <h1
+      class="text-3xl font-bold mb-1"
+      style="color: var(--color-primary);"
+    >
+      Quiz
+    </h1>
+    <p class="text-text-muted">
+      Choose a drill mode to practice.
+    </p>
+  </div>
+
+  <div class="grid sm:grid-cols-2 gap-6 max-w-2xl">
+
+    <!-- Paradigm Quiz -->
+    <a
+      href="/paradigms"
+      class="group block bg-bg-card rounded-2xl shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden border border-white hover:-translate-y-0.5"
+    >
+      <div class="h-1.5 w-full" style="background: #F43F5E;" />
+      <div class="p-6">
+        <div
+          class="w-12 h-12 rounded-xl flex items-center justify-center text-xl mb-4 font-mono font-bold"
+          style="background: #FFF1F2; color: #F43F5E;"
+        >
+          ⊞
+        </div>
+        <h2 class="text-lg font-bold mb-2" style="color: #F43F5E;">
+          Paradigm Quiz
+        </h2>
+        <p class="text-text-muted text-sm leading-relaxed">
+          Fill in the blanks of a full paradigm table from memory — noun declensions, verb conjugations, pronouns, and more.
+        </p>
+      </div>
+      <div
+        class="px-6 pb-4 text-xs font-semibold flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+        style="color: #F43F5E;"
+      >
+        Open →
+      </div>
+    </a>
+
+    <!-- Verb Parsing -->
+    <a
+      href="/parse"
+      class="group block bg-bg-card rounded-2xl shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden border border-white hover:-translate-y-0.5"
+    >
+      <div class="h-1.5 w-full" style="background: #059669;" />
+      <div class="p-6">
+        <div
+          class="w-12 h-12 rounded-xl flex items-center justify-center text-xl mb-4 font-mono font-bold"
+          style="background: #ECFDF5; color: #059669;"
+        >
+          λύ
+        </div>
+        <h2 class="text-lg font-bold mb-2" style="color: #059669;">
+          Verb Parsing
+        </h2>
+        <p class="text-text-muted text-sm leading-relaxed">
+          Given a single verb form, identify its tense, voice, mood, person, and number — the core skill for reading Greek.
+        </p>
+      </div>
+      <div
+        class="px-6 pb-4 text-xs font-semibold flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+        style="color: #059669;"
+      >
+        Open →
+      </div>
+    </a>
+
+  </div>
+</Layout>

--- a/src/pages/quiz.astro
+++ b/src/pages/quiz.astro
@@ -18,7 +18,7 @@ import Layout from '../layouts/Layout.astro';
     </p>
   </div>
 
-  <div class="grid sm:grid-cols-2 gap-6 max-w-2xl">
+  <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-4xl">
 
     <!-- Paradigm Quiz -->
     <a
@@ -71,6 +71,34 @@ import Layout from '../layouts/Layout.astro';
       <div
         class="px-6 pb-4 text-xs font-semibold flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
         style="color: #059669;"
+      >
+        Open →
+      </div>
+    </a>
+
+    <!-- GNT Passage Parsing -->
+    <a
+      href="/parse/gnt"
+      class="group block bg-bg-card rounded-2xl shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden border border-white hover:-translate-y-0.5"
+    >
+      <div class="h-1.5 w-full" style="background: #0369a1;" />
+      <div class="p-6">
+        <div
+          class="w-12 h-12 rounded-xl flex items-center justify-center text-xl mb-4 font-mono font-bold"
+          style="background: #e0f2fe; color: #0369a1; font-family: var(--font-greek);"
+        >
+          Ἰω
+        </div>
+        <h2 class="text-lg font-bold mb-2" style="color: #0369a1;">
+          GNT Passage
+        </h2>
+        <p class="text-text-muted text-sm leading-relaxed">
+          Choose a chapter of the Greek New Testament and parse its verbs in context — finite, infinitive, and participle.
+        </p>
+      </div>
+      <div
+        class="px-6 pb-4 text-xs font-semibold flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+        style="color: #0369a1;"
       >
         Open →
       </div>


### PR DESCRIPTION
## Summary

- Adds `/parse` route with a new Verb Parsing Challenge
- Students see one λύω paradigm form at a time and identify tense, voice, mood, person, and number via dropdowns
- Covers all 18 standard λύω paradigms (indicative, subjunctive, imperative)
- Per-property grading with strikethrough + correct answer on wrong submissions
- Session results screen with overall score and accuracy breakdown by property
- Settings (tense/voice/mood filter, session length) persisted to localStorage
- 15 new unit tests in `src/lib/verb-parse.test.ts`; all 486 tests pass

## Test plan

- [ ] Navigate to `/parse` — settings phase loads
- [ ] Toggle tenses/voices/moods off and verify Start is disabled when none selected
- [ ] Filter to Present/Active/Indicative only — confirm all forms are present active indicative
- [ ] Submit correct answers — all dropdowns show ✓ and "Correct!"
- [ ] Submit wrong answers — dropdowns show strikethrough + correct answer + ✗
- [ ] Complete a session — results screen shows score and per-property bar chart
- [ ] Reload page — settings persist from localStorage
- [ ] Check `/` home page — "Verb Parsing" card present

🤖 Generated with [Claude Code](https://claude.com/claude-code)