### PR TITLE
feat(home): add Paradigm Quiz card to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,6 +42,14 @@ const tools = [
     accentColor: '#F43F5E',   // coral rose
     bgColor: '#FFF1F2',
   },
+  {
+    href: '/paradigms',
+    icon: '✎',
+    title: 'Paradigm Quiz',
+    description: 'Fill in the blanks from memory. Quiz yourself on noun declensions, verb conjugations, pronouns, and more.',
+    accentColor: '#059669',   // emerald
+    bgColor: '#ECFDF5',
+  },
 ] as const;
 ---
 


### PR DESCRIPTION
## Summary
- Adds a Paradigm Quiz card to the homepage tool grid, linking to `/paradigms`
- Uses emerald green (`#059669`) to distinguish it from existing cards

## Test plan
- [ ] Homepage shows 6 cards including Paradigm Quiz
- [ ] Clicking the card navigates to `/paradigms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)