### PR TITLE
Generate flashcard deck from GNT passage

### DIFF
--- a/src/components/DeckBuilder.test.tsx
+++ b/src/components/DeckBuilder.test.tsx
@@ -6,6 +6,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CustomDeck } from '../data/customDecks';
+import type { MorphBook } from '../data/morphgnt';
 import DeckBuilder from './DeckBuilder';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -19,7 +20,7 @@ vi.mock('../lib/book-deck', () => ({
   getBookWordKeys: vi.fn(),
 }));
 
-import { fetchBooks } from '../data/morphgnt';
+import { fetchBook, fetchBooks } from '../data/morphgnt';
 import { getBookWordKeys } from '../lib/book-deck';
 
 const mockFetchBooks = vi.mocked(fetchBooks);
@@ -30,12 +31,29 @@ const STUB_BOOKS = [
   { code: 'JHN', name: 'John', chapters: 21 },
 ];
 
+const MOCK_BOOK: MorphBook = {
+  '1': {
+    '1': [
+      { text: 'Ἐν', lemma: 'ἐν', pos: 'P-', parsing: '--------' },
+      { text: 'ἀρχῇ', lemma: 'ἀρχή', pos: 'N-', parsing: '--------' },
+    ],
+    '2': [
+      { text: 'καί', lemma: 'καί', pos: 'C-', parsing: '--------' },
+      { text: 'θεός', lemma: 'θεός', pos: 'N-', parsing: '--------' },
+    ],
+  },
+  '2': {
+    '1': [{ text: 'λόγος', lemma: 'λόγος', pos: 'N-', parsing: '--------' }],
+  },
+};
+
 beforeEach(() => {
   localStorage.clear();
   vi.clearAllMocks();
   vi.restoreAllMocks();
   mockFetchBooks.mockResolvedValue(STUB_BOOKS);
   mockGetBookWordKeys.mockResolvedValue(['καί', 'ὁ', 'λόγος']);
+  vi.mocked(fetchBook).mockResolvedValue(MOCK_BOOK);
 });
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -674,5 +692,246 @@ describe('From GNT Book', () => {
     });
 
     expect(screen.getByRole('button', { name: /\+ new deck/i })).toBeInTheDocument();
+  });
+});
+
+// ─── Passage view ─────────────────────────────────────────────────────────────
+
+describe('Passage view', () => {
+  async function goToPassage(user: ReturnType<typeof userEvent.setup>) {
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /generate from passage/i }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  it('renders a "Generate from Passage" button in list view', () => {
+    renderBuilder();
+    expect(screen.getByRole('button', { name: /generate from passage/i })).toBeInTheDocument();
+  });
+
+  it('transitions to passage view', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    expect(screen.getByText(/generate from passage/i, { selector: 'h3' })).toBeInTheDocument();
+  });
+
+  it('Back button returns to list view', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /back to deck list/i }));
+    });
+    expect(screen.getByRole('button', { name: /\+ new deck/i })).toBeInTheDocument();
+  });
+
+  it('Cancel button returns to list view', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+    });
+    expect(screen.getByRole('button', { name: /\+ new deck/i })).toBeInTheDocument();
+  });
+
+  it('renders book selector with all NT books', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    expect(screen.getByRole('combobox', { name: /book/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Matthew' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Revelation' })).toBeInTheDocument();
+  });
+
+  it('renders start and end chapter/verse inputs', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    expect(screen.getByRole('spinbutton', { name: /start chapter/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /start verse/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /end chapter/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /end verse/i })).toBeInTheDocument();
+  });
+
+  it('shows a preview count after book loads', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await waitFor(() => {
+      expect(screen.getByRole('status', { name: /passage word count/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows inline error when chapter is out of range', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    await act(async () => {
+      await user.clear(screen.getByRole('spinbutton', { name: /start chapter/i }));
+      await user.type(screen.getByRole('spinbutton', { name: /start chapter/i }), '99');
+    });
+    expect(screen.getByText(/out of range/i)).toBeInTheDocument();
+  });
+
+  it('shows inline error when start comes after end', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    const startChInput = screen.getByRole('spinbutton', { name: /start chapter/i });
+    await act(async () => {
+      await user.clear(startChInput);
+      await user.type(startChInput, '2');
+    });
+    expect(screen.getByText(/start must come before end/i)).toBeInTheDocument();
+  });
+
+  it('shows "New words only" toggle', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    expect(screen.getByRole('checkbox', { name: /new words only/i })).toBeInTheDocument();
+  });
+
+  it('auto-populates deck name from passage reference', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    expect((screen.getByRole('textbox', { name: /deck name/i }) as HTMLInputElement).value).toMatch(
+      /Matthew/i,
+    );
+  });
+
+  it('does not overwrite a manually edited deck name', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    const nameInput = screen.getByRole('textbox', { name: /deck name/i });
+    await act(async () => {
+      await user.clear(nameInput);
+      await user.type(nameInput, 'My Custom Name');
+    });
+    await act(async () => {
+      await user.clear(screen.getByRole('spinbutton', { name: /end verse/i }));
+      await user.type(screen.getByRole('spinbutton', { name: /end verse/i }), '2');
+    });
+    expect((nameInput as HTMLInputElement).value).toBe('My Custom Name');
+  });
+
+  it('shows name validation error when name is empty', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    await act(async () => {
+      await user.clear(screen.getByRole('textbox', { name: /deck name/i }));
+    });
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /generate deck/i }));
+    });
+    expect(screen.getByText(/deck name is required/i)).toBeInTheDocument();
+  });
+
+  it('shows duplicate name error', async () => {
+    const user = userEvent.setup();
+    renderBuilder({ decks: [makeDeck({ name: 'Matthew 1:1' })] });
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    const nameInput = screen.getByRole('textbox', { name: /deck name/i });
+    await act(async () => {
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Matthew 1:1');
+    });
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /generate deck/i }));
+    });
+    expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+  });
+
+  it('calls onDecksChange and onActivateDeck after successful save', async () => {
+    const user = userEvent.setup();
+    const onDecksChange = vi.fn();
+    const onActivateDeck = vi.fn();
+    renderBuilder({ onDecksChange, onActivateDeck });
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /generate deck/i }));
+    });
+    expect(onDecksChange).toHaveBeenCalled();
+    expect(onActivateDeck).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('calls onClose after successful save', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderBuilder({ onClose });
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /generate deck/i }));
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('blocks save when passage yields zero words after filtering', async () => {
+    const studiedKeys = ['ἐν', 'ἀρχή', 'καί', 'θεός', 'λόγος'];
+    localStorage.setItem(
+      'greek-tools-srs-v2',
+      JSON.stringify(
+        Object.fromEntries(
+          studiedKeys.map((key) => [
+            key,
+            {
+              key,
+              interval: 6,
+              repetition: 1,
+              easeFactor: 2.5,
+              dueDate: '2026-06-01',
+              lastReviewed: '2026-05-01',
+            },
+          ]),
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    await act(async () => {
+      await user.click(screen.getByRole('checkbox', { name: /new words only/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('status', { name: /passage word count/i })).toHaveTextContent('0');
+    });
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /generate deck/i }));
+    });
+    expect(screen.getByText(/no words found/i)).toBeInTheDocument();
+  });
+
+  it('resets chapter/verse inputs when book changes', async () => {
+    const user = userEvent.setup();
+    renderBuilder();
+    await goToPassage(user);
+    await waitFor(() => screen.getByRole('status', { name: /passage word count/i }));
+    await act(async () => {
+      await user.clear(screen.getByRole('spinbutton', { name: /end verse/i }));
+      await user.type(screen.getByRole('spinbutton', { name: /end verse/i }), '2');
+    });
+    await act(async () => {
+      await user.selectOptions(screen.getByRole('combobox', { name: /book/i }), 'MRK');
+    });
+    expect((screen.getByRole('spinbutton', { name: /end verse/i }) as HTMLInputElement).value).toBe(
+      '1',
+    );
   });
 });

--- a/src/components/DeckBuilder.tsx
+++ b/src/components/DeckBuilder.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   type CustomDeck,
   createCustomDeck,
@@ -6,14 +6,21 @@ import {
   loadCustomDecks,
   updateCustomDeck,
 } from '../data/customDecks';
-import { type BookMeta, fetchBooks } from '../data/morphgnt';
-import { normalizeKey } from '../data/srs';
+import { type BookMeta, fetchBook, fetchBooks, type MorphBook } from '../data/morphgnt';
+import { getStudiedLemmas, normalizeKey } from '../data/srs';
 import { vocabulary } from '../data/vocabulary';
 import { getBookWordKeys } from '../lib/book-deck';
+import {
+  buildVocabMap,
+  extractPassageLemmas,
+  formatPassageRef,
+  GNT_BOOKS,
+  isValidRef,
+} from '../lib/passage-deck';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type DeckBuilderView = 'list' | 'edit' | 'from-book';
+type DeckBuilderView = 'list' | 'edit' | 'from-book' | 'passage';
 
 interface DeckBuilderProps {
   decks: CustomDeck[];
@@ -49,6 +56,115 @@ export default function DeckBuilder({
   const [fromBookLoading, setFromBookLoading] = useState(false);
   const [fromBookError, setFromBookError] = useState('');
   const [fromBookNameError, setFromBookNameError] = useState('');
+
+  // Passage view state
+  const [passageBookCode, setPassageBookCode] = useState('MAT');
+  const [passageBookData, setPassageBookData] = useState<MorphBook | null>(null);
+  const [passageBookLoading, setPassageBookLoading] = useState(false);
+  const [passageBookError, setPassageBookError] = useState('');
+  const [passageStartCh, setPassageStartCh] = useState('1');
+  const [passageStartVs, setPassageStartVs] = useState('1');
+  const [passageEndCh, setPassageEndCh] = useState('1');
+  const [passageEndVs, setPassageEndVs] = useState('1');
+  const [passageNewWordsOnly, setPassageNewWordsOnly] = useState(false);
+  const [passageName, setPassageName] = useState('');
+  const [passageNameManuallyEdited, setPassageNameManuallyEdited] = useState(false);
+  const [passageNameError, setPassageNameError] = useState('');
+  const [passageSaveError, setPassageSaveError] = useState('');
+
+  // ─── Passage view: computed values ───────────────────────────────────────────
+
+  const vocabMap = useMemo(() => buildVocabMap(vocabulary), []);
+
+  useEffect(() => {
+    if (view !== 'passage') return;
+    let cancelled = false;
+    setPassageBookData(null);
+    setPassageBookLoading(true);
+    setPassageBookError('');
+    fetchBook(passageBookCode)
+      .then((data) => {
+        if (!cancelled) {
+          setPassageBookData(data);
+          setPassageBookLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPassageBookLoading(false);
+          setPassageBookError('Failed to load book data.');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [passageBookCode, view]);
+
+  const passageRefError = useMemo(() => {
+    if (!passageBookData) return '';
+    const startCh = parseInt(passageStartCh, 10);
+    const startVs = parseInt(passageStartVs, 10);
+    const endCh = parseInt(passageEndCh, 10);
+    const endVs = parseInt(passageEndVs, 10);
+    if (isNaN(startCh) || isNaN(startVs) || isNaN(endCh) || isNaN(endVs)) return '';
+    if (!isValidRef(passageBookData, startCh, startVs)) {
+      if (!(String(startCh) in passageBookData)) return `Chapter ${startCh} is out of range.`;
+      return `Verse ${startVs} is out of range for chapter ${startCh}.`;
+    }
+    if (!isValidRef(passageBookData, endCh, endVs)) {
+      if (!(String(endCh) in passageBookData)) return `Chapter ${endCh} is out of range.`;
+      return `Verse ${endVs} is out of range for chapter ${endCh}.`;
+    }
+    if (startCh > endCh || (startCh === endCh && startVs > endVs))
+      return 'Start must come before end.';
+    return '';
+  }, [passageBookData, passageStartCh, passageStartVs, passageEndCh, passageEndVs]);
+
+  const previewLemmas = useMemo(() => {
+    if (!passageBookData || passageRefError) return null;
+    const startCh = parseInt(passageStartCh, 10);
+    const startVs = parseInt(passageStartVs, 10);
+    const endCh = parseInt(passageEndCh, 10);
+    const endVs = parseInt(passageEndVs, 10);
+    if (isNaN(startCh) || isNaN(startVs) || isNaN(endCh) || isNaN(endVs)) return null;
+    const all = extractPassageLemmas(passageBookData, startCh, startVs, endCh, endVs, vocabMap);
+    if (!passageNewWordsOnly) return all;
+    const studied = getStudiedLemmas();
+    return all.filter((key) => !studied.has(key));
+  }, [
+    passageBookData,
+    passageRefError,
+    passageStartCh,
+    passageStartVs,
+    passageEndCh,
+    passageEndVs,
+    passageNewWordsOnly,
+    vocabMap,
+  ]);
+
+  const autoPassageName = useMemo(() => {
+    if (!passageBookData || passageRefError) return null;
+    const startCh = parseInt(passageStartCh, 10);
+    const startVs = parseInt(passageStartVs, 10);
+    const endCh = parseInt(passageEndCh, 10);
+    const endVs = parseInt(passageEndVs, 10);
+    if (isNaN(startCh) || isNaN(startVs) || isNaN(endCh) || isNaN(endVs)) return null;
+    const bookName = GNT_BOOKS.find((b) => b.code === passageBookCode)?.name ?? passageBookCode;
+    return formatPassageRef(bookName, startCh, startVs, endCh, endVs);
+  }, [
+    passageBookData,
+    passageRefError,
+    passageBookCode,
+    passageStartCh,
+    passageStartVs,
+    passageEndCh,
+    passageEndVs,
+  ]);
+
+  useEffect(() => {
+    if (passageNameManuallyEdited || !autoPassageName) return;
+    setPassageName(autoPassageName);
+  }, [autoPassageName, passageNameManuallyEdited]);
 
   // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -304,6 +420,13 @@ export default function DeckBuilder({
             + From GNT Book
           </button>
         </div>
+        <button
+          type="button"
+          onClick={openPassage}
+          className="w-full py-2.5 border-2 border-dashed border-indigo-200 text-text-muted rounded-xl text-sm font-medium hover:border-grape/40 hover:text-text transition-colors"
+        >
+          Generate from Passage
+        </button>
       </div>
     );
   }
@@ -422,6 +545,218 @@ export default function DeckBuilder({
           </button>
           <button
             type="button"
+            onClick={() => setView('list')}
+            className="px-4 py-2.5 border-2 border-gray-200 text-text-muted rounded-xl text-sm font-medium hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Passage view helpers ────────────────────────────────────────────────────
+
+  function openPassage() {
+    setPassageBookCode('MAT');
+    setPassageBookData(null);
+    setPassageBookLoading(false);
+    setPassageBookError('');
+    setPassageStartCh('1');
+    setPassageStartVs('1');
+    setPassageEndCh('1');
+    setPassageEndVs('1');
+    setPassageNewWordsOnly(false);
+    setPassageName('');
+    setPassageNameManuallyEdited(false);
+    setPassageNameError('');
+    setPassageSaveError('');
+    setView('passage');
+  }
+
+  function handlePassageBookChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    setPassageBookCode(e.target.value);
+    setPassageStartCh('1');
+    setPassageStartVs('1');
+    setPassageEndCh('1');
+    setPassageEndVs('1');
+    setPassageNameManuallyEdited(false);
+  }
+
+  function handlePassageSave() {
+    const trimmed = passageName.trim();
+    if (!trimmed) {
+      setPassageNameError('Deck name is required.');
+      return;
+    }
+    if (trimmed.length > 60) {
+      setPassageNameError('Name must be 60 characters or fewer.');
+      return;
+    }
+    const duplicate = decks.find((d) => d.name.trim().toLowerCase() === trimmed.toLowerCase());
+    if (duplicate) {
+      setPassageNameError('A deck with that name already exists.');
+      return;
+    }
+    setPassageNameError('');
+    if (!previewLemmas || previewLemmas.length === 0) {
+      setPassageSaveError('No words found in this passage. Adjust the range or filter.');
+      return;
+    }
+    setPassageSaveError('');
+    const newDeck = createCustomDeck(trimmed, previewLemmas);
+    onDecksChange(loadCustomDecks());
+    onActivateDeck(newDeck.id);
+    onClose();
+  }
+
+  // ─── Passage view ─────────────────────────────────────────────────────────────
+
+  if (view === 'passage') {
+    const previewCount = previewLemmas?.length ?? null;
+    return (
+      <div className="bg-bg-card rounded-2xl border-2 border-indigo-100 p-4 space-y-4 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-bold text-text uppercase tracking-wider">
+            Generate from Passage
+          </h3>
+          <button
+            onClick={() => setView('list')}
+            aria-label="Back to deck list"
+            className="text-sm text-text-muted hover:text-text transition-colors font-medium"
+          >
+            ← Back
+          </button>
+        </div>
+
+        <div>
+          <label
+            htmlFor="passage-book"
+            className="text-xs font-bold text-text-muted uppercase tracking-wider block mb-1.5"
+          >
+            Book
+          </label>
+          <select
+            id="passage-book"
+            value={passageBookCode}
+            onChange={handlePassageBookChange}
+            className="w-full px-3 py-2 border-2 border-indigo-100 rounded-xl text-sm focus:border-grape focus:outline-none bg-white"
+          >
+            {GNT_BOOKS.map((b) => (
+              <option key={b.code} value={b.code}>
+                {b.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-bold text-text-muted uppercase tracking-wider">
+            Passage Range
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-text-muted w-8 shrink-0">From</span>
+            <input
+              type="number"
+              min={1}
+              value={passageStartCh}
+              onChange={(e) => setPassageStartCh(e.target.value)}
+              aria-label="Start chapter"
+              className="w-16 px-2 py-2 border-2 border-indigo-100 rounded-xl text-sm text-center focus:border-grape focus:outline-none"
+            />
+            <span className="text-xs text-text-muted">:</span>
+            <input
+              type="number"
+              min={1}
+              value={passageStartVs}
+              onChange={(e) => setPassageStartVs(e.target.value)}
+              aria-label="Start verse"
+              className="w-16 px-2 py-2 border-2 border-indigo-100 rounded-xl text-sm text-center focus:border-grape focus:outline-none"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-text-muted w-8 shrink-0">To</span>
+            <input
+              type="number"
+              min={1}
+              value={passageEndCh}
+              onChange={(e) => setPassageEndCh(e.target.value)}
+              aria-label="End chapter"
+              className="w-16 px-2 py-2 border-2 border-indigo-100 rounded-xl text-sm text-center focus:border-grape focus:outline-none"
+            />
+            <span className="text-xs text-text-muted">:</span>
+            <input
+              type="number"
+              min={1}
+              value={passageEndVs}
+              onChange={(e) => setPassageEndVs(e.target.value)}
+              aria-label="End verse"
+              className="w-16 px-2 py-2 border-2 border-indigo-100 rounded-xl text-sm text-center focus:border-grape focus:outline-none"
+            />
+          </div>
+          {passageRefError && <p className="text-xs text-coral">{passageRefError}</p>}
+        </div>
+
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={passageNewWordsOnly}
+            onChange={(e) => setPassageNewWordsOnly(e.target.checked)}
+            className="accent-grape"
+            aria-label="New words only"
+          />
+          <span className="text-sm text-text">New words only</span>
+          <span className="text-xs text-text-muted">(exclude already studied)</span>
+        </label>
+
+        {passageBookLoading ? (
+          <p className="text-sm text-text-muted">Loading…</p>
+        ) : passageBookError ? (
+          <p className="text-sm text-coral">{passageBookError}</p>
+        ) : previewCount !== null ? (
+          <p className="text-sm text-text-muted" role="status" aria-label="passage word count">
+            <strong className="text-text">{previewCount}</strong> unique word
+            {previewCount !== 1 ? 's' : ''} found in this passage
+          </p>
+        ) : null}
+
+        <div>
+          <label
+            htmlFor="passage-deck-name"
+            className="text-xs font-bold text-text-muted uppercase tracking-wider block mb-1.5"
+          >
+            Deck Name
+          </label>
+          <input
+            id="passage-deck-name"
+            type="text"
+            value={passageName}
+            onChange={(e) => {
+              setPassageName(e.target.value);
+              setPassageNameManuallyEdited(true);
+              setPassageNameError('');
+            }}
+            placeholder="e.g. John 3:1–21"
+            maxLength={60}
+            className={`w-full px-3 py-2 border-2 rounded-xl text-sm focus:outline-none transition-colors ${passageNameError ? 'border-coral focus:border-coral' : 'border-indigo-100 focus:border-grape'}`}
+            autoComplete="off"
+          />
+          <div className="flex justify-between mt-1">
+            {passageNameError ? <p className="text-xs text-coral">{passageNameError}</p> : <span />}
+            <span className="text-xs text-text-muted ml-auto">{passageName.length}/60</span>
+          </div>
+        </div>
+
+        {passageSaveError && <p className="text-xs text-coral">{passageSaveError}</p>}
+
+        <div className="flex gap-3 pt-1">
+          <button
+            onClick={handlePassageSave}
+            className="flex-1 py-2.5 bg-grape text-white rounded-xl text-sm font-semibold hover:opacity-90 transition-opacity shadow-sm"
+          >
+            Generate Deck
+          </button>
+          <button
             onClick={() => setView('list')}
             className="px-4 py-2.5 border-2 border-gray-200 text-text-muted rounded-xl text-sm font-medium hover:bg-gray-50 transition-colors"
           >

--- a/src/lib/passage-deck.test.ts
+++ b/src/lib/passage-deck.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import type { MorphBook } from '../data/morphgnt';
+import type { VocabWord } from '../data/vocabulary';
+import {
+  buildVocabMap,
+  extractPassageLemmas,
+  formatPassageRef,
+  GNT_BOOKS,
+  isValidRef,
+} from './passage-deck';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_VOCAB: VocabWord[] = [
+  { greek: 'λόγος', gloss: 'word', frequency: 330, partOfSpeech: 'noun' },
+  { greek: 'θεός', gloss: 'God', frequency: 1307, partOfSpeech: 'noun' },
+  { greek: 'εἰμί', gloss: 'I am', frequency: 2456, partOfSpeech: 'verb' },
+  { greek: 'καί', gloss: 'and', frequency: 8973, partOfSpeech: 'conjunction' },
+  { greek: 'ὁ, ἡ, τό', gloss: 'the', frequency: 19769, partOfSpeech: 'article' },
+];
+
+// chapter 1: verses 1–3; chapter 2: verse 1
+const MOCK_BOOK: MorphBook = {
+  '1': {
+    '1': [
+      { text: 'Λόγος', lemma: 'λόγος', pos: 'N-', parsing: '--------' },
+      { text: 'θεός', lemma: 'θεός', pos: 'N-', parsing: '--------' },
+    ],
+    '2': [
+      { text: 'εἰμί', lemma: 'εἰμί', pos: 'V-', parsing: '--------' },
+      { text: 'λόγος,', lemma: 'λόγος', pos: 'N-', parsing: '--------' }, // duplicate
+    ],
+    '3': [
+      { text: 'καί', lemma: 'καί', pos: 'C-', parsing: '--------' },
+      { text: 'ξένος', lemma: 'ξένος', pos: 'A-', parsing: '--------' }, // not in MOCK_VOCAB
+    ],
+  },
+  '2': {
+    '1': [
+      { text: 'ὁ', lemma: 'ὁ', pos: 'RA', parsing: '--------' },
+      { text: 'καί', lemma: 'καί', pos: 'C-', parsing: '--------' }, // cross-chapter duplicate
+    ],
+  },
+};
+
+// ─── buildVocabMap ────────────────────────────────────────────────────────────
+
+describe('buildVocabMap', () => {
+  it('maps normalizeKey(greek) → VocabWord', () => {
+    const map = buildVocabMap(MOCK_VOCAB);
+    expect(map.get('λόγος')?.gloss).toBe('word');
+    expect(map.get('θεός')?.gloss).toBe('God');
+  });
+
+  it('strips compound form for article', () => {
+    const map = buildVocabMap(MOCK_VOCAB);
+    expect(map.get('ὁ')?.gloss).toBe('the');
+    expect(map.has('ὁ, ἡ, τό')).toBe(false);
+  });
+
+  it('returns an empty map for empty input', () => {
+    expect(buildVocabMap([]).size).toBe(0);
+  });
+
+  it('contains all provided words', () => {
+    const map = buildVocabMap(MOCK_VOCAB);
+    expect(map.size).toBe(MOCK_VOCAB.length);
+  });
+});
+
+// ─── isValidRef ───────────────────────────────────────────────────────────────
+
+describe('isValidRef', () => {
+  it('returns true for a valid chapter and verse', () => {
+    expect(isValidRef(MOCK_BOOK, 1, 1)).toBe(true);
+    expect(isValidRef(MOCK_BOOK, 1, 3)).toBe(true);
+    expect(isValidRef(MOCK_BOOK, 2, 1)).toBe(true);
+  });
+
+  it('returns false for a chapter that does not exist', () => {
+    expect(isValidRef(MOCK_BOOK, 3, 1)).toBe(false);
+    expect(isValidRef(MOCK_BOOK, 0, 1)).toBe(false);
+  });
+
+  it('returns false for a verse that does not exist in a valid chapter', () => {
+    expect(isValidRef(MOCK_BOOK, 1, 4)).toBe(false);
+    expect(isValidRef(MOCK_BOOK, 2, 2)).toBe(false);
+  });
+});
+
+// ─── extractPassageLemmas ────────────────────────────────────────────────────
+
+describe('extractPassageLemmas', () => {
+  const vocabMap = buildVocabMap(MOCK_VOCAB);
+
+  it('returns lemmas for a single verse in passage order', () => {
+    expect(extractPassageLemmas(MOCK_BOOK, 1, 1, 1, 1, vocabMap)).toEqual(['λόγος', 'θεός']);
+  });
+
+  it('deduplicates lemmas across verses, keeping first occurrence', () => {
+    const result = extractPassageLemmas(MOCK_BOOK, 1, 1, 1, 2, vocabMap);
+    expect(result.filter((k) => k === 'λόγος')).toHaveLength(1);
+    expect(result.indexOf('λόγος')).toBe(0);
+  });
+
+  it('excludes lemmas not in vocabMap', () => {
+    const result = extractPassageLemmas(MOCK_BOOK, 1, 3, 1, 3, vocabMap);
+    expect(result).toContain('καί');
+    expect(result).not.toContain('ξένος');
+  });
+
+  it('covers a multi-verse single-chapter range', () => {
+    const result = extractPassageLemmas(MOCK_BOOK, 1, 1, 1, 3, vocabMap);
+    expect(result).toContain('λόγος');
+    expect(result).toContain('θεός');
+    expect(result).toContain('εἰμί');
+    expect(result).toContain('καί');
+    expect(result).not.toContain('ξένος');
+  });
+
+  it('covers a cross-chapter range', () => {
+    const result = extractPassageLemmas(MOCK_BOOK, 1, 3, 2, 1, vocabMap);
+    expect(result).toContain('καί');
+    expect(result).toContain('ὁ');
+    expect(result.filter((k) => k === 'καί')).toHaveLength(1);
+  });
+
+  it('deduplicates lemmas across chapter boundary', () => {
+    const result = extractPassageLemmas(MOCK_BOOK, 1, 1, 2, 1, vocabMap);
+    expect(result.filter((k) => k === 'καί')).toHaveLength(1);
+  });
+
+  it('respects the start verse boundary', () => {
+    const result = extractPassageLemmas(MOCK_BOOK, 1, 2, 1, 2, vocabMap);
+    expect(result).toContain('εἰμί');
+    expect(result).not.toContain('θεός');
+  });
+
+  it('respects the end verse boundary', () => {
+    const result = extractPassageLemmas(MOCK_BOOK, 1, 1, 1, 1, vocabMap);
+    expect(result).not.toContain('εἰμί');
+    expect(result).not.toContain('καί');
+  });
+
+  it('returns an empty array when no lemmas match vocab', () => {
+    const emptyBook: MorphBook = {
+      '1': { '1': [{ text: 'ξένος', lemma: 'ξένος', pos: 'A-', parsing: '--------' }] },
+    };
+    expect(extractPassageLemmas(emptyBook, 1, 1, 1, 1, vocabMap)).toEqual([]);
+  });
+
+  it('handles a book with only one verse', () => {
+    const tiny: MorphBook = {
+      '1': { '1': [{ text: 'θεός', lemma: 'θεός', pos: 'N-', parsing: '--------' }] },
+    };
+    expect(extractPassageLemmas(tiny, 1, 1, 1, 1, vocabMap)).toEqual(['θεός']);
+  });
+});
+
+// ─── formatPassageRef ─────────────────────────────────────────────────────────
+
+describe('formatPassageRef', () => {
+  it('formats a single verse', () => {
+    expect(formatPassageRef('John', 3, 16, 3, 16)).toBe('John 3:16');
+  });
+
+  it('formats a same-chapter range', () => {
+    expect(formatPassageRef('John', 3, 1, 3, 21)).toBe('John 3:1–21');
+  });
+
+  it('formats a cross-chapter range', () => {
+    expect(formatPassageRef('Romans', 8, 35, 9, 5)).toBe('Romans 8:35–9:5');
+  });
+
+  it('uses the book name as provided', () => {
+    expect(formatPassageRef('1 Corinthians', 13, 1, 13, 13)).toBe('1 Corinthians 13:1–13');
+  });
+});
+
+// ─── GNT_BOOKS ───────────────────────────────────────────────────────────────
+
+describe('GNT_BOOKS', () => {
+  it('contains 27 books', () => {
+    expect(GNT_BOOKS).toHaveLength(27);
+  });
+
+  it('starts with Matthew and ends with Revelation', () => {
+    expect(GNT_BOOKS[0].code).toBe('MAT');
+    expect(GNT_BOOKS[26].code).toBe('REV');
+  });
+
+  it('has unique codes', () => {
+    const codes = GNT_BOOKS.map((b) => b.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});

--- a/src/lib/passage-deck.ts
+++ b/src/lib/passage-deck.ts
@@ -1,0 +1,102 @@
+import type { MorphBook } from '../data/morphgnt';
+import { normalizeKey } from '../data/srs';
+import type { VocabWord } from '../data/vocabulary';
+
+export const GNT_BOOKS: ReadonlyArray<{ code: string; name: string }> = [
+  { code: 'MAT', name: 'Matthew' },
+  { code: 'MRK', name: 'Mark' },
+  { code: 'LUK', name: 'Luke' },
+  { code: 'JHN', name: 'John' },
+  { code: 'ACT', name: 'Acts' },
+  { code: 'ROM', name: 'Romans' },
+  { code: '1CO', name: '1 Corinthians' },
+  { code: '2CO', name: '2 Corinthians' },
+  { code: 'GAL', name: 'Galatians' },
+  { code: 'EPH', name: 'Ephesians' },
+  { code: 'PHP', name: 'Philippians' },
+  { code: 'COL', name: 'Colossians' },
+  { code: '1TH', name: '1 Thessalonians' },
+  { code: '2TH', name: '2 Thessalonians' },
+  { code: '1TI', name: '1 Timothy' },
+  { code: '2TI', name: '2 Timothy' },
+  { code: 'TIT', name: 'Titus' },
+  { code: 'PHM', name: 'Philemon' },
+  { code: 'HEB', name: 'Hebrews' },
+  { code: 'JAS', name: 'James' },
+  { code: '1PE', name: '1 Peter' },
+  { code: '2PE', name: '2 Peter' },
+  { code: '1JN', name: '1 John' },
+  { code: '2JN', name: '2 John' },
+  { code: '3JN', name: '3 John' },
+  { code: 'JUD', name: 'Jude' },
+  { code: 'REV', name: 'Revelation' },
+];
+
+export function buildVocabMap(vocab: VocabWord[]): Map<string, VocabWord> {
+  const map = new Map<string, VocabWord>();
+  for (const word of vocab) {
+    map.set(normalizeKey(word.greek), word);
+  }
+  return map;
+}
+
+export function isValidRef(book: MorphBook, chapter: number, verse: number): boolean {
+  const chStr = String(chapter);
+  if (!(chStr in book)) return false;
+  return String(verse) in book[chStr];
+}
+
+export function extractPassageLemmas(
+  book: MorphBook,
+  startCh: number,
+  startVs: number,
+  endCh: number,
+  endVs: number,
+  vocabMap: Map<string, VocabWord>,
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const chapters = Object.keys(book)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  for (const ch of chapters) {
+    if (ch < startCh || ch > endCh) continue;
+    const verseMap = book[String(ch)];
+    const verses = Object.keys(verseMap)
+      .map(Number)
+      .sort((a, b) => a - b);
+
+    for (const vs of verses) {
+      if (ch === startCh && vs < startVs) continue;
+      if (ch === endCh && vs > endVs) continue;
+
+      for (const word of verseMap[String(vs)]) {
+        const key = normalizeKey(word.lemma);
+        if (!seen.has(key) && vocabMap.has(key)) {
+          seen.add(key);
+          result.push(key);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+export function formatPassageRef(
+  bookName: string,
+  startCh: number,
+  startVs: number,
+  endCh: number,
+  endVs: number,
+): string {
+  if (startCh === endCh && startVs === endVs) {
+    return `${bookName} ${startCh}:${startVs}`;
+  }
+  if (startCh === endCh) {
+    return `${bookName} ${startCh}:${startVs}–${endVs}`;
+  }
+  return `${bookName} ${startCh}:${startVs}–${endCh}:${endVs}`;
+}


### PR DESCRIPTION
## Summary

- Adds a "Generate from Passage" flow to the DeckBuilder panel on `/flashcards`
- Students select a book, chapter/verse range, and optionally filter to unlearned words — the system extracts unique lemmas from MorphGNT and creates a CustomDeck that activates immediately for study
- No new routes, no changes to the Flashcards study UI — the generated deck is an ordinary CustomDeck

## What's new

**`src/lib/passage-deck.ts`** — pure extraction logic (no React):
- `extractPassageLemmas` — iterates MorphBook for a passage range, deduplicates by first occurrence, filters to vocabulary dataset keys
- `buildVocabMap`, `isValidRef`, `formatPassageRef`, `GNT_BOOKS`

**`src/components/DeckBuilder.tsx`** — new `'passage'` view state:
- Book selector (all 27 NT books via embedded constant — no extra fetch)
- Start/end chapter + verse inputs with inline validation against actual MorphGNT book structure
- Live preview count (updates as inputs change)
- "New words only" toggle — excludes lemmas with `repetition > 0` in SRS store
- Deck name auto-populated from passage ref; manual edits are preserved
- `fetchBook` lazy-loads the selected book JSON (same cache as GNT Reader)

## Test plan

- [ ] `pnpm test:run` — 739 tests, all passing
- [ ] `pnpm typecheck` — clean
- [ ] Open `/flashcards` → Manage → Generate from Passage
- [ ] Select John, range 3:1–21, confirm preview count matches expected vocab words
- [ ] Enable "New words only" and verify count drops for already-studied words
- [ ] Confirm deck name auto-populates as "John 3:1–21"
- [ ] Edit the name manually, change the range, confirm the name is not overwritten
- [ ] Save → verify deck appears as active and cards load correctly
- [ ] Try an out-of-range chapter/verse → verify inline error appears
- [ ] Try start > end → verify "Start must come before end" error
- [ ] Try saving with 0 words (all filtered by New words only) → verify error message

closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)