### PR TITLE
fix(layout): remove "New in Quiz" announcement tooltip

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,5 @@
 ---
 import '../styles/global.css';
-import AnnouncementTooltip from '../components/AnnouncementTooltip.astro';
 
 interface Props {
   title: string;
@@ -274,14 +273,6 @@ function isActive(href: string) {
 
       </div>
     </nav>
-
-    <AnnouncementTooltip
-      dismissKey="greek-tools-quiz-announcement-v1"
-      title="New in Quiz"
-      message="Verb parsing is here — drill λύω forms or parse verbs straight from GNT passages."
-      desktopAnchor='nav:not([aria-label]) a[href="/quiz"]'
-      mobileAnchor='nav[aria-label="Main navigation"] a[href="/quiz"]'
-    />
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Removes the `AnnouncementTooltip` usage from `Layout.astro` — the verb parsing feature is no longer new
- Keeps `AnnouncementTooltip.astro` component in place for future announcements

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)