### PR TITLE
feat(parse): show word definition in verb parse quiz feedback

### DIFF
--- a/src/components/GreekText.tsx
+++ b/src/components/GreekText.tsx
@@ -5,26 +5,9 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { formatParse, type MorphWord, splitWordPunct } from '../data/morphgnt';
-import { vocabulary } from '../data/vocabulary';
+import { buildVocabLookup, type VocabEntry, vocabLookup } from '../lib/vocab-lookup';
 
-// ─── Vocabulary lookup ────────────────────────────────────────────────────────
-
-export interface VocabEntry {
-  gloss: string;
-  frequency: number;
-}
-
-export function buildVocabLookup(): Map<string, VocabEntry> {
-  const map = new Map<string, VocabEntry>();
-  for (const w of vocabulary) {
-    for (const form of w.greek.split(', ')) {
-      map.set(form.trim(), { gloss: w.gloss, frequency: w.frequency });
-    }
-  }
-  return map;
-}
-
-export const vocabLookup = buildVocabLookup();
+export { buildVocabLookup, type VocabEntry, vocabLookup };
 
 // ─── WordPopup ────────────────────────────────────────────────────────────────
 

--- a/src/components/ParseFeedback.test.tsx
+++ b/src/components/ParseFeedback.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Tests for src/components/ParseFeedback.tsx
+ *
+ * Covers: definition row visibility, lemma/gloss/frequency rendering,
+ * graceful omission when no vocab entry exists, and feedback rows.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { ParseAnswer, ParseItem, ParseResult } from '../lib/verb-parse';
+import ParseFeedback from './ParseFeedback';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeItem(overrides: Partial<ParseItem> = {}): ParseItem {
+  return {
+    form: 'λύω',
+    tense: 'present',
+    voice: 'active',
+    mood: 'indicative',
+    person: '1st',
+    number: 'singular',
+    paradigmLabel: 'Present Active Indicative — λύω',
+    lemma: 'λύω',
+    ...overrides,
+  };
+}
+
+const correctAnswer: ParseAnswer = {
+  tense: 'present',
+  voice: 'active',
+  mood: 'indicative',
+  person: '1st',
+  number: 'singular',
+};
+
+const correctResult: ParseResult = {
+  tense: true,
+  voice: true,
+  mood: true,
+  person: true,
+  number: true,
+  allCorrect: true,
+};
+
+const wrongResult: ParseResult = {
+  tense: false,
+  voice: true,
+  mood: true,
+  person: true,
+  number: true,
+  allCorrect: false,
+};
+
+// ---------------------------------------------------------------------------
+// Definition row — lemma found in vocabulary
+// ---------------------------------------------------------------------------
+
+describe('ParseFeedback — definition row', () => {
+  it('shows the lemma when vocabulary entry exists', () => {
+    render(
+      <ParseFeedback
+        item={makeItem()}
+        answer={correctAnswer}
+        result={correctResult}
+        onNext={vi.fn()}
+        isLast={false}
+      />,
+    );
+    // λύω is the form displayed at the top AND the lemma in the definition row;
+    // we check for it being present at all
+    expect(screen.getAllByText('λύω').length).toBeGreaterThan(0);
+  });
+
+  it('shows a gloss when vocabulary entry exists', () => {
+    render(
+      <ParseFeedback
+        item={makeItem()}
+        answer={correctAnswer}
+        result={correctResult}
+        onNext={vi.fn()}
+        isLast={false}
+      />,
+    );
+    // λύω should have a gloss — we just verify some gloss text appears
+    // (avoid hard-coding the exact string in case vocab data changes)
+    const glossEl = screen.getByText(/loose|release|set free/i);
+    expect(glossEl).toBeInTheDocument();
+  });
+
+  it('shows frequency with × suffix', () => {
+    render(
+      <ParseFeedback
+        item={makeItem()}
+        answer={correctAnswer}
+        result={correctResult}
+        onNext={vi.fn()}
+        isLast={false}
+      />,
+    );
+    expect(screen.getByText(/×/)).toBeInTheDocument();
+  });
+
+  it('shows definition for both correct and incorrect answers', () => {
+    const { rerender } = render(
+      <ParseFeedback
+        item={makeItem()}
+        answer={correctAnswer}
+        result={correctResult}
+        onNext={vi.fn()}
+        isLast={false}
+      />,
+    );
+    expect(screen.getByText(/×/)).toBeInTheDocument();
+
+    rerender(
+      <ParseFeedback
+        item={makeItem()}
+        answer={{ ...correctAnswer, tense: 'aorist' }}
+        result={wrongResult}
+        onNext={vi.fn()}
+        isLast={false}
+      />,
+    );
+    expect(screen.getByText(/×/)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Definition row — lemma NOT found in vocabulary
+// ---------------------------------------------------------------------------
+
+describe('ParseFeedback — missing vocab entry', () => {
+  it('omits the definition row when lemma is not in vocabulary', () => {
+    render(
+      <ParseFeedback
+        item={makeItem({ lemma: 'zzz-not-a-real-lemma' })}
+        answer={correctAnswer}
+        result={correctResult}
+        onNext={vi.fn()}
+        isLast={false}
+      />,
+    );
+    expect(screen.queryByText(/×/)).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Next button
+// ---------------------------------------------------------------------------
+
+describe('ParseFeedback — next button', () => {
+  it('calls onNext when the button is clicked', async () => {
+    const user = userEvent.setup();
+    const onNext = vi.fn();
+    render(
+      <ParseFeedback
+        item={makeItem()}
+        answer={correctAnswer}
+        result={correctResult}
+        onNext={onNext}
+        isLast={false}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /next form/i }));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it('shows "See Results" when isLast=true', () => {
+    render(
+      <ParseFeedback
+        item={makeItem()}
+        answer={correctAnswer}
+        result={correctResult}
+        onNext={vi.fn()}
+        isLast={true}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /see results/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/ParseFeedback.tsx
+++ b/src/components/ParseFeedback.tsx
@@ -6,6 +6,7 @@ import {
   TENSE_LABELS,
   VOICE_LABELS,
 } from '../lib/verb-parse';
+import { vocabLookup } from '../lib/vocab-lookup';
 
 interface Props {
   item: ParseItem;
@@ -16,6 +17,8 @@ interface Props {
 }
 
 export default function ParseFeedback({ item, answer, result, onNext, isLast }: Props) {
+  const vocab = vocabLookup.get(item.lemma);
+
   return (
     <div className="max-w-lg mx-auto space-y-6">
       {/* ── Form display ────────────────────────────────────────────────── */}
@@ -75,6 +78,22 @@ export default function ParseFeedback({ item, answer, result, onNext, isLast }: 
       >
         {result.allCorrect ? 'Correct!' : 'Not quite — review the corrections above.'}
       </div>
+
+      {/* ── Word definition ─────────────────────────────────────────────── */}
+      {vocab && (
+        <div className="flex items-baseline gap-2 px-4 py-2.5 rounded-lg bg-bg-card border border-gray-100 text-sm">
+          <span
+            className="font-semibold shrink-0"
+            style={{ fontFamily: 'var(--font-greek)', color: 'var(--color-primary)' }}
+          >
+            {item.lemma}
+          </span>
+          <span className="text-text">{vocab.gloss}</span>
+          <span className="text-text-muted ml-auto shrink-0">
+            {vocab.frequency.toLocaleString()}×
+          </span>
+        </div>
+      )}
 
       {/* ── Next button ─────────────────────────────────────────────────── */}
       <button

--- a/src/lib/verb-parse.test.ts
+++ b/src/lib/verb-parse.test.ts
@@ -9,6 +9,7 @@ import {
   buildSession,
   DEFAULT_PARSE_SETTINGS,
   emptyAnswer,
+  extractLemma,
   gradeAnswer,
   normalizeForm,
   PARSE_MOODS,
@@ -18,6 +19,28 @@ import {
   type ParseSettings,
   voicesForTense,
 } from './verb-parse';
+
+// ---------------------------------------------------------------------------
+// extractLemma
+// ---------------------------------------------------------------------------
+
+describe('extractLemma', () => {
+  it('extracts the lemma after an em dash', () => {
+    expect(extractLemma('Present Active Indicative — λύω')).toBe('λύω');
+  });
+
+  it('handles labels with multiple em dashes by taking the last segment', () => {
+    expect(extractLemma('Foo — Bar — βλέπω')).toBe('βλέπω');
+  });
+
+  it('trims whitespace around the lemma', () => {
+    expect(extractLemma('Aorist Active Indicative —  λύω ')).toBe('λύω');
+  });
+
+  it('returns the whole string when no em dash is present', () => {
+    expect(extractLemma('λύω')).toBe('λύω');
+  });
+});
 
 // ---------------------------------------------------------------------------
 // normalizeForm
@@ -55,6 +78,14 @@ describe('buildSession', () => {
       expect(['1st', '2nd', '3rd']).toContain(item.person);
       expect(['singular', 'plural']).toContain(item.number);
       expect(item.paradigmLabel).toContain('λύω');
+      expect(item.lemma).toBeTruthy();
+    }
+  });
+
+  it('populates lemma from paradigmLabel', () => {
+    const items = buildSession(DEFAULT_PARSE_SETTINGS, 20);
+    for (const item of items) {
+      expect(item.lemma).toBe(extractLemma(item.paradigmLabel));
     }
   });
 
@@ -143,6 +174,7 @@ describe('gradeAnswer', () => {
     person: '1st' as const,
     number: 'singular' as const,
     paradigmLabel: 'Present Active Indicative — λύω',
+    lemma: 'λύω',
   };
 
   it('returns allCorrect=true for a fully correct answer', () => {

--- a/src/lib/verb-parse.ts
+++ b/src/lib/verb-parse.ts
@@ -75,6 +75,8 @@ export interface ParseItem {
   number: ParseNumber;
   /** Display label for the source paradigm, e.g. "Present Active Indicative — λύω" */
   paradigmLabel: string;
+  /** Base verb lemma extracted from paradigmLabel, e.g. "λύω" */
+  lemma: string;
   /** Other valid parses when the same form appears in multiple paradigms. */
   ambiguous?: string[];
 }
@@ -140,6 +142,12 @@ const PERSON_MAP: Record<PersonNum, { person: ParsePerson; number: ParseNumber }
   '2pl': { person: '2nd', number: 'plural' },
   '3pl': { person: '3rd', number: 'plural' },
 };
+
+/** Extracts the lemma from a paradigm label, e.g. "Present Active Indicative — λύω" → "λύω" */
+export function extractLemma(paradigmLabel: string): string {
+  const parts = paradigmLabel.split(' — ');
+  return parts[parts.length - 1].trim();
+}
 
 function parseTenseFromId(id: string): ParseTense | null {
   for (const [seg, tense] of Object.entries(ID_TENSE)) {
@@ -207,6 +215,8 @@ export function buildSession(settings: ParseSettings, count: number): ParseItem[
 
     if (!settings.tenses.includes(tense) || !voiceMatch || !settings.moods.includes(mood)) continue;
 
+    const paradigmLabel = `${paradigm.label} — λύω`;
+    const lemma = extractLemma(paradigmLabel);
     for (const [personNum, form] of Object.entries(paradigm.forms) as [PersonNum, string][]) {
       const { person, number } = PERSON_MAP[personNum];
       allItems.push({
@@ -216,7 +226,8 @@ export function buildSession(settings: ParseSettings, count: number): ParseItem[
         mood,
         person,
         number,
-        paradigmLabel: `${paradigm.label} — λύω`,
+        paradigmLabel,
+        lemma,
       });
     }
   }

--- a/src/lib/vocab-lookup.test.ts
+++ b/src/lib/vocab-lookup.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildVocabLookup } from './vocab-lookup';
+
+describe('buildVocabLookup', () => {
+  it('returns a Map', () => {
+    const map = buildVocabLookup();
+    expect(map).toBeInstanceOf(Map);
+    expect(map.size).toBeGreaterThan(0);
+  });
+
+  it('looks up a single-form lemma', () => {
+    const map = buildVocabLookup();
+    const entry = map.get('λέγω');
+    expect(entry).toBeDefined();
+    expect(entry?.gloss).toBeTruthy();
+    expect(typeof entry?.frequency).toBe('number');
+    expect(entry!.frequency).toBeGreaterThan(0);
+  });
+
+  it('splits comma-separated forms and indexes each variant', () => {
+    const map = buildVocabLookup();
+    // 'οὐ, οὐκ, οὐχ' — each form should be in the map with the same gloss
+    const ou = map.get('οὐ');
+    const ouk = map.get('οὐκ');
+    const ouch = map.get('οὐχ');
+    expect(ou).toBeDefined();
+    expect(ouk).toBeDefined();
+    expect(ouch).toBeDefined();
+    expect(ou?.gloss).toBe(ouk?.gloss);
+    expect(ou?.frequency).toBe(ouk?.frequency);
+  });
+
+  it('returns undefined for an unknown lemma', () => {
+    const map = buildVocabLookup();
+    expect(map.get('zzz-not-a-greek-word')).toBeUndefined();
+  });
+});

--- a/src/lib/vocab-lookup.ts
+++ b/src/lib/vocab-lookup.ts
@@ -1,0 +1,18 @@
+import { vocabulary } from '../data/vocabulary';
+
+export interface VocabEntry {
+  gloss: string;
+  frequency: number;
+}
+
+export function buildVocabLookup(): Map<string, VocabEntry> {
+  const map = new Map<string, VocabEntry>();
+  for (const w of vocabulary) {
+    for (const form of w.greek.split(', ')) {
+      map.set(form.trim(), { gloss: w.gloss, frequency: w.frequency });
+    }
+  }
+  return map;
+}
+
+export const vocabLookup = buildVocabLookup();


### PR DESCRIPTION
## Summary

- Extracts `buildVocabLookup` into `src/lib/vocab-lookup.ts` so `GreekText` and `ParseFeedback` can share it without circular deps
- Adds `lemma` field to `ParseItem`, populated in `buildSession()` by splitting `paradigmLabel` on `" — "` (e.g. `"Present Active Indicative — λύω"` → `"λύω"`)
- Exports `extractLemma()` helper from `verb-parse.ts`
- Renders a compact definition row in `ParseFeedback` after the correctness grid — lemma in Greek font, English gloss, and GNT frequency dimmed; row is omitted when no vocab entry is found

## Test plan

- [ ] `src/lib/vocab-lookup.test.ts` — `buildVocabLookup` builds correctly, handles multi-form entries, returns undefined for unknown lemmas
- [ ] `src/lib/verb-parse.test.ts` — `extractLemma` parses labels correctly; `buildSession` items carry a non-empty `lemma` matching `extractLemma(paradigmLabel)`
- [ ] `src/components/ParseFeedback.test.tsx` — definition row appears for known lemmas (both correct and incorrect answers), is omitted for unknown lemmas, next button and "See Results" behavior unchanged
- [ ] All 668 existing tests still pass

closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)