### PR TITLE
feat(paradigms): add 1st declension η-stem feminine paradigm

### DIFF
--- a/src/data/grammar.ts
+++ b/src/data/grammar.ts
@@ -306,6 +306,19 @@ export const nounParadigms: NounParadigm[] = [
     },
   },
   {
+    id: '1f-eta',
+    name: '1st Decl. Feminine — ἀρχή (η-stem)',
+    declension: '1st',
+    gender: 'feminine',
+    forms: {
+      nom: { sg: { full: 'ἀρχή', ending: 'η' }, pl: { full: 'ἀρχαί', ending: 'αι' } },
+      gen: { sg: { full: 'ἀρχῆς', ending: 'ης' }, pl: { full: 'ἀρχῶν', ending: 'ων' } },
+      dat: { sg: { full: 'ἀρχῇ', ending: 'ῃ' }, pl: { full: 'ἀρχαῖς', ending: 'αις' } },
+      acc: { sg: { full: 'ἀρχήν', ending: 'ην' }, pl: { full: 'ἀρχάς', ending: 'ας' } },
+      voc: { sg: { full: 'ἀρχή', ending: 'η' }, pl: { full: 'ἀρχαί', ending: 'αι' } },
+    },
+  },
+  {
     id: '1m-as',
     name: '1st Decl. Masculine — νεανίας',
     declension: '1st',

--- a/src/lib/paradigm-quiz.test.ts
+++ b/src/lib/paradigm-quiz.test.ts
@@ -54,10 +54,10 @@ describe('buildTableModels', () => {
 
   // ── Nouns ────────────────────────────────────────────────────────────────
 
-  it('includes all 9 noun paradigms', () => {
+  it('includes all 10 noun paradigms', () => {
     const tables = buildTableModels();
     const nouns = tables.filter((t) => t.category === 'noun');
-    expect(nouns.length).toBe(9);
+    expect(nouns.length).toBe(10);
   });
 
   it('noun tables have 2 columns (Singular, Plural)', () => {
@@ -300,6 +300,30 @@ describe('getQuizCells', () => {
     // Gen Pl of ἡμέρα is ἡμερῶν
     const genPl = cells.find((c) => c.rowIndex === 1 && c.colIndex === 1)!;
     expect(genPl.answer).toBe('ἡμερῶν');
+  });
+
+  it('1f-eta paradigm has correct forms for ἀρχή', () => {
+    const tables = buildTableModels();
+    const noun = tables.find((t) => t.id === 'noun-1f-eta')!;
+    expect(noun).toBeDefined();
+    expect(noun.category).toBe('noun');
+    const cells = getQuizCells(noun);
+    expect(cells).toHaveLength(10);
+    // Nom Sg
+    const nomSg = cells.find((c) => c.rowIndex === 0 && c.colIndex === 0)!;
+    expect(nomSg.answer).toBe('ἀρχή');
+    // Gen Sg
+    const genSg = cells.find((c) => c.rowIndex === 1 && c.colIndex === 0)!;
+    expect(genSg.answer).toBe('ἀρχῆς');
+    // Dat Sg
+    const datSg = cells.find((c) => c.rowIndex === 2 && c.colIndex === 0)!;
+    expect(datSg.answer).toBe('ἀρχῇ');
+    // Acc Sg
+    const accSg = cells.find((c) => c.rowIndex === 3 && c.colIndex === 0)!;
+    expect(accSg.answer).toBe('ἀρχήν');
+    // Gen Pl
+    const genPl = cells.find((c) => c.rowIndex === 1 && c.colIndex === 1)!;
+    expect(genPl.answer).toBe('ἀρχῶν');
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `1f-eta` paradigm entry to `nounParadigms` in `src/data/grammar.ts` with all 10 forms (5 cases × 2 numbers) for ἀρχή
- Updates the noun count assertion in `paradigm-quiz.test.ts` from 9 → 10
- Adds targeted tests verifying all key forms of the new paradigm

## Test plan

- [ ] All 612 existing tests pass (`pnpm test:run`)
- [ ] New `1f-eta` paradigm is visible under Nouns in the paradigm quiz UI
- [ ] Easy / medium / hard density modes work on the new paradigm
- [ ] Endings-only mode shows correct η-stem endings

closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)