### PR TITLE
feat(flashcards): add Deck from GNT Book

### DIFF
--- a/src/components/DeckBuilder.test.tsx
+++ b/src/components/DeckBuilder.test.tsx
@@ -2,7 +2,7 @@
  * Tests for src/components/DeckBuilder.tsx
  */
 
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CustomDeck } from '../data/customDecks';
@@ -10,10 +10,32 @@ import DeckBuilder from './DeckBuilder';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
+vi.mock('../data/morphgnt', () => ({
+  fetchBooks: vi.fn(),
+  fetchBook: vi.fn(),
+}));
+
+vi.mock('../lib/book-deck', () => ({
+  getBookWordKeys: vi.fn(),
+}));
+
+import { fetchBooks } from '../data/morphgnt';
+import { getBookWordKeys } from '../lib/book-deck';
+
+const mockFetchBooks = vi.mocked(fetchBooks);
+const mockGetBookWordKeys = vi.mocked(getBookWordKeys);
+
+const STUB_BOOKS = [
+  { code: 'PHM', name: 'Philemon', chapters: 1 },
+  { code: 'JHN', name: 'John', chapters: 21 },
+];
+
 beforeEach(() => {
   localStorage.clear();
   vi.clearAllMocks();
   vi.restoreAllMocks();
+  mockFetchBooks.mockResolvedValue(STUB_BOOKS);
+  mockGetBookWordKeys.mockResolvedValue(['καί', 'ὁ', 'λόγος']);
 });
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -484,5 +506,173 @@ describe('Word picker', () => {
       );
     });
     expect(screen.getByText(/no words match/i)).toBeInTheDocument();
+  });
+});
+
+// ─── From GNT Book flow ───────────────────────────────────────────────────────
+
+describe('From GNT Book', () => {
+  it('renders the "+ From GNT Book" button in list view', () => {
+    renderBuilder();
+    expect(screen.getByRole('button', { name: /\+ from gnt book/i })).toBeInTheDocument();
+  });
+
+  it('transitions to from-book view and shows book selector', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: /select gnt book/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Philemon')).toBeInTheDocument();
+    expect(screen.getByText('John')).toBeInTheDocument();
+  });
+
+  it('shows "Deck from GNT Book" heading in from-book view', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() => expect(screen.getByText(/deck from gnt book/i)).toBeInTheDocument());
+  });
+
+  it('populates the name field when a book is selected', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: /select gnt book/i })).toBeInTheDocument(),
+    );
+    await act(async () => {
+      await user.selectOptions(screen.getByRole('combobox', { name: /select gnt book/i }), 'PHM');
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: /deck name/i })).toHaveValue('Philemon'),
+    );
+  });
+
+  it('shows word count after selecting a book', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: /select gnt book/i })).toBeInTheDocument(),
+    );
+    await act(async () => {
+      await user.selectOptions(screen.getByRole('combobox', { name: /select gnt book/i }), 'PHM');
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('3 unique vocabulary words'),
+    );
+  });
+
+  it('creates a deck and returns to list view', async () => {
+    const user = userEvent.setup();
+    const onDecksChange = vi.fn();
+    renderBuilder({ onDecksChange });
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: /select gnt book/i })).toBeInTheDocument(),
+    );
+    await act(async () => {
+      await user.selectOptions(screen.getByRole('combobox', { name: /select gnt book/i }), 'PHM');
+    });
+    await waitFor(() => screen.getByRole('status'));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /create deck/i })).not.toBeDisabled(),
+    );
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /create deck/i }));
+    });
+
+    expect(onDecksChange).toHaveBeenCalled();
+    const updatedDecks = onDecksChange.mock.calls[0][0] as CustomDeck[];
+    expect(updatedDecks.some((d) => d.name === 'Philemon')).toBe(true);
+    expect(screen.getByRole('button', { name: /\+ new deck/i })).toBeInTheDocument();
+  });
+
+  it('shows error when creating deck with duplicate name', async () => {
+    const user = userEvent.setup();
+    const existingDeck: CustomDeck = {
+      id: 'x',
+      name: 'Philemon',
+      wordKeys: ['καί'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    renderBuilder({ decks: [existingDeck] });
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: /select gnt book/i })).toBeInTheDocument(),
+    );
+    await act(async () => {
+      await user.selectOptions(screen.getByRole('combobox', { name: /select gnt book/i }), 'PHM');
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /create deck/i })).not.toBeDisabled(),
+    );
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /create deck/i }));
+    });
+
+    expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+  });
+
+  it('Cancel button returns to list view without creating a deck', async () => {
+    const user = userEvent.setup();
+    const onDecksChange = vi.fn();
+    renderBuilder({ onDecksChange });
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() => expect(screen.getByText(/deck from gnt book/i)).toBeInTheDocument());
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+    });
+
+    expect(onDecksChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /\+ new deck/i })).toBeInTheDocument();
+  });
+
+  it('Create Deck button is disabled until a book is selected and loaded', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: /select gnt book/i })).toBeInTheDocument(),
+    );
+
+    expect(screen.getByRole('button', { name: /create deck/i })).toBeDisabled();
+  });
+
+  it('Back button returns to list view', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /\+ from gnt book/i }));
+    });
+    await waitFor(() => expect(screen.getByText(/deck from gnt book/i)).toBeInTheDocument());
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /back to deck list/i }));
+    });
+
+    expect(screen.getByRole('button', { name: /\+ new deck/i })).toBeInTheDocument();
   });
 });

--- a/src/components/DeckBuilder.tsx
+++ b/src/components/DeckBuilder.tsx
@@ -6,12 +6,14 @@ import {
   loadCustomDecks,
   updateCustomDeck,
 } from '../data/customDecks';
+import { type BookMeta, fetchBooks } from '../data/morphgnt';
 import { normalizeKey } from '../data/srs';
 import { vocabulary } from '../data/vocabulary';
+import { getBookWordKeys } from '../lib/book-deck';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type DeckBuilderView = 'list' | 'edit';
+type DeckBuilderView = 'list' | 'edit' | 'from-book';
 
 interface DeckBuilderProps {
   decks: CustomDeck[];
@@ -37,6 +39,16 @@ export default function DeckBuilder({
   const [wordSearch, setWordSearch] = useState('');
   const [nameError, setNameError] = useState('');
   const [saveError, setSaveError] = useState('');
+
+  // From-book state
+  const [availableBooks, setAvailableBooks] = useState<BookMeta[]>([]);
+  const [booksLoading, setBooksLoading] = useState(false);
+  const [fromBookCode, setFromBookCode] = useState('');
+  const [fromBookName, setFromBookName] = useState('');
+  const [fromBookWordKeys, setFromBookWordKeys] = useState<string[]>([]);
+  const [fromBookLoading, setFromBookLoading] = useState(false);
+  const [fromBookError, setFromBookError] = useState('');
+  const [fromBookNameError, setFromBookNameError] = useState('');
 
   // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -64,6 +76,70 @@ export default function DeckBuilder({
     setView('list');
     setNameError('');
     setSaveError('');
+  }
+
+  async function openFromBook() {
+    setFromBookCode('');
+    setFromBookName('');
+    setFromBookWordKeys([]);
+    setFromBookError('');
+    setFromBookNameError('');
+    setView('from-book');
+
+    if (availableBooks.length === 0) {
+      setBooksLoading(true);
+      try {
+        const books = await fetchBooks();
+        setAvailableBooks(books);
+      } catch {
+        setFromBookError('Could not load book list. Try again.');
+      } finally {
+        setBooksLoading(false);
+      }
+    }
+  }
+
+  async function handleBookSelect(code: string) {
+    const meta = availableBooks.find((b) => b.code === code);
+    if (!meta) return;
+
+    setFromBookCode(code);
+    setFromBookName(meta.name);
+    setFromBookWordKeys([]);
+    setFromBookError('');
+    setFromBookLoading(true);
+
+    try {
+      const keys = await getBookWordKeys(code);
+      setFromBookWordKeys(keys);
+    } catch {
+      setFromBookError('Could not load book data. Try again.');
+    } finally {
+      setFromBookLoading(false);
+    }
+  }
+
+  function handleFromBookCreate() {
+    const trimmed = fromBookName.trim();
+
+    if (!trimmed) {
+      setFromBookNameError('Deck name is required.');
+      return;
+    }
+    if (trimmed.length > 60) {
+      setFromBookNameError('Name must be 60 characters or fewer.');
+      return;
+    }
+    const duplicate = decks.find((d) => d.name.trim().toLowerCase() === trimmed.toLowerCase());
+    if (duplicate) {
+      setFromBookNameError('A deck with that name already exists.');
+      return;
+    }
+    setFromBookNameError('');
+
+    createCustomDeck(trimmed, fromBookWordKeys.sort());
+    onDecksChange(loadCustomDecks());
+    setView('list');
   }
 
   function handleDelete(deck: CustomDeck) {
@@ -212,12 +288,146 @@ export default function DeckBuilder({
           </ul>
         )}
 
-        <button
-          onClick={openNew}
-          className="w-full py-2.5 border-2 border-dashed border-indigo-200 text-text-muted rounded-xl text-sm font-medium hover:border-grape/40 hover:text-text transition-colors"
-        >
-          + New Deck
-        </button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={openNew}
+            className="flex-1 py-2.5 border-2 border-dashed border-indigo-200 text-text-muted rounded-xl text-sm font-medium hover:border-grape/40 hover:text-text transition-colors"
+          >
+            + New Deck
+          </button>
+          <button
+            type="button"
+            onClick={openFromBook}
+            className="flex-1 py-2.5 border-2 border-dashed border-indigo-200 text-text-muted rounded-xl text-sm font-medium hover:border-grape/40 hover:text-text transition-colors"
+          >
+            + From GNT Book
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── From-book view ──────────────────────────────────────────────────────────
+
+  if (view === 'from-book') {
+    return (
+      <div className="bg-bg-card rounded-2xl border-2 border-indigo-100 p-4 space-y-4 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-bold text-text uppercase tracking-wider">
+            Deck from GNT Book
+          </h3>
+          <button
+            type="button"
+            onClick={() => setView('list')}
+            aria-label="Back to deck list"
+            className="text-sm text-text-muted hover:text-text transition-colors font-medium"
+          >
+            ← Back
+          </button>
+        </div>
+
+        {booksLoading ? (
+          <p className="text-sm text-text-muted text-center py-4">Loading books…</p>
+        ) : (
+          <>
+            <div>
+              <label
+                htmlFor="from-book-select"
+                className="text-xs font-bold text-text-muted uppercase tracking-wider block mb-1.5"
+              >
+                Book
+              </label>
+              <select
+                id="from-book-select"
+                value={fromBookCode}
+                onChange={(e) => handleBookSelect(e.target.value)}
+                className="w-full px-3 py-2 border-2 border-indigo-100 rounded-xl text-sm focus:border-grape focus:outline-none bg-white"
+                aria-label="Select GNT book"
+              >
+                <option value="">— Select a book —</option>
+                {availableBooks.map((b) => (
+                  <option key={b.code} value={b.code}>
+                    {b.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {fromBookCode && (
+              <div>
+                <label
+                  htmlFor="from-book-name"
+                  className="text-xs font-bold text-text-muted uppercase tracking-wider block mb-1.5"
+                >
+                  Deck Name
+                </label>
+                <input
+                  id="from-book-name"
+                  type="text"
+                  value={fromBookName}
+                  onChange={(e) => {
+                    setFromBookName(e.target.value);
+                    setFromBookNameError('');
+                  }}
+                  maxLength={60}
+                  className={`w-full px-3 py-2 border-2 rounded-xl text-sm focus:outline-none transition-colors ${
+                    fromBookNameError
+                      ? 'border-coral focus:border-coral'
+                      : 'border-indigo-100 focus:border-grape'
+                  }`}
+                  autoComplete="off"
+                />
+                <div className="flex justify-between mt-1">
+                  {fromBookNameError ? (
+                    <p className="text-xs text-coral">{fromBookNameError}</p>
+                  ) : (
+                    <span />
+                  )}
+                  <span className="text-xs text-text-muted ml-auto">{fromBookName.length}/60</span>
+                </div>
+              </div>
+            )}
+
+            {fromBookCode && (
+              <div className="text-sm" role="status" aria-live="polite">
+                {fromBookLoading ? (
+                  <span className="text-text-muted">Loading words…</span>
+                ) : fromBookError ? (
+                  <span className="text-coral">{fromBookError}</span>
+                ) : fromBookWordKeys.length > 0 ? (
+                  <span className="text-text-muted">
+                    <strong className="text-text">{fromBookWordKeys.length}</strong> unique
+                    vocabulary word{fromBookWordKeys.length !== 1 ? 's' : ''} in{' '}
+                    {availableBooks.find((b) => b.code === fromBookCode)?.name}
+                  </span>
+                ) : null}
+              </div>
+            )}
+
+            {fromBookError && !fromBookCode && (
+              <p className="text-xs text-coral">{fromBookError}</p>
+            )}
+          </>
+        )}
+
+        <div className="flex gap-3 pt-1">
+          <button
+            type="button"
+            onClick={handleFromBookCreate}
+            disabled={!fromBookCode || fromBookLoading || fromBookWordKeys.length === 0}
+            className="flex-1 py-2.5 bg-grape text-white rounded-xl text-sm font-semibold hover:opacity-90 transition-opacity shadow-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Create Deck
+          </button>
+          <button
+            type="button"
+            onClick={() => setView('list')}
+            className="px-4 py-2.5 border-2 border-gray-200 text-text-muted rounded-xl text-sm font-medium hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/lib/book-deck.test.ts
+++ b/src/lib/book-deck.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../data/morphgnt', () => ({ fetchBook: vi.fn() }));
+
+vi.mock('../data/vocabulary', () => ({
+  vocabulary: [
+    { greek: 'ὁ, ἡ, τό', gloss: 'the', frequency: 19769, partOfSpeech: 'article' },
+    { greek: 'καί', gloss: 'and, even, also', frequency: 8973, partOfSpeech: 'conjunction' },
+    { greek: 'λόγος', gloss: 'word, message', frequency: 330, partOfSpeech: 'noun' },
+  ],
+}));
+
+import { fetchBook } from '../data/morphgnt';
+import { getBookWordKeys } from './book-deck';
+
+const mockFetchBook = vi.mocked(fetchBook);
+
+function word(lemma: string) {
+  return { text: lemma, lemma, pos: 'N-', parsing: '--------' };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getBookWordKeys', () => {
+  it('returns unique vocab keys found in the book', async () => {
+    mockFetchBook.mockResolvedValue({
+      '1': {
+        '1': [word('ὁ'), word('καί')],
+        '2': [word('λόγος')],
+      },
+    });
+
+    const keys = await getBookWordKeys('JHN');
+    expect(keys).toHaveLength(3);
+    expect(keys).toContain('ὁ');
+    expect(keys).toContain('καί');
+    expect(keys).toContain('λόγος');
+  });
+
+  it('deduplicates repeated lemmas across verses', async () => {
+    mockFetchBook.mockResolvedValue({
+      '1': {
+        '1': [word('ὁ'), word('ὁ'), word('καί')],
+        '2': [word('ὁ')],
+      },
+    });
+
+    const keys = await getBookWordKeys('MAT');
+    expect(keys.filter((k) => k === 'ὁ')).toHaveLength(1);
+  });
+
+  it('deduplicates repeated lemmas across chapters', async () => {
+    mockFetchBook.mockResolvedValue({
+      '1': { '1': [word('καί')] },
+      '2': { '1': [word('καί')] },
+      '3': { '1': [word('καί')] },
+    });
+
+    const keys = await getBookWordKeys('MAT');
+    expect(keys).toHaveLength(1);
+    expect(keys).toContain('καί');
+  });
+
+  it('skips lemmas not in the vocabulary', async () => {
+    mockFetchBook.mockResolvedValue({
+      '1': {
+        '1': [word('Παῦλος'), word('καί')],
+      },
+    });
+
+    const keys = await getBookWordKeys('PHM');
+    expect(keys).toHaveLength(1);
+    expect(keys).toContain('καί');
+    expect(keys).not.toContain('Παῦλος');
+  });
+
+  it('returns an empty array for a book with no vocabulary matches', async () => {
+    mockFetchBook.mockResolvedValue({
+      '1': { '1': [word('Παῦλος'), word('Φιλήμων')] },
+    });
+
+    const keys = await getBookWordKeys('PHM');
+    expect(keys).toHaveLength(0);
+  });
+
+  it('returns an empty array for an empty book', async () => {
+    mockFetchBook.mockResolvedValue({});
+
+    const keys = await getBookWordKeys('PHM');
+    expect(keys).toHaveLength(0);
+  });
+
+  it('collects lemmas across many chapters and verses', async () => {
+    mockFetchBook.mockResolvedValue({
+      '1': { '1': [word('ὁ')] },
+      '2': { '5': [word('καί')] },
+      '3': { '10': [word('λόγος')] },
+    });
+
+    const keys = await getBookWordKeys('JHN');
+    expect(keys).toHaveLength(3);
+    expect(keys).toContain('ὁ');
+    expect(keys).toContain('καί');
+    expect(keys).toContain('λόγος');
+  });
+
+  it('propagates errors from fetchBook', async () => {
+    mockFetchBook.mockRejectedValue(new Error('HTTP 404'));
+
+    await expect(getBookWordKeys('PHM')).rejects.toThrow('HTTP 404');
+  });
+});

--- a/src/lib/book-deck.ts
+++ b/src/lib/book-deck.ts
@@ -1,0 +1,30 @@
+import { fetchBook } from '../data/morphgnt';
+import { normalizeKey } from '../data/srs';
+import { vocabulary } from '../data/vocabulary';
+
+// Build a Set of valid vocab keys for fast membership testing.
+// MorphGNT lemmas are already in normalized form (e.g. 'ὁ' not 'ὁ, ἡ, τό'),
+// so normalizeKey(w.greek) produces the key that matches the raw lemma.
+const vocabKeySet: Set<string> = new Set(vocabulary.map((w) => normalizeKey(w.greek)));
+
+/**
+ * Returns the unique vocabulary word keys for all words in a GNT book.
+ * Keys are normalized lemmas that exist in src/data/vocabulary.ts.
+ * MorphGNT lemmas with no vocabulary entry are silently skipped.
+ */
+export async function getBookWordKeys(bookCode: string): Promise<string[]> {
+  const book = await fetchBook(bookCode);
+  const seen = new Set<string>();
+
+  for (const chapter of Object.values(book)) {
+    for (const verse of Object.values(chapter)) {
+      for (const word of verse) {
+        if (vocabKeySet.has(word.lemma)) {
+          seen.add(word.lemma);
+        }
+      }
+    }
+  }
+
+  return Array.from(seen);
+}


### PR DESCRIPTION
## Summary

- Adds a **+ From GNT Book** button to the DeckBuilder alongside the existing manual deck flow
- Selecting any of the 27 NT books fetches its MorphGNT data, extracts all unique vocabulary-matched lemmas, and creates a custom deck with one click
- New utility `src/lib/book-deck.ts` (`getBookWordKeys`) handles lemma extraction; integrates with the existing SRS and custom deck stores without changes to either

## Test plan

- [ ] Open Flashcards → My Decks — confirm both `+ New Deck` and `+ From GNT Book` buttons are visible
- [ ] Click `+ From GNT Book` — book selector appears with all 27 NT books
- [ ] Select Philemon — name field auto-populates as "Philemon", word count appears
- [ ] Edit the name, then click Create Deck — deck appears in the list
- [ ] Click Study on the new deck — flashcard session starts with only Philemon words
- [ ] Try creating a deck with a duplicate name — error message appears
- [ ] Click Cancel / Back — returns to list without creating a deck
- [ ] All 700 unit tests pass (`pnpm test:run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)