### PR TITLE
fix(layout): prevent mobile bottom nav from obscuring submit button

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -115,8 +115,8 @@ function isActive(href: string) {
     </nav>
 
     <!-- ── Main content ────────────────────────────────────────────────── -->
-    <!-- pb-20 on mobile leaves room above the fixed bottom tab bar -->
-    <main class="flex-1 max-w-5xl mx-auto w-full px-4 sm:px-6 py-6 sm:py-8 pb-20 md:pb-8">
+    <!-- pb-24 on mobile leaves room above the fixed bottom tab bar -->
+    <main class="flex-1 max-w-5xl mx-auto w-full px-4 sm:px-6 pt-6 sm:pt-8 pb-24 md:pb-8">
       <slot />
     </main>
 


### PR DESCRIPTION
## Summary

- On mobile, the submit button in the GNT Passage Parsing quiz was hidden behind the fixed bottom tab bar
- Root cause: in Tailwind v4, `py-6` uses `padding-block` which sets `padding-block-end` — this was winning over `pb-20` in the CSS cascade, collapsing effective bottom padding to 24px instead of 80px
- Fix: replaced `py-6`/`sm:py-8` with `pt-6`/`sm:pt-8` to eliminate the conflict, and bumped `pb-20` → `pb-24` (96px) for 23px of clearance above the 73px nav bar

## Test plan

- [ ] Open the GNT Passage Parsing quiz on a mobile screen size
- [ ] Select Tense, Voice, Mood, and all conditional fields (e.g. a participle with Case, Number, Gender)
- [ ] Scroll to the bottom — Submit button should be fully visible above the nav bar
- [ ] Verify desktop layout is unaffected (nav is hidden, `md:pb-8` applies as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)