### PR TITLE
feat(parse): add Review Missed mode to GNT parsing challenge

### DIFF
--- a/src/components/GNTParseChallenge.tsx
+++ b/src/components/GNTParseChallenge.tsx
@@ -12,6 +12,7 @@ import {
   deduplicateByLemma,
   emptyGNTAnswer,
   extractVerbs,
+  filterMissedItems,
   formatRangeRef,
   GNT_CASE_LABELS,
   GNT_GENDER_LABELS,
@@ -47,6 +48,7 @@ function GNTParseChallengeInner() {
   const [results, setResults] = useState<GNTParseResult[]>([]);
   const [currentResult, setCurrentResult] = useState<GNTParseResult | null>(null);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [isReview, setIsReview] = useState(false);
 
   // Load settings on mount
   useEffect(() => {
@@ -112,6 +114,19 @@ function GNTParseChallengeInner() {
     setResults([]);
     setAnswer(emptyGNTAnswer());
     setCurrentResult(null);
+    setIsReview(false);
+    setPhase('question');
+  }
+
+  function handleReviewMissed() {
+    const missed = filterMissedItems(session, results);
+    if (missed.length === 0) return;
+    setSession(missed);
+    setCurrentIndex(0);
+    setResults([]);
+    setAnswer(emptyGNTAnswer());
+    setCurrentResult(null);
+    setIsReview(true);
     setPhase('question');
   }
 
@@ -216,7 +231,10 @@ function GNTParseChallengeInner() {
           setSession([]);
           setResults([]);
           setCurrentIndex(0);
+          setIsReview(false);
         }}
+        onReviewMissed={handleReviewMissed}
+        isReview={isReview}
       />
     );
   }

--- a/src/components/ParseResults.test.tsx
+++ b/src/components/ParseResults.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Tests for src/components/ParseResults.tsx
+ *
+ * Covers: score display, property breakdown, action buttons,
+ * "Review Missed" button visibility, and isReview label.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import ParseResults, { type SessionResults } from './ParseResults';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeResult(allCorrect: boolean) {
+  return {
+    tense: allCorrect,
+    voice: allCorrect,
+    mood: allCorrect,
+    person: allCorrect,
+    number: allCorrect,
+    allCorrect,
+  };
+}
+
+function makeSession(corrects: boolean[]): SessionResults {
+  return {
+    results: corrects.map(makeResult),
+    total: corrects.length,
+  };
+}
+
+const noop = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Score display
+// ---------------------------------------------------------------------------
+
+describe('ParseResults — score display', () => {
+  it('shows correct count and percentage', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([true, true, false])}
+        onRetry={noop}
+        onChangeSettings={noop}
+      />,
+    );
+    // getByText can match multiple nodes (hero + property rows); check for the percentage text
+    expect(screen.getByText('67% correct')).toBeInTheDocument();
+  });
+
+  it('shows 100% when all correct', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([true, true])}
+        onRetry={noop}
+        onChangeSettings={noop}
+      />,
+    );
+    expect(screen.getByText('100% correct')).toBeInTheDocument();
+  });
+
+  it('shows 0% when all wrong', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([false, false])}
+        onRetry={noop}
+        onChangeSettings={noop}
+      />,
+    );
+    expect(screen.getByText('0% correct')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isReview label
+// ---------------------------------------------------------------------------
+
+describe('ParseResults — isReview label', () => {
+  it('shows "Session Score" label by default', () => {
+    render(
+      <ParseResults sessionResults={makeSession([true])} onRetry={noop} onChangeSettings={noop} />,
+    );
+    expect(screen.getByText('Session Score')).toBeInTheDocument();
+  });
+
+  it('shows review label with item count when isReview=true', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([false, false, false])}
+        onRetry={noop}
+        onChangeSettings={noop}
+        isReview
+      />,
+    );
+    expect(screen.getByText('Review: Missed Verbs (3)')).toBeInTheDocument();
+    expect(screen.queryByText('Session Score')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action buttons — Try Again / Change Settings
+// ---------------------------------------------------------------------------
+
+describe('ParseResults — action buttons', () => {
+  it('calls onRetry when "Try Again" is clicked', async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(
+      <ParseResults
+        sessionResults={makeSession([true])}
+        onRetry={onRetry}
+        onChangeSettings={noop}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('calls onChangeSettings when "Change Settings" is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangeSettings = vi.fn();
+    render(
+      <ParseResults
+        sessionResults={makeSession([true])}
+        onRetry={noop}
+        onChangeSettings={onChangeSettings}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /change settings/i }));
+    expect(onChangeSettings).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review Missed button
+// ---------------------------------------------------------------------------
+
+describe('ParseResults — Review Missed button', () => {
+  it('is not rendered when onReviewMissed is not provided', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([false, false])}
+        onRetry={noop}
+        onChangeSettings={noop}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /review missed/i })).not.toBeInTheDocument();
+  });
+
+  it('is not rendered when all results are correct (no misses)', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([true, true])}
+        onRetry={noop}
+        onChangeSettings={noop}
+        onReviewMissed={noop}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /review missed/i })).not.toBeInTheDocument();
+  });
+
+  it('is rendered when onReviewMissed provided and there are misses', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([true, false])}
+        onRetry={noop}
+        onChangeSettings={noop}
+        onReviewMissed={noop}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /review missed \(1\)/i })).toBeInTheDocument();
+  });
+
+  it('shows the correct missed count in the button label', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([false, true, false, false])}
+        onRetry={noop}
+        onChangeSettings={noop}
+        onReviewMissed={noop}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /review missed \(3\)/i })).toBeInTheDocument();
+  });
+
+  it('calls onReviewMissed when clicked', async () => {
+    const user = userEvent.setup();
+    const onReviewMissed = vi.fn();
+    render(
+      <ParseResults
+        sessionResults={makeSession([true, false])}
+        onRetry={noop}
+        onChangeSettings={noop}
+        onReviewMissed={onReviewMissed}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /review missed/i }));
+    expect(onReviewMissed).toHaveBeenCalledOnce();
+  });
+
+  it('remains visible after a review session if there are still misses', () => {
+    render(
+      <ParseResults
+        sessionResults={makeSession([false])}
+        onRetry={noop}
+        onChangeSettings={noop}
+        onReviewMissed={noop}
+        isReview
+      />,
+    );
+    expect(screen.getByRole('button', { name: /review missed \(1\)/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/ParseResults.tsx
+++ b/src/components/ParseResults.tsx
@@ -9,6 +9,8 @@ interface Props {
   sessionResults: SessionResults;
   onRetry: () => void;
   onChangeSettings: () => void;
+  onReviewMissed?: () => void;
+  isReview?: boolean;
 }
 
 type PropertyKey = 'tense' | 'voice' | 'mood' | 'person' | 'number';
@@ -21,16 +23,25 @@ const PROPERTIES: { key: PropertyKey; label: string }[] = [
   { key: 'number', label: 'Number' },
 ];
 
-export default function ParseResults({ sessionResults, onRetry, onChangeSettings }: Props) {
+export default function ParseResults({
+  sessionResults,
+  onRetry,
+  onChangeSettings,
+  onReviewMissed,
+  isReview = false,
+}: Props) {
   const { results, total } = sessionResults;
   const correct = results.filter((r) => r.allCorrect).length;
+  const missed = total - correct;
   const pct = total > 0 ? Math.round((correct / total) * 100) : 0;
 
   return (
     <div className="max-w-lg mx-auto space-y-8">
       {/* ── Score hero ──────────────────────────────────────────────────── */}
       <div className="text-center py-8 bg-bg-card rounded-2xl">
-        <p className="text-xs uppercase tracking-widest text-text-muted mb-2">Session Score</p>
+        <p className="text-xs uppercase tracking-widest text-text-muted mb-2">
+          {isReview ? `Review: Missed Verbs (${total})` : 'Session Score'}
+        </p>
         <p className="text-6xl font-extrabold mb-1" style={{ color: scoreColor(pct) }}>
           {correct}/{total}
         </p>
@@ -82,6 +93,14 @@ export default function ParseResults({ sessionResults, onRetry, onChangeSettings
           Change Settings
         </button>
       </div>
+      {onReviewMissed && missed > 0 && (
+        <button
+          onClick={onReviewMissed}
+          className="w-full py-3 rounded-xl text-base font-bold border-2 border-red-500 text-red-600 hover:bg-red-50 transition-colors"
+        >
+          Review Missed ({missed})
+        </button>
+      )}
     </div>
   );
 }

--- a/src/lib/gnt-parse.test.ts
+++ b/src/lib/gnt-parse.test.ts
@@ -11,9 +11,11 @@ import {
   deduplicateByLemma,
   emptyGNTAnswer,
   extractVerbs,
+  filterMissedItems,
   formatRangeRef,
   type GNTParseAnswer,
   type GNTParseItem,
+  type GNTParseResult,
   gradeGNTAnswer,
   loadGNTSettings,
   sampleVerbs,
@@ -497,5 +499,55 @@ describe('deduplicateByLemma', () => {
     const deduped = deduplicateByLemma(items);
     expect(deduped).toHaveLength(2);
     expect(deduped.map((i) => i.lemma)).toEqual(['λύω', 'βοάω']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterMissedItems
+// ---------------------------------------------------------------------------
+
+function makeResult(allCorrect: boolean): GNTParseResult {
+  return {
+    tense: allCorrect,
+    voice: allCorrect,
+    mood: allCorrect,
+    person: allCorrect,
+    number: allCorrect,
+    parseCase: null,
+    gender: null,
+    allCorrect,
+  };
+}
+
+describe('filterMissedItems', () => {
+  const items = ['a', 'b', 'c', 'd'];
+
+  it('returns empty array when all results are correct', () => {
+    const results = items.map(() => makeResult(true));
+    expect(filterMissedItems(items, results)).toEqual([]);
+  });
+
+  it('returns all items when all results are wrong', () => {
+    const results = items.map(() => makeResult(false));
+    expect(filterMissedItems(items, results)).toEqual(items);
+  });
+
+  it('returns only the items whose result has allCorrect=false', () => {
+    const results = [makeResult(true), makeResult(false), makeResult(true), makeResult(false)];
+    expect(filterMissedItems(items, results)).toEqual(['b', 'd']);
+  });
+
+  it('preserves original order of missed items', () => {
+    const results = [makeResult(false), makeResult(true), makeResult(false)];
+    expect(filterMissedItems(['x', 'y', 'z'], results)).toEqual(['x', 'z']);
+  });
+
+  it('returns empty array when results array is empty', () => {
+    expect(filterMissedItems(items, [])).toEqual([]);
+  });
+
+  it('handles results shorter than items (partial session)', () => {
+    const results = [makeResult(false), makeResult(true)];
+    expect(filterMissedItems(items, results)).toEqual(['a']);
   });
 });

--- a/src/lib/gnt-parse.ts
+++ b/src/lib/gnt-parse.ts
@@ -222,6 +222,15 @@ export function gradeGNTAnswer(item: GNTParseItem, answer: GNTParseAnswer): GNTP
 }
 
 // ---------------------------------------------------------------------------
+// Review helpers
+// ---------------------------------------------------------------------------
+
+/** Returns the subset of items whose corresponding result was not fully correct. */
+export function filterMissedItems<T>(items: T[], results: GNTParseResult[]): T[] {
+  return items.filter((_, i) => i < results.length && !results[i].allCorrect);
+}
+
+// ---------------------------------------------------------------------------
 // Parse code → typed values
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds a **Review Missed** button to the results screen, visible only when at least one verb was answered incorrectly
- Clicking it starts a focused sub-session with just the missed verbs, using the same question → feedback → results flow
- Results screen labels review sessions as "Review: Missed Verbs (N)" so users know they're in review mode
- The button re-appears if verbs are still missed after a review pass, enabling chained drilling

## Test plan

- [ ] New `ParseResults.test.tsx` covers button visibility (with/without `onReviewMissed`, all correct, some missed), label switching (`isReview`), click callbacks, and persistent review button in chained sessions
- [ ] New `filterMissedItems` cases in `gnt-parse.test.ts` cover all correct, all wrong, partial, empty, and order-preserving behavior
- [ ] 644 tests pass (`pnpm test:run`)
- [ ] No regressions in existing challenge flow — "Try Again" and "Change Settings" remain available

closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)