### PR TITLE
feat(gnt-parse): skip repeat verbs option for GNT passage parsing

### DIFF
--- a/src/components/GNTParseChallenge.tsx
+++ b/src/components/GNTParseChallenge.tsx
@@ -9,6 +9,7 @@ import type {
 } from '../lib/gnt-parse';
 import {
   DEFAULT_GNT_SETTINGS,
+  deduplicateByLemma,
   emptyGNTAnswer,
   extractVerbs,
   formatRangeRef,
@@ -67,18 +68,26 @@ function GNTParseChallengeInner() {
         const chapterData = data[String(settings.chapter)];
         const numVerses = chapterData ? Object.keys(chapterData).length : 0;
         setVerseCount(numVerses);
-        const verbs = extractVerbs(
+        let verbs = extractVerbs(
           data,
           String(settings.chapter),
           meta?.name ?? settings.book,
           settings.verseStart,
           settings.verseEnd,
         );
+        if (settings.skipRepeatedLemmas) verbs = deduplicateByLemma(verbs);
         setVerbCount(verbs.length);
       })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, [settings.book, settings.chapter, settings.verseStart, settings.verseEnd, settingsLoaded]);
+  }, [
+    settings.book,
+    settings.chapter,
+    settings.verseStart,
+    settings.verseEnd,
+    settings.skipRepeatedLemmas,
+    settingsLoaded,
+  ]);
 
   function handleSettingsChange(s: GNTPassageSettings) {
     setSettings(s);
@@ -87,13 +96,14 @@ function GNTParseChallengeInner() {
 
   function handleStart() {
     if (!bookData) return;
-    const all = extractVerbs(
+    let all = extractVerbs(
       bookData,
       String(settings.chapter),
       bookName,
       settings.verseStart,
       settings.verseEnd,
     );
+    if (settings.skipRepeatedLemmas) all = deduplicateByLemma(all);
     const count = settings.sessionLength === 'all' ? all.length : settings.sessionLength;
     const items = sampleVerbs(all, count);
     if (items.length === 0) return;

--- a/src/components/PassageSelector.tsx
+++ b/src/components/PassageSelector.tsx
@@ -144,6 +144,17 @@ export default function PassageSelector({
           </div>
         </div>
 
+        {/* Skip repeated lemmas toggle */}
+        <label className="mt-3 flex items-center gap-2 cursor-pointer select-none w-fit">
+          <input
+            type="checkbox"
+            checked={settings.skipRepeatedLemmas}
+            onChange={(e) => onChange({ ...settings, skipRepeatedLemmas: e.target.checked })}
+            className="w-4 h-4 rounded accent-[var(--color-accent)]"
+          />
+          <span className="text-sm text-text">One form per lemma</span>
+        </label>
+
         {/* Verb count feedback */}
         <p className="mt-2 text-xs text-text-muted h-4">
           {loading && 'Loading…'}

--- a/src/components/PassageSelector.tsx
+++ b/src/components/PassageSelector.tsx
@@ -152,7 +152,7 @@ export default function PassageSelector({
             onChange={(e) => onChange({ ...settings, skipRepeatedLemmas: e.target.checked })}
             className="w-4 h-4 rounded accent-[var(--color-accent)]"
           />
-          <span className="text-sm text-text">One form per lemma</span>
+          <span className="text-sm text-text">Skip repeat verbs</span>
         </label>
 
         {/* Verb count feedback */}

--- a/src/lib/gnt-parse.test.ts
+++ b/src/lib/gnt-parse.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from 'vitest';
 import type { MorphBook } from '../data/morphgnt';
 import {
+  deduplicateByLemma,
   emptyGNTAnswer,
   extractVerbs,
   formatRangeRef,
@@ -411,5 +412,90 @@ describe('loadGNTSettings — backward compatibility', () => {
     expect(s.verseStart).toBe(3);
     expect(s.verseEnd).toBe(18);
     localStorage.removeItem('greek-tools-gnt-parse-settings-v1');
+  });
+
+  it('defaults skipRepeatedLemmas to false when missing from stored settings', () => {
+    localStorage.setItem(
+      'greek-tools-gnt-parse-settings-v1',
+      JSON.stringify({ book: 'JHN', chapter: 1, verseStart: 1, verseEnd: null, sessionLength: 20 }),
+    );
+    const s = loadGNTSettings();
+    expect(s.skipRepeatedLemmas).toBe(false);
+    localStorage.removeItem('greek-tools-gnt-parse-settings-v1');
+  });
+
+  it('preserves skipRepeatedLemmas: true when saved', () => {
+    localStorage.setItem(
+      'greek-tools-gnt-parse-settings-v1',
+      JSON.stringify({
+        book: 'JHN',
+        chapter: 1,
+        verseStart: 1,
+        verseEnd: null,
+        sessionLength: 20,
+        skipRepeatedLemmas: true,
+      }),
+    );
+    const s = loadGNTSettings();
+    expect(s.skipRepeatedLemmas).toBe(true);
+    localStorage.removeItem('greek-tools-gnt-parse-settings-v1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deduplicateByLemma
+// ---------------------------------------------------------------------------
+
+describe('deduplicateByLemma', () => {
+  const FINITE_VERB_2 = { text: 'λύεις', lemma: 'λύω', pos: 'V-', parsing: '2PAI-S--' };
+  // same lemma as FINITE_VERB, different form
+
+  it('returns all items when all lemmas are unique', () => {
+    const book = makeBook([FINITE_VERB, PARTICIPLE]); // λύω, βοάω
+    const items = extractVerbs(book, '1', 'John');
+    expect(deduplicateByLemma(items)).toHaveLength(2);
+  });
+
+  it('keeps only the first occurrence of a repeated lemma', () => {
+    const book = makeBook([FINITE_VERB, FINITE_VERB_2]); // λύω twice
+    const items = extractVerbs(book, '1', 'John');
+    const deduped = deduplicateByLemma(items);
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0].form).toBe('λύει'); // first occurrence kept
+  });
+
+  it('preserves text order', () => {
+    const book = makeBook([PARTICIPLE, FINITE_VERB, FINITE_VERB_2]); // βοάω, λύω, λύω
+    const items = extractVerbs(book, '1', 'John');
+    const deduped = deduplicateByLemma(items);
+    expect(deduped).toHaveLength(2);
+    expect(deduped[0].lemma).toBe('βοάω');
+    expect(deduped[1].lemma).toBe('λύω');
+  });
+
+  it('returns an empty array when given an empty array', () => {
+    expect(deduplicateByLemma([])).toHaveLength(0);
+  });
+
+  it('does not mutate the input array', () => {
+    const book = makeBook([FINITE_VERB, FINITE_VERB_2]);
+    const items = extractVerbs(book, '1', 'John');
+    const copy = [...items];
+    deduplicateByLemma(items);
+    expect(items).toHaveLength(copy.length);
+  });
+
+  it('deduplicates across verse boundaries in a multi-verse book', () => {
+    const FINITE_VERB_2 = { text: 'λύεις', lemma: 'λύω', pos: 'V-', parsing: '2PAI-S--' };
+    const book = makeMultiVerseBook([
+      { verse: 1, word: FINITE_VERB }, // λύω
+      { verse: 2, word: PARTICIPLE }, // βοάω
+      { verse: 3, word: FINITE_VERB_2 }, // λύω again
+    ]);
+    const items = extractVerbs(book, '1', 'John');
+    expect(items).toHaveLength(3);
+    const deduped = deduplicateByLemma(items);
+    expect(deduped).toHaveLength(2);
+    expect(deduped.map((i) => i.lemma)).toEqual(['λύω', 'βοάω']);
   });
 });

--- a/src/lib/gnt-parse.ts
+++ b/src/lib/gnt-parse.ts
@@ -339,6 +339,16 @@ export function extractVerbs(
   return items;
 }
 
+/** Return only the first occurrence of each lemma, in text order. */
+export function deduplicateByLemma(items: GNTParseItem[]): GNTParseItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.lemma)) return false;
+    seen.add(item.lemma);
+    return true;
+  });
+}
+
 /** Shuffle and take the first `count` items. */
 export function sampleVerbs(items: GNTParseItem[], count: number): GNTParseItem[] {
   const out = [...items];
@@ -359,6 +369,7 @@ export interface GNTPassageSettings {
   verseStart: number;
   verseEnd: number; // Infinity means "last verse in chapter"
   sessionLength: 10 | 20 | 30 | 'all';
+  skipRepeatedLemmas: boolean;
 }
 
 const GNT_SETTINGS_KEY = 'greek-tools-gnt-parse-settings-v1';
@@ -369,6 +380,7 @@ export const DEFAULT_GNT_SETTINGS: GNTPassageSettings = {
   verseStart: 1,
   verseEnd: Infinity,
   sessionLength: 20,
+  skipRepeatedLemmas: false,
 };
 
 export function loadGNTSettings(): GNTPassageSettings {
@@ -386,6 +398,7 @@ export function loadGNTSettings(): GNTPassageSettings {
       )
         ? (p.sessionLength as GNTPassageSettings['sessionLength'])
         : 20,
+      skipRepeatedLemmas: typeof p.skipRepeatedLemmas === 'boolean' ? p.skipRepeatedLemmas : false,
     };
   } catch {
     return { ...DEFAULT_GNT_SETTINGS };


### PR DESCRIPTION
## Overview

Adds a "Skip repeat verbs" toggle to the GNT passage parsing session setup so students can opt into parsing each unique verb lemma only once per session.

## What changed

- New `deduplicateByLemma` helper in `gnt-parse.ts`
- `skipRepeatedLemmas: boolean` added to `GNTPassageSettings` (default `false`, backwards-compatible load)
- Deduplication applied before sampling and verb-count preview in `GNTParseChallengeInner`
- "Skip repeat verbs" checkbox in `PassageSelector`
- 8 new unit tests

closes #99