### PR TITLE
feat(focus): Focus Passage — passage-scoped vocab, parsing, reader, and progress hub

### DIFF
--- a/src/components/CrossChapterSelector.tsx
+++ b/src/components/CrossChapterSelector.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react';
+import { type BookMeta, fetchBook, fetchBooks, type MorphBook } from '../data/morphgnt';
+import { GNT_BOOKS } from '../lib/passage-deck';
+
+export interface CrossChapterRange {
+  book: string;
+  startChapter: number;
+  startVerse: number;
+  endChapter: number;
+  endVerse: number;
+}
+
+interface Props {
+  value: CrossChapterRange;
+  onChange: (range: CrossChapterRange) => void;
+}
+
+const DEFAULT_BOOK = 'REV';
+
+export const DEFAULT_CROSS_CHAPTER_RANGE: CrossChapterRange = {
+  book: DEFAULT_BOOK,
+  startChapter: 1,
+  startVerse: 1,
+  endChapter: 1,
+  endVerse: 11,
+};
+
+export default function CrossChapterSelector({ value, onChange }: Props) {
+  const [books, setBooks] = useState<BookMeta[]>([]);
+  const [bookData, setBookData] = useState<MorphBook | null>(null);
+
+  useEffect(() => {
+    fetchBooks().then(setBooks).catch(console.error);
+  }, []);
+
+  useEffect(() => {
+    fetchBook(value.book).then(setBookData).catch(console.error);
+  }, [value.book]);
+
+  const currentBook = books.find((b) => b.code === value.book);
+  const chapterCount = currentBook?.chapters ?? 1;
+
+  function verseCount(chapter: number): number {
+    if (!bookData) return 1;
+    const ch = bookData[String(chapter)];
+    return ch ? Object.keys(ch).length : 1;
+  }
+
+  function handleBookChange(code: string) {
+    onChange({ book: code, startChapter: 1, startVerse: 1, endChapter: 1, endVerse: 1 });
+  }
+
+  function handleStartChapterChange(ch: number) {
+    const newEndCh = ch > value.endChapter ? ch : value.endChapter;
+    const newEndVs =
+      ch > value.endChapter
+        ? verseCount(ch)
+        : newEndCh === ch && value.endVerse < 1
+          ? 1
+          : value.endVerse;
+    onChange({
+      ...value,
+      startChapter: ch,
+      startVerse: 1,
+      endChapter: newEndCh,
+      endVerse: newEndVs,
+    });
+  }
+
+  function handleStartVerseChange(vs: number) {
+    const isSameChapter = value.startChapter === value.endChapter;
+    const newEndVs = isSameChapter && value.endVerse < vs ? vs : value.endVerse;
+    onChange({ ...value, startVerse: vs, endVerse: newEndVs });
+  }
+
+  function handleEndChapterChange(ch: number) {
+    const newEndVs = verseCount(ch);
+    onChange({ ...value, endChapter: ch, endVerse: newEndVs });
+  }
+
+  function handleEndVerseChange(vs: number) {
+    onChange({ ...value, endVerse: vs });
+  }
+
+  const startVerseMax = verseCount(value.startChapter);
+  const endVerseMax = verseCount(value.endChapter);
+  const endVerseMin = value.startChapter === value.endChapter ? value.startVerse : 1;
+
+  const selectClass =
+    'w-full rounded-lg border border-bg-card bg-bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] appearance-none';
+  const labelClass = 'block text-xs font-semibold uppercase tracking-wide text-text-muted mb-1';
+
+  return (
+    <div className="space-y-4">
+      {/* Book */}
+      <div>
+        <label className={labelClass}>Book</label>
+        <select
+          value={value.book}
+          onChange={(e) => handleBookChange(e.target.value)}
+          className={selectClass}
+        >
+          {books.length === 0
+            ? GNT_BOOKS.map((b) => (
+                <option key={b.code} value={b.code}>
+                  {b.name}
+                </option>
+              ))
+            : books.map((b) => (
+                <option key={b.code} value={b.code}>
+                  {b.name}
+                </option>
+              ))}
+        </select>
+      </div>
+
+      {/* Start */}
+      <div>
+        <p className={labelClass}>Start</p>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="block text-xs text-text-muted mb-1">Chapter</label>
+            <select
+              value={value.startChapter}
+              onChange={(e) => handleStartChapterChange(Number(e.target.value))}
+              className={selectClass}
+            >
+              {Array.from({ length: chapterCount }, (_, i) => i + 1).map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex-1">
+            <label className="block text-xs text-text-muted mb-1">Verse</label>
+            <select
+              value={value.startVerse}
+              onChange={(e) => handleStartVerseChange(Number(e.target.value))}
+              className={selectClass}
+            >
+              {Array.from({ length: startVerseMax }, (_, i) => i + 1).map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* End */}
+      <div>
+        <p className={labelClass}>End</p>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="block text-xs text-text-muted mb-1">Chapter</label>
+            <select
+              value={value.endChapter}
+              onChange={(e) => handleEndChapterChange(Number(e.target.value))}
+              className={selectClass}
+            >
+              {Array.from({ length: chapterCount }, (_, i) => i + 1)
+                .filter((n) => n >= value.startChapter)
+                .map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+            </select>
+          </div>
+          <div className="flex-1">
+            <label className="block text-xs text-text-muted mb-1">Verse</label>
+            <select
+              value={value.endVerse}
+              onChange={(e) => handleEndVerseChange(Number(e.target.value))}
+              className={selectClass}
+            >
+              {Array.from({ length: endVerseMax }, (_, i) => i + 1)
+                .filter((n) => n >= endVerseMin)
+                .map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FocusPassageHub.tsx
+++ b/src/components/FocusPassageHub.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+import { type FocusPassage, loadFocusPassages } from '../data/focusPassages';
+import { fetchBooks } from '../data/morphgnt';
+import { formatPassageRef } from '../lib/passage-deck';
+import ErrorBoundary from './ErrorBoundary';
+import FocusPassageParsing from './FocusPassageParsing';
+import FocusPassageProgress from './FocusPassageProgress';
+import FocusPassageReader from './FocusPassageReader';
+import FocusPassageVocab from './FocusPassageVocab';
+
+type Tab = 'reader' | 'vocab' | 'parsing' | 'progress';
+
+const TABS: Array<{ id: Tab; label: string }> = [
+  { id: 'reader', label: 'Reader' },
+  { id: 'vocab', label: 'Vocab' },
+  { id: 'parsing', label: 'Parsing' },
+  { id: 'progress', label: 'Progress' },
+];
+
+function getInitialTab(): Tab {
+  if (typeof window === 'undefined') return 'reader';
+  const param = new URLSearchParams(window.location.search).get('tab');
+  return TABS.find((t) => t.id === param)?.id ?? 'reader';
+}
+
+function setTabInUrl(tab: Tab) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('tab', tab);
+  history.replaceState(null, '', url.toString());
+}
+
+function FocusPassageHubInner({ passageId }: { passageId: string }) {
+  const [passage, setPassage] = useState<FocusPassage | null>(null);
+  const [bookName, setBookName] = useState('');
+  const [tab, setTab] = useState<Tab>(getInitialTab);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    const passages = loadFocusPassages();
+    const found = passages.find((p) => p.id === passageId);
+    if (!found) {
+      setNotFound(true);
+      return;
+    }
+    setPassage(found);
+    fetchBooks()
+      .then((books) => {
+        const name = books.find((b) => b.code === found.book)?.name ?? found.book;
+        setBookName(name);
+      })
+      .catch(console.error);
+  }, [passageId]);
+
+  function handleTabChange(t: Tab) {
+    setTab(t);
+    setTabInUrl(t);
+  }
+
+  if (notFound) {
+    return (
+      <div className="text-center py-24 space-y-4">
+        <p className="text-lg text-text-muted">Passage not found.</p>
+        <a
+          href="/focus"
+          className="inline-block px-5 py-2.5 bg-[var(--color-accent)] text-white rounded-xl font-bold hover:opacity-90"
+        >
+          ← Back to Focus Passages
+        </a>
+      </div>
+    );
+  }
+
+  if (!passage) {
+    return <p className="text-text-muted text-center py-16">Loading…</p>;
+  }
+
+  const ref = bookName
+    ? formatPassageRef(
+        bookName,
+        passage.startChapter,
+        passage.startVerse,
+        passage.endChapter,
+        passage.endVerse,
+      )
+    : '';
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6">
+        <a href="/focus" className="text-xs text-text-muted hover:text-text mb-2 inline-block">
+          ← Focus Passages
+        </a>
+        <h1 className="text-2xl font-bold text-text">{passage.label ?? ref}</h1>
+        {passage.label && ref && <p className="text-sm text-text-muted mt-0.5">{ref}</p>}
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-gray-200 mb-6">
+        {TABS.map(({ id, label }) => (
+          <button
+            key={id}
+            onClick={() => handleTabChange(id)}
+            className={[
+              'px-4 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors',
+              tab === id
+                ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+                : 'border-transparent text-text-muted hover:text-text',
+            ].join(' ')}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {tab === 'reader' && <FocusPassageReader passage={passage} />}
+      {tab === 'vocab' && <FocusPassageVocab passage={passage} />}
+      {tab === 'parsing' && <FocusPassageParsing passage={passage} bookName={bookName} />}
+      {tab === 'progress' && <FocusPassageProgress passage={passage} />}
+    </div>
+  );
+}
+
+export default function FocusPassageHub({ passageId }: { passageId: string }) {
+  return (
+    <ErrorBoundary component="FocusPassageHub">
+      <FocusPassageHubInner passageId={passageId} />
+    </ErrorBoundary>
+  );
+}

--- a/src/components/FocusPassageList.tsx
+++ b/src/components/FocusPassageList.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  deletePassage,
+  type FocusPassage,
+  getParseGrade,
+  loadFocusPassages,
+  saveFocusPassages,
+} from '../data/focusPassages';
+import { type BookMeta, fetchBooks } from '../data/morphgnt';
+import { formatPassageRef } from '../lib/passage-deck';
+import ErrorBoundary from './ErrorBoundary';
+
+function gradeColor(grade: string): string {
+  if (grade === 'A') return 'text-green-600';
+  if (grade === 'B') return 'text-teal-600';
+  if (grade === 'C') return 'text-amber-600';
+  if (grade === 'D' || grade === 'E') return 'text-red-600';
+  return 'text-text-muted';
+}
+
+function PassageCard({
+  passage,
+  bookName,
+  onDelete,
+  onRename,
+}: {
+  passage: FocusPassage;
+  bookName: string;
+  onDelete: () => void;
+  onRename: (label: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(passage.label ?? '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const grade = getParseGrade(passage.id);
+
+  const ref = formatPassageRef(
+    bookName,
+    passage.startChapter,
+    passage.startVerse,
+    passage.endChapter,
+    passage.endVerse,
+  );
+
+  const displayTitle = passage.label ?? ref;
+
+  function startEditing() {
+    setDraft(passage.label ?? '');
+    setEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  function commitRename() {
+    setEditing(false);
+    onRename(draft.trim());
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') commitRename();
+    if (e.key === 'Escape') setEditing(false);
+  }
+
+  function handleDelete(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (confirm(`Delete "${displayTitle}"? This cannot be undone.`)) {
+      onDelete();
+    }
+  }
+
+  function handlePencilClick(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    startEditing();
+  }
+
+  const createdDate = new Date(passage.createdAt).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return (
+    <a
+      href={`/focus/${passage.id}`}
+      className="group block bg-bg-card rounded-2xl shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden border border-white hover:-translate-y-0.5"
+    >
+      <div className="h-1.5 w-full" style={{ background: 'var(--color-accent)' }} />
+
+      <div className="p-5">
+        {/* Title row */}
+        <div className="flex items-start justify-between gap-2 mb-1">
+          {editing ? (
+            <input
+              ref={inputRef}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={handleKeyDown}
+              onClick={(e) => e.preventDefault()}
+              className="flex-1 text-base font-bold rounded px-1 border border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)] bg-bg"
+            />
+          ) : (
+            <span className="text-base font-bold text-text leading-tight">{displayTitle}</span>
+          )}
+
+          <div className="flex gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+            <button
+              onClick={handlePencilClick}
+              aria-label="Rename"
+              className="p-1 rounded hover:bg-gray-100 text-text-muted hover:text-text transition-colors"
+            >
+              ✏
+            </button>
+            <button
+              onClick={handleDelete}
+              aria-label="Delete"
+              className="p-1 rounded hover:bg-red-50 text-text-muted hover:text-red-600 transition-colors"
+            >
+              🗑
+            </button>
+          </div>
+        </div>
+
+        {/* Reference (when label is set) */}
+        {passage.label && <p className="text-xs text-text-muted mb-2">{ref}</p>}
+
+        {/* Stats row */}
+        <div className="flex items-center gap-4 mt-3 text-xs text-text-muted">
+          <span>
+            Grade: <strong className={gradeColor(grade)}>{grade}</strong>
+          </span>
+          <span className="text-text-muted/40">·</span>
+          <span>Added {createdDate}</span>
+        </div>
+      </div>
+
+      <div
+        className="px-5 pb-4 text-xs font-semibold flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+        style={{ color: 'var(--color-accent)' }}
+      >
+        Open →
+      </div>
+    </a>
+  );
+}
+
+function FocusPassageListInner() {
+  const [passages, setPassages] = useState<FocusPassage[]>(() => loadFocusPassages());
+  const [books, setBooks] = useState<BookMeta[]>([]);
+
+  useEffect(() => {
+    fetchBooks().then(setBooks).catch(console.error);
+  }, []);
+
+  function getBookName(code: string): string {
+    return books.find((b) => b.code === code)?.name ?? code;
+  }
+
+  function handleDelete(id: string) {
+    deletePassage(id);
+    setPassages((prev) => prev.filter((p) => p.id !== id));
+  }
+
+  function handleRename(id: string, label: string) {
+    const updated = passages.map((p) => (p.id === id ? { ...p, label: label || undefined } : p));
+    saveFocusPassages(updated);
+    setPassages(updated);
+  }
+
+  if (passages.length === 0) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold text-text">Focus Passages</h1>
+            <p className="text-text-muted text-sm mt-1">
+              Pin a verse range and master it through vocab, parsing, and reading.
+            </p>
+          </div>
+          <a
+            href="/focus/new"
+            className="px-4 py-2 bg-[var(--color-accent)] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity"
+          >
+            New Passage
+          </a>
+        </div>
+
+        <div className="text-center py-24 space-y-4">
+          <p
+            className="text-5xl opacity-20 select-none"
+            style={{ fontFamily: 'var(--font-greek)' }}
+            aria-hidden="true"
+          >
+            Αα
+          </p>
+          <p className="text-lg text-text-muted">No focus passages yet.</p>
+          <a
+            href="/focus/new"
+            className="inline-block px-5 py-2.5 bg-[var(--color-accent)] text-white rounded-xl font-bold hover:opacity-90 transition-opacity"
+          >
+            Create your first →
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold text-text">Focus Passages</h1>
+          <p className="text-text-muted text-sm mt-1">
+            {passages.length} passage{passages.length !== 1 ? 's' : ''} saved
+          </p>
+        </div>
+        <a
+          href="/focus/new"
+          className="px-4 py-2 bg-[var(--color-accent)] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity"
+        >
+          New Passage
+        </a>
+      </div>
+
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {passages.map((p) => (
+          <PassageCard
+            key={p.id}
+            passage={p}
+            bookName={getBookName(p.book)}
+            onDelete={() => handleDelete(p.id)}
+            onRename={(label) => handleRename(p.id, label)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function FocusPassageList() {
+  return (
+    <ErrorBoundary component="FocusPassageList">
+      <FocusPassageListInner />
+    </ErrorBoundary>
+  );
+}

--- a/src/components/FocusPassageNew.tsx
+++ b/src/components/FocusPassageNew.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react';
+import {
+  type FocusPassage,
+  generateId,
+  loadFocusPassages,
+  saveFocusPassages,
+} from '../data/focusPassages';
+import { type BookMeta, fetchBook, fetchBooks } from '../data/morphgnt';
+import { vocabulary } from '../data/vocabulary';
+import { extractVerbsMultiChapter } from '../lib/gnt-parse';
+import { buildVocabMap, extractPassageLemmas, formatPassageRef } from '../lib/passage-deck';
+import CrossChapterSelector, {
+  type CrossChapterRange,
+  DEFAULT_CROSS_CHAPTER_RANGE,
+} from './CrossChapterSelector';
+import ErrorBoundary from './ErrorBoundary';
+
+type Step = 'select' | 'preview' | 'confirm';
+
+function FocusPassageNewInner() {
+  const [step, setStep] = useState<Step>('select');
+  const [range, setRange] = useState<CrossChapterRange>(DEFAULT_CROSS_CHAPTER_RANGE);
+  const [label, setLabel] = useState('');
+  const [books, setBooks] = useState<BookMeta[]>([]);
+  const [preview, setPreview] = useState<{
+    lemmaCount: number;
+    verbCount: number;
+    snippet: string;
+    bookName: string;
+  } | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+
+  useEffect(() => {
+    fetchBooks().then(setBooks).catch(console.error);
+  }, []);
+
+  function bookName(): string {
+    return books.find((b) => b.code === range.book)?.name ?? range.book;
+  }
+
+  function passageRef(): string {
+    return formatPassageRef(
+      bookName(),
+      range.startChapter,
+      range.startVerse,
+      range.endChapter,
+      range.endVerse,
+    );
+  }
+
+  async function handlePreview() {
+    setLoadingPreview(true);
+    try {
+      const bookData = await fetchBook(range.book);
+      const name = books.find((b) => b.code === range.book)?.name ?? range.book;
+      const vocabMap = buildVocabMap(vocabulary);
+      const lemmas = extractPassageLemmas(
+        bookData,
+        range.startChapter,
+        range.startVerse,
+        range.endChapter,
+        range.endVerse,
+        vocabMap,
+      );
+      const verbs = extractVerbsMultiChapter(
+        bookData,
+        range.startChapter,
+        range.startVerse,
+        range.endChapter,
+        range.endVerse,
+        name,
+      );
+
+      // Build a short text snippet from the first few words of the first verse
+      const firstChapter = bookData[String(range.startChapter)];
+      const firstVerse = firstChapter?.[String(range.startVerse)];
+      const snippet = firstVerse
+        ? firstVerse
+            .slice(0, 8)
+            .map((w) => w.text)
+            .join(' ') + (firstVerse.length > 8 ? '…' : '')
+        : '';
+
+      setPreview({ lemmaCount: lemmas.length, verbCount: verbs.length, snippet, bookName: name });
+      setStep('preview');
+    } catch {
+      // stay on select step; user can try again
+    } finally {
+      setLoadingPreview(false);
+    }
+  }
+
+  function handleConfirm() {
+    if (!preview) return;
+    const newPassage: FocusPassage = {
+      id: generateId(),
+      label: label.trim() || undefined,
+      book: range.book,
+      startChapter: range.startChapter,
+      startVerse: range.startVerse,
+      endChapter: range.endChapter,
+      endVerse: range.endVerse,
+      createdAt: new Date().toISOString(),
+    };
+    saveFocusPassages([...loadFocusPassages(), newPassage]);
+    window.location.href = `/focus/${newPassage.id}`;
+  }
+
+  const ref = passageRef();
+
+  if (step === 'select') {
+    return (
+      <div className="max-w-lg mx-auto space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold text-text mb-1">New Focus Passage</h1>
+          <p className="text-text-muted text-sm">
+            Choose a verse range to study deeply — vocab, parsing, and reading in one place.
+          </p>
+        </div>
+
+        <CrossChapterSelector value={range} onChange={setRange} />
+
+        <button
+          onClick={handlePreview}
+          disabled={loadingPreview}
+          className="w-full py-3 rounded-xl text-base font-bold bg-[var(--color-accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+        >
+          {loadingPreview ? 'Loading…' : 'Preview Passage →'}
+        </button>
+      </div>
+    );
+  }
+
+  if (step === 'preview' && preview) {
+    return (
+      <div className="max-w-lg mx-auto space-y-8">
+        <div>
+          <button
+            onClick={() => setStep('select')}
+            className="text-sm text-text-muted hover:text-text mb-4 inline-flex items-center gap-1"
+          >
+            ← Back
+          </button>
+          <h1 className="text-2xl font-bold text-text mb-1">{ref}</h1>
+          {preview.snippet && (
+            <p
+              className="mt-2 text-text-muted leading-relaxed"
+              style={{ fontFamily: 'var(--font-greek)', fontSize: '1.1rem' }}
+            >
+              {preview.snippet}
+            </p>
+          )}
+        </div>
+
+        <div className="bg-bg-card rounded-2xl border border-indigo-100 p-5 space-y-3">
+          <div className="flex justify-between text-sm">
+            <span className="text-text-muted">Vocabulary words</span>
+            <span className="font-semibold text-text">{preview.lemmaCount}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-text-muted">Verb forms</span>
+            <span className="font-semibold text-text">{preview.verbCount}</span>
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-semibold uppercase tracking-wide text-text-muted mb-2">
+            Name (optional)
+          </label>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleConfirm();
+            }}
+            placeholder={`e.g. "${ref}"`}
+            className="w-full rounded-lg border border-bg-card bg-bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+          />
+        </div>
+
+        <button
+          onClick={handleConfirm}
+          className="w-full py-3 rounded-xl text-base font-bold bg-[var(--color-accent)] text-white hover:opacity-90 transition-opacity"
+        >
+          Create Focus Passage
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export default function FocusPassageNew() {
+  return (
+    <ErrorBoundary component="FocusPassageNew">
+      <FocusPassageNewInner />
+    </ErrorBoundary>
+  );
+}

--- a/src/components/FocusPassageParsing.tsx
+++ b/src/components/FocusPassageParsing.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useState } from 'react';
+import type { FocusPassage } from '../data/focusPassages';
+import { recordParseSession } from '../data/focusPassages';
+import { fetchBook, fetchBooks } from '../data/morphgnt';
+import {
+  deduplicateByLemma,
+  emptyGNTAnswer,
+  extractVerbsMultiChapter,
+  filterMissedItems,
+  type GNTParseAnswer,
+  type GNTParseItem,
+  type GNTParseResult,
+  gradeGNTAnswer,
+  sampleVerbs,
+} from '../lib/gnt-parse';
+import { formatPassageRef } from '../lib/passage-deck';
+import GNTFeedback from './GNTFeedback';
+import GNTParseQuestion from './GNTParseQuestion';
+import type { SessionResults } from './ParseResults';
+import ParseResults from './ParseResults';
+
+type Phase = 'select' | 'question' | 'feedback' | 'results';
+
+const SESSION_LENGTHS = [10, 20, 30, 'all'] as const;
+type SessionLength = (typeof SESSION_LENGTHS)[number];
+const SESSION_LABELS: Record<string, string> = { 10: '10', 20: '20', 30: '30', all: 'All' };
+
+interface Props {
+  passage: FocusPassage;
+  bookName: string;
+}
+
+export default function FocusPassageParsing({ passage, bookName }: Props) {
+  const [verbCount, setVerbCount] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sessionLength, setSessionLength] = useState<SessionLength>(20);
+  const [skipRepeated, setSkipRepeated] = useState(false);
+
+  const [phase, setPhase] = useState<Phase>('select');
+  const [session, setSession] = useState<GNTParseItem[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answer, setAnswer] = useState<GNTParseAnswer>(emptyGNTAnswer());
+  const [results, setResults] = useState<GNTParseResult[]>([]);
+  const [currentResult, setCurrentResult] = useState<GNTParseResult | null>(null);
+  const [isReview, setIsReview] = useState(false);
+  const [allItems, setAllItems] = useState<GNTParseItem[]>([]);
+
+  const ref = formatPassageRef(
+    bookName,
+    passage.startChapter,
+    passage.startVerse,
+    passage.endChapter,
+    passage.endVerse,
+  );
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([fetchBook(passage.book), fetchBooks()])
+      .then(([bookData, books]) => {
+        const name = books.find((b) => b.code === passage.book)?.name ?? bookName;
+        let verbs = extractVerbsMultiChapter(
+          bookData,
+          passage.startChapter,
+          passage.startVerse,
+          passage.endChapter,
+          passage.endVerse,
+          name,
+        );
+        if (skipRepeated) verbs = deduplicateByLemma(verbs);
+        setAllItems(verbs);
+        setVerbCount(verbs.length);
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [
+    passage.book,
+    passage.startChapter,
+    passage.startVerse,
+    passage.endChapter,
+    passage.endVerse,
+    bookName,
+    skipRepeated,
+  ]);
+
+  function handleStart() {
+    const items = [...allItems];
+    const count = sessionLength === 'all' ? items.length : sessionLength;
+    const sampled = sampleVerbs(items, count);
+    if (sampled.length === 0) return;
+    setSession(sampled);
+    setCurrentIndex(0);
+    setResults([]);
+    setAnswer(emptyGNTAnswer());
+    setCurrentResult(null);
+    setIsReview(false);
+    setPhase('question');
+  }
+
+  function handleReviewMissed() {
+    const missed = filterMissedItems(session, results);
+    if (missed.length === 0) return;
+    setSession(missed);
+    setCurrentIndex(0);
+    setResults([]);
+    setAnswer(emptyGNTAnswer());
+    setCurrentResult(null);
+    setIsReview(true);
+    setPhase('question');
+  }
+
+  function handleSubmit() {
+    const result = gradeGNTAnswer(session[currentIndex], answer);
+    setCurrentResult(result);
+    setPhase('feedback');
+  }
+
+  function handleNext() {
+    if (!currentResult) return;
+    const updated = [...results, currentResult];
+    setResults(updated);
+    if (currentIndex + 1 >= session.length) {
+      // Persist cumulative parse history at session end
+      const correct = updated.filter((r) => r.allCorrect).length;
+      recordParseSession(passage.id, correct, updated.length);
+      setPhase('results');
+    } else {
+      setCurrentIndex((i) => i + 1);
+      setAnswer(emptyGNTAnswer());
+      setCurrentResult(null);
+      setPhase('question');
+    }
+  }
+
+  const sessionResults: SessionResults = {
+    results: results.map((r) => ({
+      tense: r.tense,
+      voice: r.voice,
+      mood: r.mood,
+      person: r.person ?? true,
+      number: r.number ?? true,
+      allCorrect: r.allCorrect,
+    })),
+    total: session.length,
+  };
+
+  if (phase === 'question' && session[currentIndex]) {
+    return (
+      <div>
+        <p className="text-center text-xs text-text-muted mb-4">{ref}</p>
+        <GNTParseQuestion
+          item={session[currentIndex]}
+          index={currentIndex}
+          total={session.length}
+          answer={answer}
+          onChange={setAnswer}
+          onSubmit={handleSubmit}
+        />
+      </div>
+    );
+  }
+
+  if (phase === 'feedback' && session[currentIndex] && currentResult) {
+    return (
+      <div>
+        <p className="text-center text-xs text-text-muted mb-4">{ref}</p>
+        <GNTFeedback
+          item={session[currentIndex]}
+          answer={answer}
+          result={currentResult}
+          onNext={handleNext}
+          isLast={currentIndex + 1 >= session.length}
+        />
+      </div>
+    );
+  }
+
+  if (phase === 'results') {
+    return (
+      <ParseResults
+        sessionResults={sessionResults}
+        onRetry={handleStart}
+        onChangeSettings={() => {
+          setPhase('select');
+          setSession([]);
+          setResults([]);
+          setCurrentIndex(0);
+          setIsReview(false);
+        }}
+        onReviewMissed={handleReviewMissed}
+        isReview={isReview}
+      />
+    );
+  }
+
+  // Select phase
+  return (
+    <div className="max-w-lg mx-auto space-y-8">
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-1">
+          Passage
+        </h2>
+        <p className="text-base font-semibold text-text">{ref}</p>
+        <p className="mt-1 text-xs text-text-muted h-4">
+          {loading && 'Loading…'}
+          {!loading && verbCount === 0 && 'No verbs found in this passage.'}
+          {!loading &&
+            verbCount !== null &&
+            verbCount > 0 &&
+            `${verbCount} verb form${verbCount !== 1 ? 's' : ''} in this passage`}
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-3">
+          Forms per session
+        </h2>
+        <div className="flex gap-2">
+          {SESSION_LENGTHS.map((n) => (
+            <button
+              key={n}
+              onClick={() => setSessionLength(n)}
+              disabled={n !== 'all' && verbCount !== null && verbCount < Number(n)}
+              className={[
+                'px-4 py-2 rounded-lg text-sm font-semibold border-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed',
+                sessionLength === n
+                  ? 'border-[var(--color-accent)] bg-[var(--color-accent)] text-white'
+                  : 'border-bg-card bg-bg-card text-text-muted hover:border-[var(--color-accent)]',
+              ].join(' ')}
+            >
+              {SESSION_LABELS[n]}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <label className="flex items-center gap-2 cursor-pointer select-none w-fit">
+        <input
+          type="checkbox"
+          checked={skipRepeated}
+          onChange={(e) => setSkipRepeated(e.target.checked)}
+          className="w-4 h-4 rounded accent-[var(--color-accent)]"
+        />
+        <span className="text-sm text-text">Skip repeat verbs</span>
+      </label>
+
+      <button
+        onClick={handleStart}
+        disabled={loading || !verbCount || verbCount === 0}
+        className={[
+          'w-full py-3 rounded-xl text-base font-bold transition-colors',
+          !loading && verbCount && verbCount > 0
+            ? 'bg-[var(--color-accent)] text-white hover:opacity-90'
+            : 'bg-bg-card text-text-muted cursor-not-allowed',
+        ].join(' ')}
+      >
+        {loading ? 'Loading…' : 'Start Parsing'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/FocusPassageProgress.tsx
+++ b/src/components/FocusPassageProgress.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react';
+import {
+  type FocusPassage,
+  getParseGrade,
+  getVocabMaturityBreakdown,
+  loadParseHistoryStore,
+  type MaturityBreakdown,
+  type ParseGrade,
+} from '../data/focusPassages';
+import { fetchBook } from '../data/morphgnt';
+import { loadSRSStore } from '../data/srs';
+import { vocabulary } from '../data/vocabulary';
+import { buildVocabMap, extractPassageLemmas } from '../lib/passage-deck';
+
+function gradeColor(grade: ParseGrade): string {
+  if (grade === 'A') return '#059669';
+  if (grade === 'B') return '#0d9488';
+  if (grade === 'C') return '#d97706';
+  if (grade === 'D' || grade === 'E') return '#dc2626';
+  return 'var(--color-text-muted)';
+}
+
+export default function FocusPassageProgress({ passage }: { passage: FocusPassage }) {
+  const [breakdown, setBreakdown] = useState<MaturityBreakdown | null>(null);
+  const [lemmaCount, setLemmaCount] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const grade = getParseGrade(passage.id);
+  const parseHistory = loadParseHistoryStore()[passage.id];
+
+  useEffect(() => {
+    setLoading(true);
+    fetchBook(passage.book)
+      .then((bookData) => {
+        const srsStore = loadSRSStore();
+        const vocabMap = buildVocabMap(vocabulary);
+        const lemmas = extractPassageLemmas(
+          bookData,
+          passage.startChapter,
+          passage.startVerse,
+          passage.endChapter,
+          passage.endVerse,
+          vocabMap,
+        );
+        setLemmaCount(lemmas.length);
+        setBreakdown(getVocabMaturityBreakdown(lemmas, srsStore));
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [
+    passage.book,
+    passage.startChapter,
+    passage.startVerse,
+    passage.endChapter,
+    passage.endVerse,
+  ]);
+
+  if (loading) {
+    return <p className="text-text-muted text-center py-16">Loading progress…</p>;
+  }
+
+  const totalWords = lemmaCount ?? 0;
+
+  const maturityBars = breakdown
+    ? [
+        { label: 'Mature', count: breakdown.mature, color: '#059669' },
+        { label: 'Familiar', count: breakdown.familiar, color: '#0d9488' },
+        { label: 'Learning', count: breakdown.learning, color: '#d97706' },
+        { label: 'New', count: breakdown.unseen, color: '#94a3b8' },
+      ]
+    : [];
+
+  return (
+    <div className="max-w-lg space-y-8">
+      {/* Vocab maturity */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-4">
+          Vocabulary Maturity
+        </h2>
+
+        {breakdown && totalWords > 0 ? (
+          <>
+            {/* Proportional bar */}
+            <div className="flex rounded-full overflow-hidden h-3 mb-4 bg-gray-100">
+              {maturityBars
+                .filter((b) => b.count > 0)
+                .map((b) => (
+                  <div
+                    key={b.label}
+                    style={{
+                      width: `${(b.count / totalWords) * 100}%`,
+                      background: b.color,
+                    }}
+                    title={`${b.label}: ${b.count}`}
+                  />
+                ))}
+            </div>
+
+            {/* Legend */}
+            <div className="grid grid-cols-2 gap-3">
+              {maturityBars.map((b) => (
+                <div key={b.label} className="flex items-center gap-2">
+                  <span className="w-3 h-3 rounded-full shrink-0" style={{ background: b.color }} />
+                  <span className="text-sm text-text-muted">
+                    {b.label}: <strong className="text-text">{b.count}</strong>
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            <p className="mt-3 text-xs text-text-muted">
+              {totalWords} unique vocab word{totalWords !== 1 ? 's' : ''} in this passage
+            </p>
+          </>
+        ) : (
+          <p className="text-text-muted text-sm">No vocabulary data yet.</p>
+        )}
+      </section>
+
+      {/* Parse grade */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted mb-4">
+          Parse Grade
+        </h2>
+
+        <div className="flex items-center gap-4">
+          <span
+            className="text-6xl font-extrabold leading-none"
+            style={{ color: gradeColor(grade) }}
+          >
+            {grade}
+          </span>
+
+          {parseHistory && parseHistory.total > 0 ? (
+            <div className="text-sm text-text-muted space-y-0.5">
+              <p>
+                <strong className="text-text">{parseHistory.correct}</strong> correct out of{' '}
+                <strong className="text-text">{parseHistory.total}</strong>
+              </p>
+              <p>
+                {Math.round((parseHistory.correct / parseHistory.total) * 100)}% accuracy (
+                cumulative)
+              </p>
+            </div>
+          ) : (
+            <p className="text-sm text-text-muted">No parse sessions yet.</p>
+          )}
+        </div>
+
+        {grade !== '—' && (
+          <div className="mt-3 text-xs text-text-muted">
+            <span className="font-semibold">A</span> ≥90% · <span className="font-semibold">B</span>{' '}
+            75–89% · <span className="font-semibold">C</span> 60–74% ·{' '}
+            <span className="font-semibold">D</span> 45–59% ·{' '}
+            <span className="font-semibold">E</span> &lt;45%
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/FocusPassageReader.tsx
+++ b/src/components/FocusPassageReader.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { FocusPassage } from '../data/focusPassages';
+import { fetchBook, type MorphBook, type MorphWord } from '../data/morphgnt';
+import { getStudiedLemmas } from '../data/srs';
+import { type ActiveWord, WordPopup, WordToken } from './GreekText';
+
+interface VerseDisplayProps {
+  verseNum: number;
+  words: MorphWord[];
+  showGlosses: boolean;
+  studiedLemmas: Set<string>;
+  activeWord: MorphWord | null;
+  onActivate: (word: MorphWord, rect: DOMRect) => void;
+}
+
+function VerseDisplay({
+  verseNum,
+  words,
+  showGlosses,
+  studiedLemmas,
+  activeWord,
+  onActivate,
+}: VerseDisplayProps) {
+  return (
+    <span id={`fp-verse-${verseNum}`} className="inline">
+      <sup className="text-text-muted text-xs font-normal select-none mr-0.5 relative top-0">
+        {verseNum}
+      </sup>
+      {words.map((word, i) => (
+        <WordToken
+          key={i}
+          word={word}
+          showGloss={showGlosses}
+          studied={studiedLemmas.has(word.lemma)}
+          onActivate={onActivate}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default function FocusPassageReader({ passage }: { passage: FocusPassage }) {
+  const [bookData, setBookData] = useState<MorphBook | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showGlosses, setShowGlosses] = useState(false);
+  const [activeWord, setActiveWord] = useState<ActiveWord | null>(null);
+  const [studiedLemmas] = useState<Set<string>>(() => {
+    try {
+      return getStudiedLemmas();
+    } catch {
+      return new Set();
+    }
+  });
+
+  useEffect(() => {
+    setLoading(true);
+    fetchBook(passage.book)
+      .then(setBookData)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [passage.book]);
+
+  const handleActivate = useCallback((word: MorphWord, rect: DOMRect) => {
+    setActiveWord((prev) => (prev?.word === word ? null : { word, rect }));
+  }, []);
+
+  const handleClose = useCallback(() => setActiveWord(null), []);
+
+  if (loading) {
+    return <p className="text-text-muted text-center py-16">Loading…</p>;
+  }
+
+  if (!bookData) {
+    return <p className="text-text-muted text-center py-16">Could not load passage.</p>;
+  }
+
+  // Collect verses in the passage range
+  const verseRows: Array<{ chapter: number; verse: number; words: MorphWord[] }> = [];
+
+  const chapters = Object.keys(bookData)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  for (const ch of chapters) {
+    if (ch < passage.startChapter || ch > passage.endChapter) continue;
+    const chData = bookData[String(ch)];
+    const verses = Object.keys(chData)
+      .map(Number)
+      .sort((a, b) => a - b);
+    for (const vs of verses) {
+      if (ch === passage.startChapter && vs < passage.startVerse) continue;
+      if (ch === passage.endChapter && vs > passage.endVerse) continue;
+      const words = chData[String(vs)];
+      if (words) verseRows.push({ chapter: ch, verse: vs, words });
+    }
+  }
+
+  const isMultiChapter = passage.startChapter !== passage.endChapter;
+
+  return (
+    <div onClick={handleClose}>
+      {/* Toolbar */}
+      <div className="flex items-center justify-between mb-6" onClick={(e) => e.stopPropagation()}>
+        <div />
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowGlosses((g) => !g);
+          }}
+          className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+            showGlosses
+              ? 'border-primary bg-primary text-white'
+              : 'border-gray-200 text-text-muted hover:border-gray-300 hover:text-text'
+          }`}
+        >
+          {showGlosses ? 'Hide glosses' : 'Show glosses'}
+        </button>
+      </div>
+
+      {/* Text */}
+      <div
+        className="leading-relaxed max-w-2xl"
+        style={{ wordSpacing: showGlosses ? '0.3em' : undefined }}
+      >
+        {verseRows.map(({ chapter, verse, words }) => (
+          <span key={`${chapter}-${verse}`}>
+            {isMultiChapter && verse === 1 && (
+              <span className="block text-xs font-semibold text-text-muted uppercase tracking-wide mt-4 mb-1 select-none">
+                Chapter {chapter}
+              </span>
+            )}
+            <VerseDisplay
+              verseNum={verse}
+              words={words}
+              showGlosses={showGlosses}
+              studiedLemmas={studiedLemmas}
+              activeWord={activeWord?.word ?? null}
+              onActivate={handleActivate}
+            />
+          </span>
+        ))}
+      </div>
+
+      {studiedLemmas.size > 0 && (
+        <p className="text-text-muted text-xs mt-6 select-none">
+          <span className="underline decoration-accent/60 decoration-dotted underline-offset-2">
+            dotted underline
+          </span>{' '}
+          = word studied in Flashcards
+        </p>
+      )}
+
+      {activeWord && <WordPopup active={activeWord} onClose={handleClose} />}
+    </div>
+  );
+}

--- a/src/components/FocusPassageVocab.tsx
+++ b/src/components/FocusPassageVocab.tsx
@@ -1,0 +1,525 @@
+import posthog from 'posthog-js';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { FocusPassage } from '../data/focusPassages';
+import { fetchBook } from '../data/morphgnt';
+import {
+  isDue,
+  loadSRSStore,
+  loadStats,
+  newCard,
+  nextSRS,
+  normalizeKey,
+  recordReview,
+  type SRSCard,
+  STREAK_THRESHOLD,
+  saveSRSStore,
+  saveStats,
+} from '../data/srs';
+import { type VocabWord, vocabulary } from '../data/vocabulary';
+import { buildVocabMap, extractPassageLemmas } from '../lib/passage-deck';
+
+type StudyMode = 'srs' | 'all';
+type Direction = 'gr-en' | 'en-gr';
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function levenshtein(a: string, b: string): number {
+  const dp: number[] = Array.from({ length: a.length + 1 }, (_, i) => i);
+  for (let j = 1; j <= b.length; j++) {
+    let prev = dp[0];
+    dp[0] = j;
+    for (let i = 1; i <= a.length; i++) {
+      const tmp = dp[i];
+      dp[i] = a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[i - 1], dp[i]);
+      prev = tmp;
+    }
+  }
+  return dp[a.length];
+}
+
+function checkAnswer(input: string, gloss: string): boolean {
+  const norm = (s: string) => s.toLowerCase().replace(/[()]/g, '').trim();
+  const ans = norm(input);
+  if (!ans) return false;
+  const parts = gloss.split(/[,/]/).map(norm).filter(Boolean);
+  return parts.some(
+    (p) =>
+      p === ans ||
+      (ans.length >= 4 && p.startsWith(ans)) ||
+      (p.length > 3 && levenshtein(p, ans) <= 1),
+  );
+}
+
+function buildQueue(
+  vocab: VocabWord[],
+  mode: StudyMode,
+  store: Record<string, SRSCard>,
+): VocabWord[] {
+  if (mode === 'all') return shuffle(vocab);
+  const due: VocabWord[] = [];
+  const fresh: VocabWord[] = [];
+  for (const w of vocab) {
+    const c = store[normalizeKey(w.greek)];
+    if (!c) fresh.push(w);
+    else if (isDue(c)) due.push(w);
+  }
+  return [...shuffle(due), ...shuffle(fresh)];
+}
+
+export default function FocusPassageVocab({ passage }: { passage: FocusPassage }) {
+  const [passageVocab, setPassageVocab] = useState<VocabWord[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [srsStore, setSrsStore] = useState<Record<string, SRSCard>>(() => loadSRSStore());
+  const [stats, setStats] = useState(() => loadStats());
+  const srsStoreRef = useRef(srsStore);
+  srsStoreRef.current = srsStore;
+
+  const [studyMode, setStudyMode] = useState<StudyMode>('srs');
+  const [direction, setDirection] = useState<Direction>('gr-en');
+  const [answerMode, setAnswerMode] = useState<'flip' | 'type'>('flip');
+
+  const [queue, setQueue] = useState<VocabWord[]>([]);
+  const [index, setIndex] = useState(0);
+  const [flipped, setFlipped] = useState(false);
+  const [typedAnswer, setTypedAnswer] = useState('');
+  const [answerResult, setAnswerResult] = useState<'correct' | 'incorrect' | null>(null);
+  const [sessionScore, setSessionScore] = useState({ known: 0, learning: 0 });
+  const [sessionDone, setSessionDone] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Load passage vocab
+  useEffect(() => {
+    setLoading(true);
+    fetchBook(passage.book)
+      .then((bookData) => {
+        const vocabMap = buildVocabMap(vocabulary);
+        const lemmaKeys = extractPassageLemmas(
+          bookData,
+          passage.startChapter,
+          passage.startVerse,
+          passage.endChapter,
+          passage.endVerse,
+          vocabMap,
+        );
+        const keySet = new Set(lemmaKeys);
+        const filtered = vocabulary.filter((w) => keySet.has(normalizeKey(w.greek)));
+        setPassageVocab(filtered);
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [
+    passage.book,
+    passage.startChapter,
+    passage.startVerse,
+    passage.endChapter,
+    passage.endVerse,
+  ]);
+
+  const startSession = useCallback(() => {
+    if (passageVocab.length === 0) return;
+    const q = buildQueue(passageVocab, studyMode, srsStoreRef.current);
+    setQueue(q);
+    setIndex(0);
+    setFlipped(false);
+    setTypedAnswer('');
+    setAnswerResult(null);
+    setSessionScore({ known: 0, learning: 0 });
+    setSessionDone(false);
+    posthog.capture('focus_vocab_session_started', { deck_size: q.length });
+  }, [passageVocab, studyMode]);
+
+  useEffect(() => {
+    if (passageVocab.length > 0) startSession();
+  }, [passageVocab, startSession]);
+
+  const dueCount = useMemo(
+    () =>
+      passageVocab.filter((w) => {
+        const c = srsStore[normalizeKey(w.greek)];
+        return c ? isDue(c) : false;
+      }).length,
+    [passageVocab, srsStore],
+  );
+  const newCount = useMemo(
+    () => passageVocab.filter((w) => !srsStore[normalizeKey(w.greek)]).length,
+    [passageVocab, srsStore],
+  );
+
+  const card = queue[index];
+
+  const handleReview = useCallback(
+    (correct: boolean) => {
+      if (!card) return;
+      if (studyMode === 'srs') {
+        setSrsStore((prev) => {
+          const k = normalizeKey(card.greek);
+          const existing = prev[k] ?? newCard(k);
+          const updated = nextSRS(existing, correct ? 4 : 1);
+          const next = { ...prev, [k]: updated };
+          saveSRSStore(next);
+          return next;
+        });
+      }
+      setStats((prev) => {
+        const next = recordReview(prev, correct);
+        saveStats(next);
+        return next;
+      });
+      setSessionScore((s) => ({
+        known: s.known + (correct ? 1 : 0),
+        learning: s.learning + (correct ? 0 : 1),
+      }));
+      if (index + 1 < queue.length) {
+        setIndex((i) => i + 1);
+        setFlipped(false);
+        setTypedAnswer('');
+        setAnswerResult(null);
+      } else {
+        setSessionDone(true);
+      }
+    },
+    [card, studyMode, index, queue.length],
+  );
+
+  const handleFlip = useCallback(() => setFlipped((f) => !f), []);
+
+  const handleTypeSubmit = useCallback(() => {
+    if (!card || answerResult !== null) return;
+    const expected = direction === 'gr-en' ? card.gloss : card.greek;
+    const correct = checkAnswer(typedAnswer, expected);
+    setAnswerResult(correct ? 'correct' : 'incorrect');
+  }, [card, direction, typedAnswer, answerResult]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (sessionDone) return;
+      if (answerMode === 'flip') {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault();
+          handleFlip();
+        }
+        if (e.key === 'ArrowRight' && flipped) handleReview(true);
+        if (e.key === 'ArrowLeft' && flipped) handleReview(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [answerMode, flipped, sessionDone, handleFlip, handleReview]);
+
+  useEffect(() => {
+    if (answerMode === 'type' && !sessionDone) inputRef.current?.focus();
+  }, [answerMode, sessionDone]);
+
+  if (loading) {
+    return <p className="text-text-muted text-center py-16">Loading vocabulary…</p>;
+  }
+
+  if (passageVocab.length === 0) {
+    return (
+      <p className="text-text-muted text-center py-16">
+        No vocabulary words found in this passage.
+      </p>
+    );
+  }
+
+  const front = card ? (direction === 'gr-en' ? card.greek : card.gloss) : '';
+  const back = card ? (direction === 'gr-en' ? card.gloss : card.greek) : '';
+  const expectedAnswer = card ? (direction === 'gr-en' ? card.gloss : card.greek) : '';
+
+  if (sessionDone) {
+    const total = sessionScore.known + sessionScore.learning;
+    const pct = total > 0 ? Math.round((sessionScore.known / total) * 100) : 0;
+    return (
+      <div className="text-center space-y-4 py-12">
+        <div className="text-7xl font-bold" style={{ color: 'var(--color-grape)' }}>
+          {pct}%
+        </div>
+        <h2 className="text-2xl font-bold text-text">Session Complete</h2>
+        <p className="text-text-muted">
+          {sessionScore.known} got it · {sessionScore.learning} still learning
+        </p>
+        <button
+          onClick={startSession}
+          className="px-5 py-2.5 bg-grape text-white rounded-lg hover:opacity-90 font-semibold shadow-sm"
+        >
+          Study Again
+        </button>
+      </div>
+    );
+  }
+
+  if (!card) {
+    return (
+      <div className="text-center py-16 space-y-4">
+        <p className="text-text-muted">
+          {studyMode === 'srs'
+            ? 'No cards due — all caught up!'
+            : 'No cards match the current filters.'}
+        </p>
+        {studyMode === 'srs' && (
+          <button
+            onClick={() => setStudyMode('all')}
+            className="px-5 py-2.5 bg-grape text-white rounded-lg hover:opacity-90 font-semibold"
+          >
+            Study all anyway
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Controls */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex gap-1 bg-white border border-indigo-100 p-1 rounded-xl shadow-sm">
+          {(['srs', 'all'] as StudyMode[]).map((m) => (
+            <button
+              key={m}
+              onClick={() => setStudyMode(m)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-semibold transition-all ${
+                studyMode === m
+                  ? 'bg-grape text-white shadow-sm'
+                  : 'text-text-muted hover:text-text'
+              }`}
+            >
+              {m === 'srs' ? 'SRS Review' : 'Study All'}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex gap-1 bg-white border border-indigo-100 p-1 rounded-xl shadow-sm">
+            {(['gr-en', 'en-gr'] as Direction[]).map((d) => (
+              <button
+                key={d}
+                onClick={() => setDirection(d)}
+                className={`px-2.5 py-1 rounded-lg text-xs font-semibold transition-all ${
+                  direction === d
+                    ? 'bg-grape text-white shadow-sm'
+                    : 'text-text-muted hover:text-text'
+                }`}
+              >
+                {d === 'gr-en' ? 'Gr → En' : 'En → Gr'}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-1 bg-white border border-indigo-100 p-1 rounded-xl shadow-sm">
+            {(['flip', 'type'] as const).map((m) => (
+              <button
+                key={m}
+                onClick={() => setAnswerMode(m)}
+                className={`px-2.5 py-1 rounded-lg text-xs font-semibold transition-all ${
+                  answerMode === m
+                    ? 'bg-grape text-white shadow-sm'
+                    : 'text-text-muted hover:text-text'
+                }`}
+              >
+                {m === 'flip' ? 'Flip' : 'Type'}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="bg-bg-card rounded-2xl border-2 border-indigo-100 px-4 py-2.5 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-sm text-text-muted">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            {studyMode === 'srs' ? (
+              <>
+                <span>
+                  Due: <strong className="text-grape">{dueCount}</strong>
+                </span>
+                <span className="text-indigo-200">|</span>
+                <span>
+                  New: <strong className="text-primary">{newCount}</strong>
+                </span>
+                <span className="text-indigo-200">|</span>
+              </>
+            ) : (
+              <>
+                <span>
+                  Card:{' '}
+                  <strong className="text-grape">
+                    {index + 1}/{queue.length}
+                  </strong>
+                </span>
+                <span className="text-indigo-200">|</span>
+              </>
+            )}
+            <span>
+              Today:{' '}
+              <strong className="text-text">
+                {Math.min(stats.cardsStudiedToday, STREAK_THRESHOLD)}/{STREAK_THRESHOLD}
+              </strong>
+            </span>
+          </div>
+          <span className="text-xs shrink-0 font-medium">
+            <span className="text-jade">✓ {sessionScore.known}</span>
+            {' · '}
+            <span className="text-coral">✗ {sessionScore.learning}</span>
+          </span>
+        </div>
+      </div>
+
+      {/* Card */}
+      <div
+        onClick={answerMode === 'flip' && !flipped ? handleFlip : undefined}
+        className={`bg-bg-card rounded-2xl shadow-md border-2 border-indigo-100 px-4 py-6 sm:px-10 sm:py-8 text-center select-none min-h-[200px] flex flex-col items-center justify-center transition-all ${
+          answerMode === 'flip' && !flipped
+            ? 'cursor-pointer hover:shadow-lg hover:border-grape/30'
+            : ''
+        }`}
+      >
+        <p
+          className="leading-tight"
+          style={{
+            fontSize: direction === 'gr-en' ? '3rem' : '1.8rem',
+            fontFamily: direction === 'gr-en' ? 'var(--font-greek)' : 'var(--font-sans)',
+            fontWeight: direction === 'gr-en' ? '700' : '600',
+            color: direction === 'gr-en' ? 'var(--color-greek)' : 'var(--color-text)',
+          }}
+        >
+          {front}
+        </p>
+        {direction === 'gr-en' && (
+          <p className="text-text-muted text-sm mt-2 uppercase tracking-wide text-xs">
+            {card.partOfSpeech}
+          </p>
+        )}
+
+        {answerMode === 'flip' && !flipped && (
+          <p className="text-text-muted/60 text-xs mt-6">
+            <span className="sm:hidden">tap to reveal</span>
+            <span className="hidden sm:inline">click or press space to reveal</span>
+          </p>
+        )}
+
+        {answerMode === 'flip' && flipped && (
+          <div className="mt-4 pt-4 border-t-2 border-indigo-50 w-full text-center">
+            <p
+              className="leading-tight"
+              style={{
+                fontSize: direction === 'en-gr' ? '3rem' : '1.8rem',
+                fontFamily: direction === 'en-gr' ? 'var(--font-greek)' : 'var(--font-sans)',
+                fontWeight: direction === 'en-gr' ? '700' : '600',
+                color: direction === 'en-gr' ? 'var(--color-greek)' : 'var(--color-text)',
+              }}
+            >
+              {back}
+            </p>
+          </div>
+        )}
+
+        {answerMode === 'type' && answerResult === null && (
+          <div className="mt-6 flex flex-col sm:flex-row gap-2 w-full max-w-sm">
+            <input
+              ref={inputRef}
+              type="text"
+              value={typedAnswer}
+              onChange={(e) => setTypedAnswer(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleTypeSubmit();
+              }}
+              placeholder={
+                direction === 'gr-en' ? 'Type the English gloss…' : 'Type the Greek word…'
+              }
+              className="flex-1 px-3 py-2.5 border-2 border-indigo-100 rounded-xl focus:border-grape focus:outline-none text-base sm:text-sm"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <button
+              onClick={handleTypeSubmit}
+              className="px-4 py-2.5 bg-grape text-white rounded-xl hover:opacity-90 text-sm font-semibold"
+            >
+              Check
+            </button>
+          </div>
+        )}
+
+        {answerMode === 'type' && answerResult !== null && (
+          <div
+            className={`mt-4 px-4 py-3 rounded-xl w-full max-w-sm text-center border-2 ${
+              answerResult === 'correct' ? 'bg-jade/5 border-jade/30' : 'bg-coral/5 border-coral/30'
+            }`}
+          >
+            {answerResult === 'correct' ? (
+              <p className="font-bold" style={{ color: 'var(--color-jade)' }}>
+                Correct!
+              </p>
+            ) : (
+              <>
+                <p className="font-bold" style={{ color: 'var(--color-coral)' }}>
+                  Not quite
+                </p>
+                <p className="text-text-muted text-sm mt-1">
+                  Answer: <span className="font-semibold text-text">{expectedAnswer}</span>
+                </p>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Action buttons */}
+      {answerMode === 'flip' && flipped && (
+        <div className="flex gap-3 sm:gap-4 sm:justify-center">
+          <button
+            onClick={() => handleReview(false)}
+            className="flex-1 sm:flex-none px-6 py-3 sm:py-2.5 bg-coral/10 border-2 border-coral/30 text-coral rounded-xl hover:bg-coral/20 font-semibold"
+          >
+            ← Still Learning
+          </button>
+          <button
+            onClick={() => handleReview(true)}
+            className="flex-1 sm:flex-none px-6 py-3 sm:py-2.5 bg-jade/10 border-2 border-jade/30 text-jade rounded-xl hover:bg-jade/20 font-semibold"
+          >
+            Got It →
+          </button>
+        </div>
+      )}
+
+      {answerMode === 'type' && answerResult !== null && (
+        <div className="flex gap-3 sm:gap-4 sm:justify-center">
+          {answerResult === 'incorrect' && (
+            <button
+              onClick={() => handleReview(false)}
+              className="flex-1 sm:flex-none px-6 py-3 sm:py-2.5 bg-coral/10 border-2 border-coral/30 text-coral rounded-xl hover:bg-coral/20 font-semibold"
+            >
+              ← Still Learning
+            </button>
+          )}
+          <button
+            onClick={() => handleReview(answerResult === 'correct')}
+            className={`flex-1 sm:flex-none px-6 py-3 sm:py-2.5 rounded-xl border-2 font-semibold ${
+              answerResult === 'correct'
+                ? 'bg-jade/10 border-jade/30 text-jade hover:bg-jade/20'
+                : 'bg-gray-100 border-gray-200 text-text hover:bg-gray-200'
+            }`}
+          >
+            {answerResult === 'correct' ? 'Got It →' : 'Next →'}
+          </button>
+        </div>
+      )}
+
+      <div className="flex justify-center pt-1">
+        <button
+          onClick={startSession}
+          className="text-sm text-text-muted hover:text-grape font-medium"
+        >
+          Restart session
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/data/focusPassages.test.ts
+++ b/src/data/focusPassages.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  deletePassage,
+  type FocusPassage,
+  generateId,
+  getMaturityLevel,
+  getParseGrade,
+  getVocabMaturityBreakdown,
+  loadFocusPassages,
+  loadParseHistoryStore,
+  type MaturityBreakdown,
+  recordParseSession,
+  saveFocusPassages,
+  saveParseHistoryStore,
+} from './focusPassages';
+import type { SRSCard } from './srs';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makePassage(overrides: Partial<FocusPassage> = {}): FocusPassage {
+  return {
+    id: 'test-id',
+    book: 'REV',
+    startChapter: 1,
+    startVerse: 1,
+    endChapter: 1,
+    endVerse: 11,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeCard(interval: number): SRSCard {
+  return {
+    key: 'test',
+    interval,
+    repetition: interval > 0 ? 1 : 0,
+    easeFactor: 2.5,
+    dueDate: '2099-01-01',
+    lastReviewed: '2026-01-01',
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// ─── loadFocusPassages / saveFocusPassages ───────────────────────────────────
+
+describe('loadFocusPassages', () => {
+  it('returns empty array when nothing saved', () => {
+    expect(loadFocusPassages()).toEqual([]);
+  });
+
+  it('returns saved passages', () => {
+    const passages = [makePassage({ id: 'a' }), makePassage({ id: 'b' })];
+    saveFocusPassages(passages);
+    expect(loadFocusPassages()).toEqual(passages);
+  });
+
+  it('returns empty array on corrupt data', () => {
+    localStorage.setItem('greek-tools-focus-passages-v1', 'not-json');
+    expect(loadFocusPassages()).toEqual([]);
+  });
+});
+
+// ─── loadParseHistoryStore / saveParseHistoryStore ───────────────────────────
+
+describe('loadParseHistoryStore', () => {
+  it('returns empty object when nothing saved', () => {
+    expect(loadParseHistoryStore()).toEqual({});
+  });
+
+  it('returns saved store', () => {
+    const store = { 'test-id': { correct: 8, total: 10 } };
+    saveParseHistoryStore(store);
+    expect(loadParseHistoryStore()).toEqual(store);
+  });
+
+  it('returns empty object on corrupt data', () => {
+    localStorage.setItem('greek-tools-focus-parse-v1', '{bad');
+    expect(loadParseHistoryStore()).toEqual({});
+  });
+});
+
+// ─── recordParseSession ──────────────────────────────────────────────────────
+
+describe('recordParseSession', () => {
+  it('creates a new entry for a new passage id', () => {
+    recordParseSession('p1', 8, 10);
+    expect(loadParseHistoryStore()['p1']).toEqual({ correct: 8, total: 10 });
+  });
+
+  it('accumulates correct and total across sessions', () => {
+    recordParseSession('p1', 8, 10);
+    recordParseSession('p1', 7, 10);
+    expect(loadParseHistoryStore()['p1']).toEqual({ correct: 15, total: 20 });
+  });
+
+  it('does not affect other passage ids', () => {
+    recordParseSession('p1', 5, 10);
+    recordParseSession('p2', 3, 10);
+    expect(loadParseHistoryStore()['p1']).toEqual({ correct: 5, total: 10 });
+  });
+});
+
+// ─── deletePassage ───────────────────────────────────────────────────────────
+
+describe('deletePassage', () => {
+  it('removes the passage from the list', () => {
+    saveFocusPassages([makePassage({ id: 'a' }), makePassage({ id: 'b' })]);
+    deletePassage('a');
+    const remaining = loadFocusPassages();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe('b');
+  });
+
+  it('removes its parse history', () => {
+    saveParseHistoryStore({ a: { correct: 5, total: 10 }, b: { correct: 3, total: 5 } });
+    deletePassage('a');
+    const store = loadParseHistoryStore();
+    expect(store['a']).toBeUndefined();
+    expect(store['b']).toEqual({ correct: 3, total: 5 });
+  });
+
+  it('is a no-op for unknown ids', () => {
+    saveFocusPassages([makePassage({ id: 'a' })]);
+    deletePassage('unknown');
+    expect(loadFocusPassages()).toHaveLength(1);
+  });
+});
+
+// ─── getMaturityLevel ────────────────────────────────────────────────────────
+
+describe('getMaturityLevel', () => {
+  it('returns 0 for interval 0 (unseen)', () => {
+    expect(getMaturityLevel(0)).toBe(0);
+  });
+
+  it('returns 1 for interval 1–5 (learning)', () => {
+    expect(getMaturityLevel(1)).toBe(1);
+    expect(getMaturityLevel(5)).toBe(1);
+  });
+
+  it('returns 2 for interval 6–20 (familiar)', () => {
+    expect(getMaturityLevel(6)).toBe(2);
+    expect(getMaturityLevel(20)).toBe(2);
+  });
+
+  it('returns 3 for interval 21+ (mature)', () => {
+    expect(getMaturityLevel(21)).toBe(3);
+    expect(getMaturityLevel(100)).toBe(3);
+  });
+});
+
+// ─── getVocabMaturityBreakdown ───────────────────────────────────────────────
+
+describe('getVocabMaturityBreakdown', () => {
+  it('counts unseen lemmas (no card)', () => {
+    const result: MaturityBreakdown = getVocabMaturityBreakdown(['καί', 'ὁ'], {});
+    expect(result.unseen).toBe(2);
+    expect(result.learning).toBe(0);
+  });
+
+  it('correctly categorises cards by interval', () => {
+    const store: Record<string, SRSCard> = {
+      λόγος: makeCard(0),
+      καί: makeCard(3),
+      ὁ: makeCard(15),
+      θεός: makeCard(30),
+    };
+    const result = getVocabMaturityBreakdown(['λόγος', 'καί', 'ὁ', 'θεός'], store);
+    expect(result.unseen).toBe(1);
+    expect(result.learning).toBe(1);
+    expect(result.familiar).toBe(1);
+    expect(result.mature).toBe(1);
+  });
+
+  it('returns zeroes for empty lemma list', () => {
+    const result = getVocabMaturityBreakdown([], {});
+    expect(result).toEqual({ mature: 0, familiar: 0, learning: 0, unseen: 0 });
+  });
+});
+
+// ─── getParseGrade ───────────────────────────────────────────────────────────
+
+describe('getParseGrade', () => {
+  it('returns — when no history', () => {
+    expect(getParseGrade('missing')).toBe('—');
+  });
+
+  it('returns — when total is 0', () => {
+    saveParseHistoryStore({ p: { correct: 0, total: 0 } });
+    expect(getParseGrade('p')).toBe('—');
+  });
+
+  it('returns A for ≥ 90%', () => {
+    saveParseHistoryStore({ p: { correct: 9, total: 10 } });
+    expect(getParseGrade('p')).toBe('A');
+  });
+
+  it('returns B for 75–89%', () => {
+    saveParseHistoryStore({ p: { correct: 8, total: 10 } });
+    expect(getParseGrade('p')).toBe('B');
+  });
+
+  it('returns C for 60–74%', () => {
+    saveParseHistoryStore({ p: { correct: 65, total: 100 } });
+    expect(getParseGrade('p')).toBe('C');
+  });
+
+  it('returns D for 45–59%', () => {
+    saveParseHistoryStore({ p: { correct: 5, total: 10 } });
+    expect(getParseGrade('p')).toBe('D');
+  });
+
+  it('returns E for < 45%', () => {
+    saveParseHistoryStore({ p: { correct: 4, total: 10 } });
+    expect(getParseGrade('p')).toBe('E');
+  });
+});
+
+// ─── generateId ─────────────────────────────────────────────────────────────
+
+describe('generateId', () => {
+  it('generates non-empty strings', () => {
+    expect(generateId().length).toBeGreaterThan(0);
+  });
+
+  it('generates unique ids', () => {
+    const ids = new Set(Array.from({ length: 20 }, generateId));
+    expect(ids.size).toBe(20);
+  });
+});

--- a/src/data/focusPassages.ts
+++ b/src/data/focusPassages.ts
@@ -1,0 +1,116 @@
+import type { SRSCard } from './srs';
+
+export interface FocusPassage {
+  id: string;
+  label?: string;
+  book: string;
+  startChapter: number;
+  startVerse: number;
+  endChapter: number;
+  endVerse: number;
+  createdAt: string;
+}
+
+export interface ParseHistory {
+  correct: number;
+  total: number;
+}
+
+const PASSAGES_KEY = 'greek-tools-focus-passages-v1';
+const PARSE_KEY = 'greek-tools-focus-parse-v1';
+
+export function loadFocusPassages(): FocusPassage[] {
+  try {
+    const raw = localStorage.getItem(PASSAGES_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as FocusPassage[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveFocusPassages(passages: FocusPassage[]): void {
+  localStorage.setItem(PASSAGES_KEY, JSON.stringify(passages));
+}
+
+export function loadParseHistoryStore(): Record<string, ParseHistory> {
+  try {
+    const raw = localStorage.getItem(PARSE_KEY);
+    if (!raw) return {};
+    return JSON.parse(raw) as Record<string, ParseHistory>;
+  } catch {
+    return {};
+  }
+}
+
+export function saveParseHistoryStore(store: Record<string, ParseHistory>): void {
+  localStorage.setItem(PARSE_KEY, JSON.stringify(store));
+}
+
+export function recordParseSession(id: string, correct: number, total: number): void {
+  const store = loadParseHistoryStore();
+  const prev = store[id] ?? { correct: 0, total: 0 };
+  store[id] = { correct: prev.correct + correct, total: prev.total + total };
+  saveParseHistoryStore(store);
+}
+
+export function deletePassage(id: string): void {
+  saveFocusPassages(loadFocusPassages().filter((p) => p.id !== id));
+  const store = loadParseHistoryStore();
+  delete store[id];
+  saveParseHistoryStore(store);
+}
+
+export type MaturityLevel = 0 | 1 | 2 | 3;
+
+export function getMaturityLevel(interval: number): MaturityLevel {
+  if (interval <= 0) return 0;
+  if (interval <= 5) return 1;
+  if (interval <= 20) return 2;
+  return 3;
+}
+
+export interface MaturityBreakdown {
+  mature: number;
+  familiar: number;
+  learning: number;
+  unseen: number;
+}
+
+export function getVocabMaturityBreakdown(
+  lemmas: string[],
+  srsStore: Record<string, SRSCard>,
+): MaturityBreakdown {
+  const result: MaturityBreakdown = { mature: 0, familiar: 0, learning: 0, unseen: 0 };
+  for (const lemma of lemmas) {
+    const card = srsStore[lemma];
+    if (!card) {
+      result.unseen++;
+    } else {
+      const level = getMaturityLevel(card.interval);
+      if (level === 3) result.mature++;
+      else if (level === 2) result.familiar++;
+      else if (level === 1) result.learning++;
+      else result.unseen++;
+    }
+  }
+  return result;
+}
+
+export type ParseGrade = 'A' | 'B' | 'C' | 'D' | 'E' | '—';
+
+export function getParseGrade(id: string): ParseGrade {
+  const store = loadParseHistoryStore();
+  const entry = store[id];
+  if (!entry || entry.total === 0) return '—';
+  const accuracy = entry.correct / entry.total;
+  if (accuracy >= 0.9) return 'A';
+  if (accuracy >= 0.75) return 'B';
+  if (accuracy >= 0.6) return 'C';
+  if (accuracy >= 0.45) return 'D';
+  return 'E';
+}
+
+export function generateId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,6 +18,7 @@ const navLinks = [
   { href: '/reader', label: 'Reader', tabLabel: 'Reader' },
   { href: '/grammar', label: 'Grammar', tabLabel: 'Grammar' },
   { href: '/quiz', label: 'Quiz', tabLabel: 'Quiz' },
+  { href: '/focus', label: 'Focus', tabLabel: 'Focus' },
 ];
 
 const currentPath = Astro.url.pathname;
@@ -268,6 +269,22 @@ function isActive(href: string) {
               <line x1="12" y1="17" x2="12.01" y2="17"/>
             </svg>
             <span class="tab-label">Quiz</span>
+          </span>
+        </a>
+
+        <!-- Focus Passages -->
+        <a
+          href="/focus"
+          class:list={["tab-item", isActive('/focus') ? "tab-active" : "tab-inactive"]}
+          aria-label="Focus Passages"
+          aria-current={isActive('/focus') ? 'page' : undefined}
+        >
+          <span class:list={["tab-pill", { "tab-pill-active": isActive('/focus') }]}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="3"/>
+              <path d="M12 2v3M12 19v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M2 12h3M19 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12"/>
+            </svg>
+            <span class="tab-label">Focus</span>
           </span>
         </a>
 

--- a/src/lib/gnt-parse.test.ts
+++ b/src/lib/gnt-parse.test.ts
@@ -11,6 +11,7 @@ import {
   deduplicateByLemma,
   emptyGNTAnswer,
   extractVerbs,
+  extractVerbsMultiChapter,
   filterMissedItems,
   formatRangeRef,
   type GNTParseAnswer,
@@ -678,5 +679,67 @@ describe('filterMissedItems', () => {
   it('handles results shorter than items (partial session)', () => {
     const results = [makeResult(false), makeResult(true)];
     expect(filterMissedItems(items, results)).toEqual(['a']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractVerbsMultiChapter
+// ---------------------------------------------------------------------------
+
+describe('extractVerbsMultiChapter', () => {
+  const FINITE_VERB = { text: 'λύει', lemma: 'λύω', pos: 'V-', parsing: '3PAI-S--' };
+
+  function makeMultiChapterBook(): MorphBook {
+    return {
+      '1': {
+        '1': [{ ...FINITE_VERB, text: 'ch1v1' }],
+        '5': [{ ...FINITE_VERB, text: 'ch1v5' }],
+      },
+      '2': {
+        '1': [{ ...FINITE_VERB, text: 'ch2v1' }],
+        '3': [{ ...FINITE_VERB, text: 'ch2v3' }],
+      },
+      '3': {
+        '1': [{ ...FINITE_VERB, text: 'ch3v1' }],
+      },
+    };
+  }
+
+  it('returns all verbs in a single-chapter range', () => {
+    const book = makeMultiChapterBook();
+    const items = extractVerbsMultiChapter(book, 1, 1, 1, 5, 'Test');
+    expect(items).toHaveLength(2);
+  });
+
+  it('returns verbs spanning two chapters', () => {
+    const book = makeMultiChapterBook();
+    const items = extractVerbsMultiChapter(book, 1, 5, 2, 3, 'Test');
+    expect(items).toHaveLength(3); // ch1v5, ch2v1, ch2v3
+  });
+
+  it('respects startVerse in first chapter', () => {
+    const book = makeMultiChapterBook();
+    const items = extractVerbsMultiChapter(book, 1, 2, 2, 1, 'Test');
+    // ch1v1 excluded (verse < 2), ch1v5 included, ch2v1 included
+    expect(items).toHaveLength(2);
+  });
+
+  it('respects endVerse in last chapter', () => {
+    const book = makeMultiChapterBook();
+    const items = extractVerbsMultiChapter(book, 1, 1, 2, 2, 'Test');
+    // ch1v1, ch1v5, ch2v1 included; ch2v3 excluded (verse > 2)
+    expect(items).toHaveLength(3);
+  });
+
+  it('returns all verbs across all chapters when full range given', () => {
+    const book = makeMultiChapterBook();
+    const items = extractVerbsMultiChapter(book, 1, 1, 3, 1, 'Test');
+    expect(items).toHaveLength(5);
+  });
+
+  it('returns empty array when range matches no verses', () => {
+    const book = makeMultiChapterBook();
+    const items = extractVerbsMultiChapter(book, 4, 1, 4, 10, 'Test');
+    expect(items).toHaveLength(0);
   });
 });

--- a/src/lib/gnt-parse.ts
+++ b/src/lib/gnt-parse.ts
@@ -462,3 +462,29 @@ export function formatRangeRef(
 export function saveGNTSettings(s: GNTPassageSettings): void {
   localStorage.setItem(GNT_SETTINGS_KEY, JSON.stringify(s));
 }
+
+/**
+ * Extract verb parse items across a multi-chapter range (inclusive on both ends).
+ * For single-chapter passages, equivalent to extractVerbs.
+ */
+export function extractVerbsMultiChapter(
+  bookData: MorphBook,
+  startCh: number,
+  startVs: number,
+  endCh: number,
+  endVs: number,
+  bookName: string,
+): GNTParseItem[] {
+  const chapters = Object.keys(bookData)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  const items: GNTParseItem[] = [];
+  for (const ch of chapters) {
+    if (ch < startCh || ch > endCh) continue;
+    const vsStart = ch === startCh ? startVs : 1;
+    const vsEnd = ch === endCh ? endVs : Infinity;
+    items.push(...extractVerbs(bookData, String(ch), bookName, vsStart, vsEnd));
+  }
+  return items;
+}

--- a/src/pages/focus.astro
+++ b/src/pages/focus.astro
@@ -1,0 +1,11 @@
+---
+import FocusPassageList from '../components/FocusPassageList';
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+  title="Focus Passages"
+  description="Pin a scripture passage and master it through vocabulary flashcards, parsing drills, and reading."
+>
+  <FocusPassageList client:load />
+</Layout>

--- a/src/pages/focus/[id].astro
+++ b/src/pages/focus/[id].astro
@@ -1,0 +1,13 @@
+---
+import FocusPassageHub from '../../components/FocusPassageHub';
+import Layout from '../../layouts/Layout.astro';
+
+const { id } = Astro.params;
+---
+
+<Layout
+  title="Focus Passage"
+  description="Study this passage with vocabulary flashcards, parsing drills, and the GNT reader."
+>
+  <FocusPassageHub client:load passageId={id!} />
+</Layout>

--- a/src/pages/focus/[id].astro
+++ b/src/pages/focus/[id].astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import FocusPassageHub from '../../components/FocusPassageHub';
 import Layout from '../../layouts/Layout.astro';
 

--- a/src/pages/focus/new.astro
+++ b/src/pages/focus/new.astro
@@ -1,0 +1,11 @@
+---
+import FocusPassageNew from '../../components/FocusPassageNew';
+import Layout from '../../layouts/Layout.astro';
+---
+
+<Layout
+  title="New Focus Passage"
+  description="Choose a verse range to study deeply with vocabulary, parsing, and reading."
+>
+  <FocusPassageNew client:load />
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,6 +56,15 @@ const tools = [
     accentColor: '#7C3AED', // grape violet (reused from flashcards family)
     bgColor: '#F5F3FF',
   },
+  {
+    href: '/focus',
+    icon: '⌖',
+    title: 'Focus Passages',
+    description:
+      'Pin a verse range and master it deeply — vocabulary flashcards, parsing drills, and reading all in one place.',
+    accentColor: '#059669', // emerald
+    bgColor: '#ECFDF5',
+  },
 ] as const;
 ---
 


### PR DESCRIPTION
## Summary

- Adds `/focus`, `/focus/new`, and `/focus/[id]` routes for passage-based mastery study (closes #113)
- Each Focus Passage has a 4-tab hub: **Reader**, **Vocab**, **Parsing**, and **Progress**
- All state persists in `localStorage`; no account required

## What's included

**New routes**
- `/focus` — aggregation list with inline rename, delete with confirm, and per-passage parse grade
- `/focus/new` — 2-step creation flow: cross-chapter range selector → preview (lemma count, verb count, text snippet) → optional name → save
- `/focus/[id]` — 4-tab hub with tab state in URL `?tab=`

**Tabs**
- **Reader** — passage-scoped GNT text with studied-word highlighting and gloss toggle
- **Vocab** — SRS flashcards filtered to passage lemmas, backed by the shared `greek-tools-srs-v2` store
- **Parsing** — verb parse drill pre-scoped to the passage range with session length selector; records cumulative correct/total at session end
- **Progress** — proportional vocab maturity bar (Mature / Familiar / Learning / New) + cumulative parse letter grade (A–E)

**New data layer**
- `greek-tools-focus-passages-v1` — passage list
- `greek-tools-focus-parse-v1` — cumulative parse history per passage id; deletes alongside passage on remove

**New logic**
- `extractVerbsMultiChapter()` in `gnt-parse.ts` — cross-chapter verb extraction using the same iteration pattern as `extractPassageLemmas`
- `CrossChapterSelector` component — book + start ch/vs + end ch/vs selectors with range invariant enforcement

**Nav**
- Focus Passages card added to home page
- "Focus" added to desktop nav and mobile tab bar

## Test plan

- [x] All 791 tests pass
- [x] TypeScript: clean
- [x] Lint: clean (no errors)
- [ ] Create a focus passage for a single-chapter range (e.g. Rev 1:1–11)
- [ ] Create a focus passage for a cross-chapter range (e.g. Rev 1:14–2:3)
- [ ] Rename a passage inline; confirm it saves on blur and Enter
- [ ] Delete a passage; confirm parse history is also removed
- [ ] Study Vocab tab; confirm SRS state updates in the shared store
- [ ] Complete a Parsing session; confirm grade updates on Progress tab
- [ ] Verify Reader shows only the selected verses with gloss toggle working
- [ ] Reload page; confirm all state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)